### PR TITLE
fix(agent-card): enrich endpoint objects with method, schema, and examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- 2026-03-26 — fix(agent-card): enrich endpoint objects with method, schema, and examples for ai agent discovery
+- 2026-03-26 — fix(agent-card): enrich endpoint objects with method, schema, and examples for AI agent discovery
 - 2026-03-26 — chore(api): add startup log confirming route registration
 - 2026-03-26 — fix(api): disable hono strict mode to handle trailing slash variants without 404
 - 2026-03-26 — fix(query): add GET handler for endpoint discovery to prevent 404 on non-POST requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- 2026-03-26 — fix(agent-card): enrich endpoint objects with method, schema, and examples for ai agent discovery
 - 2026-03-26 — chore(api): add startup log confirming route registration
 - 2026-03-26 — fix(api): disable hono strict mode to handle trailing slash variants without 404
 - 2026-03-26 — fix(query): add GET handler for endpoint discovery to prevent 404 on non-POST requests

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.2.9",
         "@ai-sdk/google": "^1.2.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/routes/agent-card.ts
+++ b/src/routes/agent-card.ts
@@ -14,7 +14,7 @@ app.get('/', async (c) => {
   const baseUrl = process.env.PUBLIC_URL ?? `http://localhost:${process.env.PORT ?? 3000}`
 
   return c.json({
-    schema_version: '1.0',
+    schema_version: '1.1',
     name: data?.contact?.name ?? 'Resume Agent',
     description: 'AI agent representing a professional profile. Query skills, experience, and availability.',
     url: baseUrl,
@@ -36,8 +36,12 @@ app.get('/', async (c) => {
         content_type: 'application/json',
         description: 'Ask a natural language question about this candidate.',
         input_schema: {
-          question: 'string (required) — e.g. "What is your experience with TypeScript?"',
-          context: 'string (optional) — caller type hint, e.g. "ATS", "recruiter", "ai-agent"',
+          type: 'object',
+          required: ['question'],
+          properties: {
+            question: { type: 'string', description: 'Natural language question about the candidate.' },
+            context: { type: 'string', description: 'Caller type hint — e.g. "ATS", "recruiter", "ai-agent".', required: false },
+          },
         },
         example: { question: 'What is your experience with TypeScript?' },
       },
@@ -45,9 +49,13 @@ app.get('/', async (c) => {
         url: `${baseUrl}/match`,
         method: 'POST',
         content_type: 'application/json',
-        description: 'Score this candidate against a job description and return a fit breakdown.',
+        description: 'Score this candidate against a job description and return a fit breakdown. This endpoint is POST-only; GET is not supported.',
         input_schema: {
-          job_description: 'string (required) — full or partial job description text',
+          type: 'object',
+          required: ['job_description'],
+          properties: {
+            job_description: { type: 'string', description: 'Full or partial job description text.' },
+          },
         },
         example: { job_description: 'Senior frontend engineer, React, TypeScript, 5+ years.' },
       },

--- a/src/routes/agent-card.ts
+++ b/src/routes/agent-card.ts
@@ -20,11 +20,42 @@ app.get('/', async (c) => {
     url: baseUrl,
     capabilities: ['query', 'match', 'info', 'availability', 'projects'],
     endpoints: {
-      info: `${baseUrl}/info`,
-      availability: `${baseUrl}/availability`,
-      query: `${baseUrl}/query`,
-      match: `${baseUrl}/match`,
-      projects: `${baseUrl}/projects`,
+      info: {
+        url: `${baseUrl}/info`,
+        method: 'GET',
+        description: 'Returns full profile data including skills, employment, education, and projects.',
+      },
+      availability: {
+        url: `${baseUrl}/availability`,
+        method: 'GET',
+        description: 'Returns current availability status and preferred roles.',
+      },
+      query: {
+        url: `${baseUrl}/query`,
+        method: 'POST',
+        content_type: 'application/json',
+        description: 'Ask a natural language question about this candidate.',
+        input_schema: {
+          question: 'string (required) — e.g. "What is your experience with TypeScript?"',
+          context: 'string (optional) — caller type hint, e.g. "ATS", "recruiter", "ai-agent"',
+        },
+        example: { question: 'What is your experience with TypeScript?' },
+      },
+      match: {
+        url: `${baseUrl}/match`,
+        method: 'POST',
+        content_type: 'application/json',
+        description: 'Score this candidate against a job description and return a fit breakdown.',
+        input_schema: {
+          job_description: 'string (required) — full or partial job description text',
+        },
+        example: { job_description: 'Senior frontend engineer, React, TypeScript, 5+ years.' },
+      },
+      projects: {
+        url: `${baseUrl}/projects`,
+        method: 'GET',
+        description: 'Returns all portfolio projects with tech stack, highlights, and architecture.',
+      },
     },
     contact: {
       email: data?.contact?.email,


### PR DESCRIPTION
## Summary
- Agent card endpoints were bare URLs — AI agents (e.g. Grok) had no way to know that `/query` and `/match` require POST with a JSON body
- Each endpoint now includes `method`, `content_type`, `description`, `input_schema`, and `example`
- Fixes Grok only issuing GET requests to `/query` instead of POST

## Test plan
- [ ] `GET /.well-known/agent-card.json` — verify `query` and `match` endpoints now include `method: "POST"`, `input_schema`, and `example`
- [ ] Verify `info`, `availability`, `projects` show `method: "GET"`
- [ ] Retest with Grok using the agent card URL