### PR TITLE
chore(profile): add email and calendly to contact seed data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- 2026-03-25 — chore(profile): add email and calendly to contact seed data
 - 2026-03-25 — chore(deploy): add railway config, seed script, and supabase cli
 - 2026-03-24 — feat(projects): add /projects endpoint with rich project schema and seed data
 - 2026-03-23 — feat(api): add hono server with resume, profile, match, and query routes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.2.9",
         "@ai-sdk/google": "^1.2.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/seed-profile.json
+++ b/scripts/seed-profile.json
@@ -1,6 +1,8 @@
 {
   "contact": {
     "name": "Sunny Yuen",
+    "email": "syuen@sbgrp.cc",
+    "calendly": "https://calendly.com/syuen-sbgrp/get_to_know_you",
     "github": "https://github.com/yuens1002",
     "linkedin": "https://linkedin.com/in/yuens-me/"
   },


### PR DESCRIPTION
## Summary
- Add `email` and `calendly` fields to contact in `seed-profile.json`
- Enables `/availability` and `/.well-known/agent-card.json` to surface contact info for employer AI systems

## Test plan
- [ ] `GET /availability` returns `contact.email` and `contact.calendly`
- [ ] `GET /.well-known/agent-card.json` returns populated `contact` object