### PR TITLE
chore(api): add startup log confirming route registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- 2026-03-26 — chore(api): add startup log confirming route registration
 - 2026-03-26 — fix(api): disable hono strict mode to handle trailing slash variants without 404
 - 2026-03-26 — fix(query): add GET handler for endpoint discovery to prevent 404 on non-POST requests
 - 2026-03-25 — chore(profile): enrich artisan roast project data with ai tooling and accurate details

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.2.9",
         "@ai-sdk/google": "^1.2.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,12 +26,11 @@ app.route('/.well-known/agent-card.json', agentCardRoute)
 app.route('/profile', profileRoute)
 app.route('/projects', projectsRoute)
 
-console.log('[routes] registered: /info, /availability, /query (GET+POST), /match, /resume, /.well-known/agent-card.json, /profile, /projects')
-
 app.get('/', (c) => c.json({ status: 'ok', agent: 'resume-agent' }))
 
 const port = parseInt(process.env.PORT ?? '3000')
 
 serve({ fetch: app.fetch, port }, () => {
   console.log(`resume-agent running on http://localhost:${port}`)
+  console.log('[routes] registered and listening — GET+POST /query, /match, /info, /availability, /resume, /profile, /projects, /.well-known/agent-card.json')
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,8 @@ app.route('/.well-known/agent-card.json', agentCardRoute)
 app.route('/profile', profileRoute)
 app.route('/projects', projectsRoute)
 
+console.log('[routes] registered: /info, /availability, /query (GET+POST), /match, /resume, /.well-known/agent-card.json, /profile, /projects')
+
 app.get('/', (c) => c.json({ status: 'ok', agent: 'resume-agent' }))
 
 const port = parseInt(process.env.PORT ?? '3000')


### PR DESCRIPTION
## Summary
- Adds a `console.log` after all routes are mounted in `src/index.ts`
- Confirms in Railway logs that all routes (including `GET+POST /query`) registered successfully at startup

## Test plan
- [ ] Deploy and check Railway logs for `[routes] registered: ...` line at startup
- [ ] Verify all endpoints still respond correctly