### PR TITLE
feat(projects): add /projects endpoint with rich project schema and seed data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ## [Unreleased]
 
+- 2026-03-24 — feat(projects): add /projects endpoint with rich project schema and seed data
 - 2026-03-23 — feat(api): add hono server with resume, profile, match, and query routes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.2.9",
         "@ai-sdk/google": "^1.2.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/seed-profile.json
+++ b/scripts/seed-profile.json
@@ -119,15 +119,45 @@
   ],
   "projects": [
     {
-      "name": "Artisan Roast",
-      "description": "Specialized SaaS platform for coffee retailers featuring a core e-commerce engine and a custom instance hosting service.",
-      "tech": ["Next.js", "TypeScript", "Stripe", "GitHub Actions", "Puppeteer"],
-      "url": "https://github.com/yuens1002/artisan-roast",
+      "name": "Artisan Roast Platform",
+      "slug": "artisan-roast",
+      "description": "Open-source self-hosted e-commerce platform for specialty coffee retailers, with a SaaS business layer for managed hosting, billing, and AI-powered back office.",
+      "problem": "Independent coffee shop owners lack affordable, purpose-built e-commerce tooling. Generic platforms are expensive and not tailored to specialty coffee workflows. Non-technical owners have no viable self-hosted option.",
+      "role": "Sole developer and architect — designed and built both the open-source store and the SaaS platform end-to-end.",
+      "tech": ["Next.js", "TypeScript", "Prisma", "PostgreSQL", "Stripe", "NextAuth.js", "Tailwind CSS", "shadcn/ui", "Playwright", "Vercel"],
       "highlights": [
-        "Sole developer and architect — designed and built the full platform end-to-end",
-        "Engineered monetization via Stripe Billing for tiered subscriptions, automated service provisioning, and premium add-on products",
-        "Built a CI/CD and QA pipeline using Puppeteer and GitHub Actions verifying 16+ critical acceptance criteria with 100% reliability for hosted tenant instances"
-      ]
+        "Built a complete e-commerce platform (products, orders, customers, admin, cart) from scratch as a solo developer",
+        "Engineered a SaaS monetization layer with Stripe Billing, tiered subscriptions (Free/Pro/Hosted), and automated license key generation and validation",
+        "Designed and implemented an automated data migration pipeline for self-hosted → managed hosting transitions, modeled as a state machine (PENDING → EXPORTING → EXPORTED → IMPORTING → COMPLETED)",
+        "Built a telemetry ingestion system that phones home from open-source instances to drive platform analytics and tier enforcement",
+        "Established a CI/CD and QA pipeline using Playwright verifying 16+ critical acceptance criteria with 100% reliability",
+        "Implemented a verification state machine in the development workflow enforced by pre-commit hooks (planning → planned → implementing → pending → partial → verified)"
+      ],
+      "architecture": "Two-repo architecture: open-source store (Next.js App Router, Prisma, Neon PostgreSQL) and a separate SaaS platform on the same stack. Both apps served from a single Vercel project via Next.js middleware hostname routing (artisanroast.app → marketing, manage.artisanroast.app → admin). Store instances validate licenses and send telemetry to the platform API. Row Level Security in Supabase enforces public/private data boundaries.",
+      "impact": "Live at artisanroast.app. Free community tier, support plans, and add-on packages deployed. Hosted solution and AI back office layer (MCP server) in active development.",
+      "status": "active",
+      "started": "2024-01",
+      "url": "https://demo.artisanroast.app",
+      "repo": "https://github.com/yuens1002/artisan-roast"
+    },
+    {
+      "name": "Resume Agent",
+      "slug": "resume-agent",
+      "description": "A2A-compatible AI agent that represents a professional profile as a machine-queryable JSON API — built for employer AI systems, ATS tools, and personal LLM interfaces.",
+      "problem": "AI systems are increasingly the first pass in hiring. Most candidates have no structured, queryable representation of their professional profile that AI agents can interrogate directly.",
+      "role": "Sole developer and architect.",
+      "tech": ["Node.js", "TypeScript", "Hono", "Supabase", "PostgreSQL", "Anthropic Claude", "Vercel AI SDK", "Zod"],
+      "highlights": [
+        "Designed a mathematical job fit scoring model — AI provides categorical sub-dimension judgments (skills matched/partial/missing, experience, domain), code computes the weighted average (50/30/20) for deterministic, auditable results",
+        "Built A2A-compliant agent card autodiscovery (/.well-known/agent-card.json) for AI system interoperability",
+        "Implemented caller detection to adapt response tone and verbosity based on whether the requester is an ATS, a human recruiter, or another AI agent",
+        "Structured as a singleton-profile API with Supabase RLS enforcing public read-only access and a service-role-only write path"
+      ],
+      "architecture": "Hono HTTP server on Node.js. Single public_profile row in Supabase (singleton enforced via CHECK constraint on UUID). AI routes use Vercel AI SDK with provider abstraction (Anthropic/OpenAI/Google). /match uses Sonnet for reasoning-heavy scoring; lightweight routes use Haiku.",
+      "impact": "Designed to be discovered and queried by employer AI systems, ATS tools, and personal LLM agents. Queryable via QR code at networking events or by any A2A-compatible system.",
+      "status": "in-progress",
+      "started": "2026-03",
+      "repo": "https://github.com/yuens1002/resume-agent"
     }
   ],
   "availability": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import matchRoute from './routes/match.js'
 import resumeRoute from './routes/resume.js'
 import agentCardRoute from './routes/agent-card.js'
 import profileRoute from './routes/profile.js'
