### PR TITLE
feat(ob1): add Open Brain MCP server and thoughts table

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,9 @@ SUPA_SERVICE_ROLE=your_supabase_service_role_key_here
 # Supabase CLI (for db:link and db:push)
 SUPABASE_PROJECT_REF=your-project-ref       # from dashboard URL: supabase.com/dashboard/project/<ref>
 SUPABASE_DB_PASSWORD=your-db-password       # Project Settings → Database → Connection string
-# OB1 MCP
-MCP_ACCESS_KEY=your_64_char_hex_key_here
+# OB1 (Open Brain) MCP
+OPENROUTER_API_KEY=your_openrouter_api_key_here   # openrouter.ai/keys — used for embeddings + metadata extraction
+MCP_ACCESS_KEY=your_64_char_hex_key_here          # generate: openssl rand -hex 32 (or PowerShell equivalent)
 
 # Private endpoint protection
 API_KEY=your_private_api_key_here

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- 2026-03-26 — feat(ob1): add Open Brain MCP server as Supabase Edge Function with thoughts table, pgvector search, and 4 MCP tools
 - 2026-03-26 — feat(query): support GET /query?question= as fallback for GET-only AI agents
 - 2026-03-26 — chore(config): pin Node.js to >=20 via engines field and railway nixpacks variable
 - 2026-03-26 — fix(agent-card): enrich endpoint objects with method, schema, and examples for AI agent discovery

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.2.9",
         "@ai-sdk/google": "^1.2.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "engines": {
@@ -12,7 +12,9 @@
     "start": "node dist/index.js",
     "seed": "tsx --env-file=.env.local scripts/seed.ts",
     "db:link": "supabase link --project-ref $SUPABASE_PROJECT_REF",
-    "db:push": "supabase db push"
+    "db:push": "supabase db push",
+    "ob1:deploy": "supabase functions deploy open-brain-mcp --no-verify-jwt",
+    "ob1:logs": "supabase functions logs open-brain-mcp"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.2.9",

--- a/supabase/functions/open-brain-mcp/deno.json
+++ b/supabase/functions/open-brain-mcp/deno.json
@@ -1,0 +1,9 @@
+{
+  "imports": {
+    "@hono/mcp": "npm:@hono/mcp@0.1.1",
+    "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@1.24.3",
+    "hono": "npm:hono@4.9.2",
+    "zod": "npm:zod@4.1.13",
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@2.47.10"
+  }
+}

