### PR TITLE
fix(query): add GET handler for endpoint discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- 2026-03-26 — fix(query): add get handler for endpoint discovery to prevent 404 on non-post requests
 - 2026-03-25 — chore(profile): enrich artisan roast project data with ai tooling and accurate details
 - 2026-03-25 — chore(profile): add email and calendly to contact seed data
 - 2026-03-25 — chore(deploy): add railway config, seed script, and supabase cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- 2026-03-26 — fix(query): add get handler for endpoint discovery to prevent 404 on non-post requests
+- 2026-03-26 — fix(query): add GET handler for endpoint discovery to prevent 404 on non-POST requests
 - 2026-03-25 — chore(profile): enrich artisan roast project data with ai tooling and accurate details
 - 2026-03-25 — chore(profile): add email and calendly to contact seed data
 - 2026-03-25 — chore(deploy): add railway config, seed script, and supabase cli

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.2.9",
         "@ai-sdk/google": "^1.2.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/routes/query.ts
+++ b/src/routes/query.ts
@@ -15,6 +15,14 @@ const schema = z.object({
   context: z.string().optional(),
 })
 
+app.get('/', (c) => c.json({
+  endpoint: '/query',
+  method: 'POST',
+  description: 'Ask a natural language question about this candidate.',
+  body: { question: 'string (required)', context: 'string (optional, e.g. "ATS", "recruiter", "ai-agent")' },
+  example: { question: 'What is your experience with TypeScript?' },
+}))
+
 app.post('/', zValidator('json', schema), async (c) => {
   const { question, context } = c.req.valid('json')
 

--- a/src/routes/query.ts
+++ b/src/routes/query.ts
@@ -15,13 +15,16 @@ const schema = z.object({
   context: z.string().optional(),
 })
 
-app.get('/', (c) => c.json({
-  endpoint: '/query',
-  method: 'POST',
-  description: 'Ask a natural language question about this candidate.',
-  body: { question: 'string (required)', context: 'string (optional, e.g. "ATS", "recruiter", "ai-agent")' },
-  example: { question: 'What is your experience with TypeScript?' },
-}))
+app.get('/', (c) => {
+  const url = new URL(c.req.url)
+  return c.json({
+    endpoint: url.pathname,
+    method: 'POST',
+    description: 'Ask a natural language question about this candidate.',
+    body: { question: 'string (required)', context: 'string (optional, e.g. "ATS", "recruiter", "ai-agent")' },
+    example: { question: 'What is your experience with TypeScript?' },
+  })
+})
 
 app.post('/', zValidator('json', schema), async (c) => {
   const { question, context } = c.req.valid('json')


### PR DESCRIPTION
## Summary
- `GET /query` was returning 404 (Hono has no handler = not found, not method-not-allowed)
- Added a `GET /query` handler that returns endpoint usage documentation
- Browsers, LLMs, and A2A agents hitting the URL directly now get a helpful JSON description instead of 404

## Test plan
- [ ] `GET /query` returns endpoint description with method, body shape, and example
- [ ] `POST /query` still works as before