### PR TITLE
feat(query): support GET /query?question= as fallback for GET-only AI agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- 2026-03-26 — feat(query): support GET /query?question= as fallback for get-only ai agents
 - 2026-03-26 — chore(config): pin Node.js to >=20 via engines field and railway nixpacks variable
 - 2026-03-26 — fix(agent-card): enrich endpoint objects with method, schema, and examples for AI agent discovery
 - 2026-03-26 — chore(api): add startup log confirming route registration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- 2026-03-26 — feat(query): support GET /query?question= as fallback for get-only ai agents
+- 2026-03-26 — feat(query): support GET /query?question= as fallback for GET-only AI agents
 - 2026-03-26 — chore(config): pin Node.js to >=20 via engines field and railway nixpacks variable
 - 2026-03-26 — fix(agent-card): enrich endpoint objects with method, schema, and examples for AI agent discovery
 - 2026-03-26 — chore(api): add startup log confirming route registration

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.2.9",
         "@ai-sdk/google": "^1.2.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/routes/agent-card.ts
+++ b/src/routes/agent-card.ts
@@ -33,8 +33,9 @@ app.get('/', async (c) => {
       query: {
         url: `${baseUrl}/query`,
         method: 'POST',
+        also_supports: `GET ${baseUrl}/query?question=Your+question+here`,
         content_type: 'application/json',
-        description: 'Ask a natural language question about this candidate.',
+        description: 'Ask a natural language question about this candidate. Supports POST with JSON body or GET with ?question= param.',
         input_schema: {
           type: 'object',
           required: ['question'],

--- a/src/routes/query.ts
+++ b/src/routes/query.ts
@@ -22,7 +22,7 @@ async function handleQuery(c: Context, question: string, context?: string): Prom
     ? headerCaller
     : { ...headerCaller, ...queryCaller }
 
-  const callerHint = context ?? caller.hint
+  const callerHint = (context?.trim() || undefined) ?? caller.hint
 
   const { data: profile, error } = await supabase
     .from('public_profile')
@@ -84,21 +84,27 @@ Question: ${question}`
     meta: { model: MODEL, latency_ms },
   }
 
+  c.header('Cache-Control', 'no-store')
   return c.json(response)
 }
 
 app.get('/', async (c) => {
-  const question = c.req.query('question')
-  if (question) {
-    return handleQuery(c, question, c.req.query('context'))
+  const rawQuestion = c.req.query('question')
+  if (rawQuestion !== undefined) {
+    const result = schema.safeParse({ question: rawQuestion, context: c.req.query('context') })
+    if (!result.success) {
+      return c.json({ error: 'Invalid query', details: result.error.format() }, 400)
+    }
+    return handleQuery(c, result.data.question, result.data.context)
   }
   const url = new URL(c.req.url)
   return c.json({
     endpoint: url.pathname,
-    methods: ['GET ?question=', 'POST'],
+    method: 'POST',
+    also_supports: 'GET ?question=',
     description: 'Ask a natural language question about this candidate.',
+    body: { question: 'string (required)', context: 'string (optional, e.g. "ATS", "recruiter", "ai-agent")' },
     get_usage: 'GET /query?question=Your+question+here',
-    post_body: { question: 'string (required)', context: 'string (optional, e.g. "ATS", "recruiter", "ai-agent")' },
     example: { question: 'What is your experience with TypeScript?' },
   })
 })

--- a/src/routes/query.ts
+++ b/src/routes/query.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono'
+import { Hono, type Context } from 'hono'
 import { zValidator } from '@hono/zod-validator'
 import { z } from 'zod'
 import { supabase } from '../lib/supabase.js'
@@ -15,21 +15,7 @@ const schema = z.object({
   context: z.string().optional(),
 })
 
-app.get('/', (c) => {
-  const url = new URL(c.req.url)
-  return c.json({
-    endpoint: url.pathname,
-    method: 'POST',
-    description: 'Ask a natural language question about this candidate.',
-    body: { question: 'string (required)', context: 'string (optional, e.g. "ATS", "recruiter", "ai-agent")' },
-    example: { question: 'What is your experience with TypeScript?' },
-  })
-})
-
-app.post('/', zValidator('json', schema), async (c) => {
-  const { question, context } = c.req.valid('json')
-
-  // Detect caller from headers, fall back to query language inference
+async function handleQuery(c: Context, question: string, context?: string): Promise<Response> {
   const headerCaller = detectCaller(c)
   const queryCaller = callerContextFromQuery(question)
   const caller = headerCaller.type !== 'unknown'
@@ -99,6 +85,27 @@ Question: ${question}`
   }
 
   return c.json(response)
+}
+
+app.get('/', async (c) => {
+  const question = c.req.query('question')
+  if (question) {
+    return handleQuery(c, question, c.req.query('context'))
+  }
+  const url = new URL(c.req.url)
+  return c.json({
+    endpoint: url.pathname,
+    methods: ['GET ?question=', 'POST'],
+    description: 'Ask a natural language question about this candidate.',
+    get_usage: 'GET /query?question=Your+question+here',
+    post_body: { question: 'string (required)', context: 'string (optional, e.g. "ATS", "recruiter", "ai-agent")' },
+    example: { question: 'What is your experience with TypeScript?' },
+  })
+})
+
+app.post('/', zValidator('json', schema), async (c) => {
+  const { question, context } = c.req.valid('json')
+  return handleQuery(c, question, context)
 })
 
 export default app


### PR DESCRIPTION
## Summary
- Grok and some other AI agents can only issue GET requests to external APIs
- Extracts the shared AI query logic into a `handleQuery` helper
- GET `/query?question=Your+question` now returns the full AI response (same as POST)
- GET `/query` with no params still returns the discovery/schema response
- POST `/query` unchanged

## Test plan
- [ ] `GET /query?question=What+is+your+TypeScript+experience` returns full AI answer
- [ ] `GET /query?question=...&context=ai-agent` respects the context param
- [ ] `GET /query` (no params) still returns discovery response
- [ ] `POST /query` with JSON body still works as before