--- a/supabase/functions/open-brain-mcp/index.ts
+++ b/supabase/functions/open-brain-mcp/index.ts
@@ -1,0 +1,396 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPTransport } from "@hono/mcp";
+import { Hono } from "hono";
+import { z } from "zod";
+import { createClient } from "@supabase/supabase-js";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const OPENROUTER_API_KEY = Deno.env.get("OPENROUTER_API_KEY")!;
+const MCP_ACCESS_KEY = Deno.env.get("MCP_ACCESS_KEY")!;
+
+const OPENROUTER_BASE = "https://openrouter.ai/api/v1";
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+async function getEmbedding(text: string): Promise<number[]> {
+  const r = await fetch(`${OPENROUTER_BASE}/embeddings`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${OPENROUTER_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "openai/text-embedding-3-small",
+      input: text,
+    }),
+  });
+  if (!r.ok) {
+    const msg = await r.text().catch(() => "");
+    throw new Error(`OpenRouter embeddings failed: ${r.status} ${msg}`);
+  }
+  const d = await r.json();
+  return d.data[0].embedding;
+}
+
+async function extractMetadata(text: string): Promise<Record<string, unknown>> {
+  const r = await fetch(`${OPENROUTER_BASE}/chat/completions`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${OPENROUTER_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "openai/gpt-4o-mini",
+      response_format: { type: "json_object" },
+      messages: [
+        {
+          role: "system",
+          content: `Extract metadata from the user's captured thought. Return JSON with:
+- "people": array of people mentioned (empty if none)
+- "action_items": array of implied to-dos (empty if none)
+- "dates_mentioned": array of dates YYYY-MM-DD (empty if none)
+- "topics": array of 1-3 short topic tags (always at least one)
+- "type": one of "observation", "task", "idea", "reference", "person_note"
+Only extract what's explicitly there.`,
+        },
+        { role: "user", content: text },
+      ],
+    }),
+  });
+  const d = await r.json();
+  try {
+    return JSON.parse(d.choices[0].message.content);
+  } catch {
+    return { topics: ["uncategorized"], type: "observation" };
+  }
+}
+
+// --- MCP Server Setup ---
+
+const server = new McpServer({
+  name: "open-brain",
+  version: "1.0.0",
+});
+
+// Tool 1: Semantic Search
+server.registerTool(
+  "search_thoughts",
+  {
+    title: "Search Thoughts",
+    description:
+      "Search captured thoughts by meaning. Use this when the user asks about a topic, person, or idea they've previously captured.",
+    inputSchema: {
+      query: z.string().describe("What to search for"),
+      limit: z.number().optional().default(10),
+      threshold: z.number().optional().default(0.5),
+    },
+  },
+  async ({ query, limit, threshold }) => {
+    try {
+      const qEmb = await getEmbedding(query);
+      const { data, error } = await supabase.rpc("match_thoughts", {
+        query_embedding: qEmb,
+        match_threshold: threshold,
+        match_count: limit,
+        filter: {},
+      });
+
+      if (error) {
+        return {
+          content: [{ type: "text" as const, text: `Search error: ${error.message}` }],
+          isError: true,
+        };
+      }
+
+      if (!data || data.length === 0) {
+        return {
+          content: [{ type: "text" as const, text: `No thoughts found matching "${query}".` }],
+        };
+      }
+
+      const results = data.map(
+        (
+          t: {
+            content: string;
+            metadata: Record<string, unknown>;
+            similarity: number;
+            created_at: string;
+          },
+          i: number
+        ) => {
+          const m = t.metadata || {};
+          const parts = [
+            `--- Result ${i + 1} (${(t.similarity * 100).toFixed(1)}% match) ---`,
+            `Captured: ${new Date(t.created_at).toLocaleDateString()}`,
+            `Type: ${m.type || "unknown"}`,
+          ];
+          if (Array.isArray(m.topics) && m.topics.length)
+            parts.push(`Topics: ${(m.topics as string[]).join(", ")}`);
+          if (Array.isArray(m.people) && m.people.length)
+            parts.push(`People: ${(m.people as string[]).join(", ")}`);
+          if (Array.isArray(m.action_items) && m.action_items.length)
+            parts.push(`Actions: ${(m.action_items as string[]).join("; ")}`);
+          parts.push(`\n${t.content}`);
+          return parts.join("\n");
+        }
+      );
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Found ${data.length} thought(s):\n\n${results.join("\n\n")}`,
+          },
+        ],
+      };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// Tool 2: List Recent
+server.registerTool(
+  "list_thoughts",
+  {
+    title: "List Recent Thoughts",
+    description:
+      "List recently captured thoughts with optional filters by type, topic, person, or time range.",
+    inputSchema: {
+      limit: z.number().optional().default(10),
+      type: z.string().optional().describe("Filter by type: observation, task, idea, reference, person_note"),
+      topic: z.string().optional().describe("Filter by topic tag"),
+      person: z.string().optional().describe("Filter by person mentioned"),
+      days: z.number().optional().describe("Only thoughts from the last N days"),
+    },
+  },
+  async ({ limit, type, topic, person, days }) => {
+    try {
+      let q = supabase
+        .from("thoughts")
+        .select("content, metadata, created_at")
+        .order("created_at", { ascending: false })
+        .limit(limit);
+
+      if (type) q = q.contains("metadata", { type });
+      if (topic) q = q.contains("metadata", { topics: [topic] });
+      if (person) q = q.contains("metadata", { people: [person] });
+      if (days) {
+        const since = new Date();
+        since.setDate(since.getDate() - days);
+        q = q.gte("created_at", since.toISOString());
+      }
+
+      const { data, error } = await q;
+
+      if (error) {
+        return {
+          content: [{ type: "text" as const, text: `Error: ${error.message}` }],
+          isError: true,
+        };
+      }
+
+      if (!data || !data.length) {
+        return { content: [{ type: "text" as const, text: "No thoughts found." }] };
+      }
+
+      const results = data.map(
+        (
+          t: { content: string; metadata: Record<string, unknown>; created_at: string },
+          i: number
+        ) => {
+          const m = t.metadata || {};
+          const tags = Array.isArray(m.topics) ? (m.topics as string[]).join(", ") : "";
+          return `${i + 1}. [${new Date(t.created_at).toLocaleDateString()}] (${m.type || "??"}${tags ? " - " + tags : ""})\n   ${t.content}`;
+        }
+      );
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `${data.length} recent thought(s):\n\n${results.join("\n\n")}`,
+          },
+        ],
+      };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// Tool 3: Stats
+server.registerTool(
+  "thought_stats",
+  {
+    title: "Thought Statistics",
+    description: "Get a summary of all captured thoughts: totals, types, top topics, and people.",
+    inputSchema: {},
+  },
+  async () => {
+    try {
+      const { count } = await supabase
+        .from("thoughts")
+        .select("*", { count: "exact", head: true });
+
+      const { data } = await supabase
+        .from("thoughts")
+        .select("metadata, created_at")
+        .order("created_at", { ascending: false });
+
+      const types: Record<string, number> = {};
+      const topics: Record<string, number> = {};
+      const people: Record<string, number> = {};
+
+      for (const r of data || []) {
+        const m = (r.metadata || {}) as Record<string, unknown>;
+        if (m.type) types[m.type as string] = (types[m.type as string] || 0) + 1;
+        if (Array.isArray(m.topics))
+          for (const t of m.topics) topics[t as string] = (topics[t as string] || 0) + 1;
+        if (Array.isArray(m.people))
+          for (const p of m.people) people[p as string] = (people[p as string] || 0) + 1;
+      }
+
+      const sort = (o: Record<string, number>): [string, number][] =>
+        Object.entries(o)
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, 10);
+
+      const lines: string[] = [
+        `Total thoughts: ${count}`,
+        `Date range: ${
+          data?.length
+            ? new Date(data[data.length - 1].created_at).toLocaleDateString() +
+              " → " +
+              new Date(data[0].created_at).toLocaleDateString()
+            : "N/A"
+        }`,
+        "",
+        "Types:",
+        ...sort(types).map(([k, v]) => `  ${k}: ${v}`),
+      ];
+
+      if (Object.keys(topics).length) {
+        lines.push("", "Top topics:");
+        for (const [k, v] of sort(topics)) lines.push(`  ${k}: ${v}`);
+      }
+
+      if (Object.keys(people).length) {
+        lines.push("", "People mentioned:");
+        for (const [k, v] of sort(people)) lines.push(`  ${k}: ${v}`);
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// Tool 4: Capture Thought
+server.registerTool(
+  "capture_thought",
+  {
+    title: "Capture Thought",
+    description:
+      "Save a new thought to the Open Brain. Generates an embedding and extracts metadata automatically. Use this when the user wants to save something to their brain directly from any AI client — notes, insights, decisions, or migrated content from other systems.",
+    inputSchema: {
+      content: z.string().describe("The thought to capture — a clear, standalone statement that will make sense when retrieved later by any AI"),
+    },
+  },
+  async ({ content }) => {
+    try {
+      const [embedding, metadata] = await Promise.all([
+        getEmbedding(content),
+        extractMetadata(content),
+      ]);
+
+      const { error } = await supabase.from("thoughts").insert({
+        content,
+        embedding,
+        metadata: { ...metadata, source: "mcp" },
+      });
+
+      if (error) {
+        return {
+          content: [{ type: "text" as const, text: `Failed to capture: ${error.message}` }],
+          isError: true,
+        };
+      }
+
+      const meta = metadata as Record<string, unknown>;
+      let confirmation = `Captured as ${meta.type || "thought"}`;
+      if (Array.isArray(meta.topics) && meta.topics.length)
+        confirmation += ` — ${(meta.topics as string[]).join(", ")}`;
+      if (Array.isArray(meta.people) && meta.people.length)
+        confirmation += ` | People: ${(meta.people as string[]).join(", ")}`;
+      if (Array.isArray(meta.action_items) && meta.action_items.length)
+        confirmation += ` | Actions: ${(meta.action_items as string[]).join("; ")}`;
+
+      return {
+        content: [{ type: "text" as const, text: confirmation }],
+      };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: "text" as const, text: `Error: ${(err as Error).message}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// --- Hono App with Auth + CORS ---
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-brain-key, accept, mcp-session-id",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS, DELETE",
+};
+
+const app = new Hono();
+
+// CORS preflight — required for browser/Electron-based clients (Claude Desktop, claude.ai)
+app.options("*", (c) => {
+  return c.text("ok", 200, corsHeaders);
+});
+
+app.all("*", async (c) => {
+  // Accept access key via header OR URL query parameter
+  const provided = c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");
+  if (!provided || provided !== MCP_ACCESS_KEY) {
+    return c.json({ error: "Invalid or missing access key" }, 401, corsHeaders);
+  }
+
+  // Fix: Claude Desktop connectors don't send the Accept header that
+  // StreamableHTTPTransport requires. Build a patched request if missing.
+  // See: https://github.com/NateBJones-Projects/OB1/issues/33
+  if (!c.req.header("accept")?.includes("text/event-stream")) {
+    const headers = new Headers(c.req.raw.headers);
+    headers.set("Accept", "application/json, text/event-stream");
+    const patched = new Request(c.req.raw.url, {
+      method: c.req.raw.method,
+      headers,
+      body: c.req.raw.body,
+      // @ts-ignore -- duplex required for streaming body in Deno
+      duplex: "half",
+    });
+    Object.defineProperty(c.req, "raw", { value: patched, writable: true });
+  }
+
+  const transport = new StreamableHTTPTransport();
+  await server.connect(transport);
+  return transport.handleRequest(c);
+});
+
+Deno.serve(app.fetch);

--- a/supabase/functions/open-brain-mcp/index.ts
+++ b/supabase/functions/open-brain-mcp/index.ts
@@ -59,6 +59,11 @@ Only extract what's explicitly there.`,
       ],
     }),
   });
