### PR TITLE
chore(config): pin Node.js to >=20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- 2026-03-26 — chore(config): pin node.js to >=20 via engines field and railway nixpacks variable
 - 2026-03-26 — fix(agent-card): enrich endpoint objects with method, schema, and examples for AI agent discovery
 - 2026-03-26 — chore(api): add startup log confirming route registration
 - 2026-03-26 — fix(api): disable hono strict mode to handle trailing slash variants without 404

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- 2026-03-26 — chore(config): pin node.js to >=20 via engines field and railway nixpacks variable
+- 2026-03-26 — chore(config): pin Node.js to >=20 via engines field and railway nixpacks variable
 - 2026-03-26 — fix(agent-card): enrich endpoint objects with method, schema, and examples for AI agent discovery
 - 2026-03-26 — chore(api): add startup log confirming route registration
 - 2026-03-26 — fix(api): disable hono strict mode to handle trailing slash variants without 404

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.2.9",
         "@ai-sdk/google": "^1.2.16",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "resume-agent",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",

--- a/railway.toml
+++ b/railway.toml
@@ -2,6 +2,9 @@
 builder = "nixpacks"
 buildCommand = "npm run build"
 
+[build.nixpacksPlan.variables]
+NIXPACKS_NODE_VERSION = "20"
+
 [deploy]
 startCommand = "npm start"
 healthcheckPath = "/"


### PR DESCRIPTION
## Summary
- Adds `engines: { node: ">=20" }` to `package.json` — nixpacks respects this during Railway builds
- Adds `NIXPACKS_NODE_VERSION = "20"` to `railway.toml` as an explicit build override
- Eliminates the Supabase `@supabase/supabase-js` deprecation warning about Node 18

## Test plan
- [ ] Railway build log shows Node 20.x being used (not 18.x)
- [ ] Supabase deprecation warning no longer appears in startup logs