### PR TITLE
fix(api): disable hono strict mode to handle trailing slash variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- 2026-03-26 — fix(api): disable hono strict mode to handle trailing slash variants without 404
 - 2026-03-26 — fix(query): add GET handler for endpoint discovery to prevent 404 on non-POST requests
 - 2026-03-25 — chore(profile): enrich artisan roast project data with ai tooling and accurate details
 - 2026-03-25 — chore(profile): add email and calendly to contact seed data

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.2.9",
         "@ai-sdk/google": "^1.2.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import agentCardRoute from './routes/agent-card.js'
 import profileRoute from './routes/profile.js'
 import projectsRoute from './routes/projects.js'
 
-const app = new Hono()
+const app = new Hono({ strict: false })
 
 app.use('*', logger())
 app.use('*', cors())


### PR DESCRIPTION
## Summary
- Hono defaults to `strict: true` — `/query` and `/query/` are treated as different routes, causing 404s
- External AI agents (e.g. Grok) may append trailing slashes when constructing URLs from the agent card
- Set `strict: false` on the root Hono instance so trailing slash variants resolve correctly across all routes

## Test plan
- [ ] `GET /query/` returns the same discovery JSON as `GET /query`
- [ ] `POST /query/` works the same as `POST /query`
- [ ] All other routes unaffected