+  if (!r.ok) {
+    const msg = await r.text().catch(() => "");
+    console.error(`OpenRouter metadata extraction failed: ${r.status} ${msg}`);
+    return { topics: ["uncategorized"], type: "observation" };
+  }
   const d = await r.json();
   try {
     return JSON.parse(d.choices[0].message.content);
@@ -83,8 +88,8 @@ server.registerTool(
       "Search captured thoughts by meaning. Use this when the user asks about a topic, person, or idea they've previously captured.",
     inputSchema: {
       query: z.string().describe("What to search for"),
-      limit: z.number().optional().default(10),
-      threshold: z.number().optional().default(0.5),
+      limit: z.number().int().min(1).max(100).optional().default(10),
+      threshold: z.number().min(0).max(1).optional().default(0.5),
     },
   },
   async ({ query, limit, threshold }) => {
@@ -162,27 +167,30 @@ server.registerTool(
     description:
       "List recently captured thoughts with optional filters by type, topic, person, or time range.",
     inputSchema: {
-      limit: z.number().optional().default(10),
+      limit: z.number().int().min(1).max(100).optional().default(10),
       type: z.string().optional().describe("Filter by type: observation, task, idea, reference, person_note"),
       topic: z.string().optional().describe("Filter by topic tag"),
       person: z.string().optional().describe("Filter by person mentioned"),
-      days: z.number().optional().describe("Only thoughts from the last N days"),
+      days: z.number().int().min(1).max(365).optional().describe("Only thoughts from the last N days"),
     },
   },
   async ({ limit, type, topic, person, days }) => {
     try {
+      const effectiveLimit = Math.min(limit ?? 10, 100);
+      const effectiveDays = days != null ? Math.min(days, 365) : undefined;
+
       let q = supabase
         .from("thoughts")
         .select("content, metadata, created_at")
         .order("created_at", { ascending: false })
-        .limit(limit);
+        .limit(effectiveLimit);
 
       if (type) q = q.contains("metadata", { type });
       if (topic) q = q.contains("metadata", { topics: [topic] });
       if (person) q = q.contains("metadata", { people: [person] });
-      if (days) {
+      if (effectiveDays != null) {
         const since = new Date();
-        since.setDate(since.getDate() - days);
+        since.setDate(since.getDate() - effectiveDays);
         q = q.gte("created_at", since.toISOString());
       }
 
@@ -237,14 +245,28 @@ server.registerTool(
   },
   async () => {
     try {
-      const { count } = await supabase
+      const { count, error: countError } = await supabase
         .from("thoughts")
         .select("*", { count: "exact", head: true });
 
-      const { data } = await supabase
+      if (countError) {
+        return {
+          content: [{ type: "text" as const, text: `Error fetching thought count: ${countError.message}` }],
+          isError: true,
+        };
+      }
+
+      const { data, error: dataError } = await supabase
         .from("thoughts")
         .select("metadata, created_at")
         .order("created_at", { ascending: false });
+
+      if (dataError) {
+        return {
+          content: [{ type: "text" as const, text: `Error fetching thought metadata: ${dataError.message}` }],
+          isError: true,
+        };
+      }
 
       const types: Record<string, number> = {};
       const topics: Record<string, number> = {};
@@ -366,7 +388,8 @@ app.options("*", (c) => {
 });
 
 app.all("*", async (c) => {
-  // Accept access key via header OR URL query parameter
+  // Accept access key via header (preferred) or URL query param.
+  // Note: query param leaks the key via logs/history — use header auth where possible.
   const provided = c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");
   if (!provided || provided !== MCP_ACCESS_KEY) {
     return c.json({ error: "Invalid or missing access key" }, 401, corsHeaders);
@@ -390,7 +413,11 @@ app.all("*", async (c) => {
 
   const transport = new StreamableHTTPTransport();
   await server.connect(transport);
-  return transport.handleRequest(c);
+  const response = await transport.handleRequest(c);
+  for (const [key, value] of Object.entries(corsHeaders)) {
+    response.headers.set(key, value);
+  }
+  return response;
 });
 
 Deno.serve(app.fetch);

--- a/supabase/migrations/20260326000000_ob1_thoughts.sql
+++ b/supabase/migrations/20260326000000_ob1_thoughts.sql
@@ -1,0 +1,81 @@
+-- OB1 (Open Brain) — thoughts table + semantic search
+
+-- Enable pgvector (idempotent — safe to run even if already enabled)
+create extension if not exists vector with schema extensions;
+
+-- 2.2: Thoughts table + indexes
+create table thoughts (
+  id uuid default gen_random_uuid() primary key,
+  content text not null,
+  embedding extensions.vector(1536),
+  metadata jsonb default '{}'::jsonb,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- Index for fast vector similarity search
+create index on thoughts
+  using hnsw (embedding extensions.vector_cosine_ops);
+
+-- Index for filtering by metadata fields
+create index on thoughts using gin (metadata);
+
+-- Index for date range queries
+create index on thoughts (created_at desc);
+
+-- Auto-update the updated_at timestamp
+create or replace function update_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger thoughts_updated_at
+  before update on thoughts
+  for each row
+  execute function update_updated_at();
+
+-- 2.3: Semantic search function
+create or replace function match_thoughts(
+  query_embedding extensions.vector(1536),
+  match_threshold float default 0.7,
+  match_count int default 10,
+  filter jsonb default '{}'::jsonb
+)
+returns table (
+  id uuid,
+  content text,
+  metadata jsonb,
+  similarity float,
+  created_at timestamptz
+)
+language plpgsql
+as $$
+begin
+  return query
+  select
+    t.id,
+    t.content,
+    t.metadata,
+    1 - (t.embedding <=> query_embedding) as similarity,
+    t.created_at
+  from thoughts t
+  where 1 - (t.embedding <=> query_embedding) > match_threshold
+    and (filter = '{}'::jsonb or t.metadata @> filter)
+  order by t.embedding <=> query_embedding
+  limit match_count;
+end;
+$$;
+
+-- 2.4: Row Level Security
+alter table thoughts enable row level security;
+
+create policy "Service role full access"
+  on thoughts
+  for all
+  using (auth.role() = 'service_role');
+
+-- 2.5: Grant service_role access (required on new Supabase projects)
+grant select, insert, update, delete on table public.thoughts to service_role;

--- a/supabase/migrations/20260326000000_ob1_thoughts.sql
+++ b/supabase/migrations/20260326000000_ob1_thoughts.sql
@@ -1,6 +1,7 @@
 -- OB1 (Open Brain) — thoughts table + semantic search
 
--- Enable pgvector (idempotent — safe to run even if already enabled)
+-- Enable required extensions (idempotent — safe to run even if already enabled)
+create extension if not exists pgcrypto;
 create extension if not exists vector with schema extensions;
 
 -- 2.2: Thoughts table + indexes
@@ -23,8 +24,8 @@ create index on thoughts using gin (metadata);
 -- Index for date range queries
 create index on thoughts (created_at desc);
 
--- Auto-update the updated_at timestamp
-create or replace function update_updated_at()
+-- Auto-update the updated_at timestamp (table-specific name avoids cross-migration collisions)
+create or replace function thoughts_update_updated_at()
 returns trigger as $$
 begin
   new.updated_at = now();
@@ -35,7 +36,7 @@ $$ language plpgsql;
 create trigger thoughts_updated_at
   before update on thoughts
   for each row
-  execute function update_updated_at();
+  execute function thoughts_update_updated_at();
 
 -- 2.3: Semantic search function
 create or replace function match_thoughts(


### PR DESCRIPTION
## Summary
- Adds `supabase/functions/open-brain-mcp/` — Supabase Edge Function exposing 4 MCP tools: `search_thoughts`, `list_thoughts`, `thought_stats`, `capture_thought`
- Adds `supabase/migrations/20260326000000_ob1_thoughts.sql` — thoughts table with pgvector (hnsw index), `match_thoughts` semantic search function, RLS, and service_role grants
- Adds `ob1:deploy` and `ob1:logs` scripts to `package.json`
- Updates `.env.example` with `OPENROUTER_API_KEY` and `MCP_ACCESS_KEY`

## Test plan
- [ ] `supabase functions list` shows `open-brain-mcp` as ACTIVE
- [ ] `supabase migration list` shows `20260326000000` as applied
- [ ] Start new Claude Code session — `open-brain` appears in MCP tool list
- [ ] `capture_thought` saves a thought and returns confirmation
- [ ] `search_thoughts` returns semantically relevant results
- [ ] `list_thoughts` returns recent thoughts with metadata
- [ ] `thought_stats` returns totals and type breakdown
- [ ] Supabase Table Editor shows thoughts table with correct schema