+import projectsRoute from './routes/projects.js'
 
 const app = new Hono()
 
@@ -23,6 +24,7 @@ app.route('/match', matchRoute)
 app.route('/resume', resumeRoute)
 app.route('/.well-known/agent-card.json', agentCardRoute)
 app.route('/profile', profileRoute)
+app.route('/projects', projectsRoute)
 
 app.get('/', (c) => c.json({ status: 'ok', agent: 'resume-agent' }))
 

--- a/src/routes/agent-card.ts
+++ b/src/routes/agent-card.ts
@@ -18,12 +18,13 @@ app.get('/', async (c) => {
     name: data?.contact?.name ?? 'Resume Agent',
     description: 'AI agent representing a professional profile. Query skills, experience, and availability.',
     url: baseUrl,
-    capabilities: ['query', 'match', 'info', 'availability'],
+    capabilities: ['query', 'match', 'info', 'availability', 'projects'],
     endpoints: {
       info: `${baseUrl}/info`,
       availability: `${baseUrl}/availability`,
       query: `${baseUrl}/query`,
       match: `${baseUrl}/match`,
+      projects: `${baseUrl}/projects`,
     },
     contact: {
       email: data?.contact?.email,

--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -4,7 +4,8 @@ import type { Project } from '../types.js'
 
 const app = new Hono()
 
-// GET /projects — lightweight list of all projects
+// GET /projects — project list: summary fields only (excludes highlights, problem, architecture, impact)
+// Includes url/repo/started intentionally — useful for list consumers without the full narrative payload
 app.get('/', async (c) => {
   const { data, error } = await supabase
     .from('public_profile')

--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -1,0 +1,60 @@
+import { Hono } from 'hono'
+import { supabase } from '../lib/supabase.js'
+import type { Project } from '../types.js'
+
+const app = new Hono()
+
+// GET /projects — lightweight list of all projects
+app.get('/', async (c) => {
+  const { data, error } = await supabase
+    .from('public_profile')
+    .select('projects')
+    .eq('id', '00000000-0000-0000-0000-000000000001')
+    .single()
+
+  if (error || !data) {
+    return c.json({ error: 'Profile not found' }, 404)
+  }
+
+  const projects: Project[] = data.projects ?? []
+
+  return c.json(
+    projects.map(({ name, slug, description, role, tech, status, started, url, repo }) => ({
+      name,
+      slug,
+      description,
+      role,
+      tech,
+      status,
+      started,
+      url,
+      repo,
+    }))
+  )
+})
+
+// GET /projects/:slug — full project detail
+app.get('/:slug', async (c) => {
+  const slug = c.req.param('slug')
+
+  const { data, error } = await supabase
+    .from('public_profile')
+    .select('projects')
+    .eq('id', '00000000-0000-0000-0000-000000000001')
+    .single()
+
+  if (error || !data) {
+    return c.json({ error: 'Profile not found' }, 404)
+  }
+
+  const projects: Project[] = data.projects ?? []
+  const project = projects.find((p) => p.slug === slug)
+
+  if (!project) {
+    return c.json({ error: `Project '${slug}' not found` }, 404)
+  }
+
+  return c.json(project)
+})
+
+export default app

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,10 +33,18 @@ export interface Education {
 
 export interface Project {
   name: string
-  description: string
+  slug: string
+  description: string       // one-liner for list views
+  problem: string           // what problem it solves
+  role: string              // your role on the project
   tech: string[]
-  url?: string
-  highlights: string[]
+  highlights: string[]      // key achievements
+  architecture?: string     // technical architecture summary
+  impact?: string           // measurable business/user impact
+  status: 'active' | 'in-progress' | 'archived'
+  started?: string          // YYYY-MM
+  url?: string              // live URL
+  repo?: string             // source repo URL
 }
 
 export interface Availability {


### PR DESCRIPTION
## Summary

- Add `GET /projects` — lightweight project list (name, slug, description, role, tech, status)
- Add `GET /projects/:slug` — full project detail including problem, architecture, impact
- Enrich `Project` type with `slug`, `problem`, `role`, `architecture`, `impact`, `status`, `started`, `repo`
- Update agent card to advertise `projects` capability and endpoint
- Update seed data with rich entries for Artisan Roast Platform and Resume Agent

## Test plan

- [ ] `GET /projects` returns array of project summaries
- [ ] `GET /projects/artisan-roast` returns full Artisan Roast project detail
- [ ] `GET /projects/resume-agent` returns full Resume Agent project detail
- [ ] `GET /projects/unknown-slug` returns 404
- [ ] `GET /.well-known/agent-card.json` includes `projects` in capabilities and endpoints