### PR TITLE
feat(api): rate limiting, README fixes, ResumeResponse type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- 2026-03-28 — feat(api): add IP-based rate limiting (30 req/min), fix README discrepancies, add ResumeResponse type
 - 2026-03-26 — feat(ob1): add Open Brain MCP server as Supabase Edge Function with thoughts table, pgvector search, and 4 MCP tools
 - 2026-03-26 — feat(query): support GET /query?question= as fallback for GET-only AI agents
 - 2026-03-26 — chore(config): pin Node.js to >=20 via engines field and railway nixpacks variable

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Full read/write GET /.well-known/agent-card.json
 |---|---|---|
 | `public_profile` | Public API (read-only) | Skills, experience, projects, availability |
 | `thoughts` | MCP only (private) | Raw notes, captures, work-in-progress |
-| `job_hunt_pipeline` | MCP only (private) | Applications, interviews, contacts |
+| `job_hunt_pipeline` | MCP only (private) — _planned_ | Applications, interviews, contacts |
 
 Row Level Security in Supabase enforces the boundary. The public API has no knowledge of the private tables and no credentials to reach them.
 
@@ -93,7 +93,7 @@ Response:
   "sources": ["experience.company_name", "skills.languages"],
   "follow_up_suggestions": ["..."],
   "contact": { "email": "...", "calendly": "..." },
-  "meta": { "model": "claude-sonnet-4-6", "latency_ms": 740 }
+  "meta": { "model": "claude-haiku-4-5-20251001", "latency_ms": 740 }
 }
 ```
 
@@ -183,7 +183,7 @@ Then in Claude:
 | Layer | Technology |
 |---|---|
 | API framework | Hono (TypeScript) |
-| AI | Anthropic SDK — claude-sonnet-4-6 |
+| AI | Anthropic SDK — Haiku (query/resume) + Sonnet (match) |
 | Database | Supabase (Postgres + pgvector) |
 | Private interface | MCP (Model Context Protocol) via OB1 |
 | Validation | Zod |
@@ -205,21 +205,21 @@ Then in Claude:
 
 ## Setup
 
-> Full setup guide in [`docs/setup.md`](docs/setup.md)
-
 1. Clone this repo
-2. Set up a Supabase project and run migrations in `supabase/migrations/`
-3. Set up OB1 on the same Supabase project (see OB1 docs)
-4. Copy `.env.example` → `.env` and fill in your keys
-5. `npm install && npm run dev`
-6. Deploy to Railway
-7. Generate a QR code pointing to `https://your-domain.dev/.well-known/agent-card.json`
+2. Set up a Supabase project and run migrations: `npm run db:link && npm run db:push`
+3. Set up OB1 on the same Supabase project (see [OB1 docs](https://github.com/NateBJones-Projects/OB1))
+4. Copy `.env.example` → `.env.local` and fill in your keys
+5. Seed your profile: `npm run seed`
+6. `npm install && npm run dev`
+7. Deploy to Railway (connect the repo — `railway.toml` handles build + start)
+8. Set env vars in Railway dashboard (see `.env.example` for the full list)
+9. Generate a QR code pointing to `https://your-domain/.well-known/agent-card.json`
 
 ---
 
 ## Project status
 
-Early stage. The architecture is decided. Implementation in progress.
+Live at [agent.yuens.me](https://agent.yuens.me). All public endpoints are operational.
 
 Contributions welcome — particularly around the job match scoring methodology and MCP tool definitions.
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Then in Claude:
 
 ## Security model
 
-- All secrets in `.env`, never committed
+- All secrets in `.env.local`, never committed
 - `public_profile` table: read-only, no auth required, rate-limited by IP
 - Private endpoints (`/resume`, MCP): require `Authorization: Bearer` header
 - Supabase service role key: server-side only, never returned to clients
@@ -206,14 +206,15 @@ Then in Claude:
 ## Setup
 
 1. Clone this repo
-2. Set up a Supabase project and run migrations: `npm run db:link && npm run db:push`
-3. Set up OB1 on the same Supabase project (see [OB1 docs](https://github.com/NateBJones-Projects/OB1))
-4. Copy `.env.example` → `.env.local` and fill in your keys
-5. Seed your profile: `npm run seed`
-6. `npm install && npm run dev`
-7. Deploy to Railway (connect the repo — `railway.toml` handles build + start)
-8. Set env vars in Railway dashboard (see `.env.example` for the full list)
-9. Generate a QR code pointing to `https://your-domain/.well-known/agent-card.json`
+2. `npm install`
+3. Set up a Supabase project and run migrations: `npm run db:link && npm run db:push`
+4. Set up OB1 on the same Supabase project (see [OB1 docs](https://github.com/NateBJones-Projects/OB1))
+5. Copy `.env.example` → `.env.local` and fill in your keys
+6. Seed your profile: `npm run seed`
+7. `npm run dev`
+8. Deploy to Railway (connect the repo — `railway.toml` handles build + start)
+9. Set env vars in Railway dashboard (see `.env.example` for the full list)
+10. Generate a QR code pointing to `https://your-domain/.well-known/agent-card.json`
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,26 @@ const app = new Hono({ strict: false })
 app.use('*', logger())
 app.use('*', cors())
 
+// IP-based rate limiting: 30 requests per minute per IP
+const rateLimitMap = new Map<string, { count: number; resetAt: number }>()
+app.use('*', async (c, next) => {
+  const ip = c.req.header('x-forwarded-for')?.split(',')[0].trim() ?? 'unknown'
+  const now = Date.now()
+  const windowMs = 60_000
+  const limit = 30
+
+  const record = rateLimitMap.get(ip)
+  if (!record || now > record.resetAt) {
+    rateLimitMap.set(ip, { count: 1, resetAt: now + windowMs })
+  } else {
+    record.count++
+    if (record.count > limit) {
+      return c.json({ error: 'Rate limit exceeded. Try again in a minute.' }, 429)
+    }
+  }
+  await next()
+})
+
 app.route('/info', infoRoute)
 app.route('/availability', availabilityRoute)
 app.route('/query', queryRoute)
@@ -32,5 +52,7 @@ const port = parseInt(process.env.PORT ?? '3000')
 
 serve({ fetch: app.fetch, port }, () => {
   console.log(`resume-agent running on http://localhost:${port}`)
-  console.log('[routes] registered and listening — GET+POST /query, /match, /info, /availability, /resume, /profile, /projects, /.well-known/agent.json')
+  console.log('[routes] GET /info, /availability, /projects, /.well-known/agent.json')
+  console.log('[routes] POST /query, /match, /resume (key-protected) | PATCH /profile (key-protected)')
+  console.log('[middleware] rate-limit: 30 req/min per IP')
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { serve } from '@hono/node-server'
-import { Hono } from 'hono'
+import { Hono, type Context } from 'hono'
 import { cors } from 'hono/cors'
 import { logger } from 'hono/logger'
 
@@ -19,8 +19,30 @@ app.use('*', cors())
 
 // IP-based rate limiting: 30 requests per minute per IP
 const rateLimitMap = new Map<string, { count: number; resetAt: number }>()
+
+// Evict expired entries every 5 minutes to prevent unbounded memory growth
+setInterval(() => {
+  const now = Date.now()
+  for (const [key, record] of rateLimitMap) {
+    if (now > record.resetAt) rateLimitMap.delete(key)
+  }
+}, 5 * 60_000)
+
+const getClientIp = (c: Context): string => {
+  for (const header of ['cf-connecting-ip', 'x-real-ip', 'x-client-ip', 'true-client-ip'] as const) {
+    const value = c.req.header(header)
+    if (value) return value
+  }
+  const xff = c.req.header('x-forwarded-for')
+  if (xff) return xff.split(',')[0].trim()
+  return `${c.req.header('host') ?? 'unknown-host'}:${c.req.header('user-agent') ?? 'unknown-ua'}`
+}
+
 app.use('*', async (c, next) => {
-  const ip = c.req.header('x-forwarded-for')?.split(',')[0].trim() ?? 'unknown'
+  // Skip OPTIONS preflights — don't count them toward the rate limit
+  if (c.req.method === 'OPTIONS') return next()
+
+  const ip = getClientIp(c)
   const now = Date.now()
   const windowMs = 60_000
   const limit = 30
@@ -51,8 +73,9 @@ app.get('/', (c) => c.json({ status: 'ok', agent: 'resume-agent' }))
 const port = parseInt(process.env.PORT ?? '3000')
 
 serve({ fetch: app.fetch, port }, () => {
+  const authMode = process.env.AUTH_MODE ?? 'open'
   console.log(`resume-agent running on http://localhost:${port}`)
-  console.log('[routes] GET /info, /availability, /projects, /.well-known/agent.json')
-  console.log('[routes] POST /query, /match, /resume (key-protected) | PATCH /profile (key-protected)')
-  console.log('[middleware] rate-limit: 30 req/min per IP')
+  console.log('[routes] GET /, /info, /availability, /projects, /projects/:slug, /.well-known/agent.json')
+  console.log(`[routes] POST /query, /match | POST /resume (auth: ${authMode}) | PATCH /profile (auth: key)`)
+  console.log('[middleware] rate-limit: 30 req/min per IP (excludes OPTIONS)')
 })

--- a/src/routes/resume.ts
+++ b/src/routes/resume.ts
@@ -5,6 +5,7 @@ import { supabase } from '../lib/supabase.js'
 import { getModel } from '../lib/ai.js'
 import { generateText } from 'ai'
 import { parseJSON } from '../lib/parse-json.js'
+import type { ResumeResponse } from '../types.js'
 
 const app = new Hono()
 
@@ -70,9 +71,9 @@ ${job_description}`
     prompt: userMessage,
   })
 
-  let parsed: unknown
+  let parsed: ResumeResponse
   try {
-    parsed = parseJSON(raw)
+    parsed = parseJSON(raw) as ResumeResponse
   } catch {
     return c.json({ error: 'Failed to parse resume response' }, 500)
   }

--- a/src/routes/resume.ts
+++ b/src/routes/resume.ts
@@ -73,7 +73,7 @@ ${job_description}`
 
   let parsed: ResumeResponse
   try {
-    parsed = parseJSON(raw) as ResumeResponse
+    parsed = parseJSON<ResumeResponse>(raw)
   } catch {
     return c.json({ error: 'Failed to parse resume response' }, 500)
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,3 +121,12 @@ export interface MatchResponse {
 export interface ResumeRequest {
   job_description: string
 }
+
+export interface ResumeResponse {
+  contact: Contact
+  summary: string
+  skills: Skill[]
+  employment: Employment[]
+  education: Education[]
+  projects: Project[]
+}


### PR DESCRIPTION
## Summary
- Add IP-based rate limiting middleware (30 req/min per IP) on all public endpoints
- Fix README discrepancies: model name in /query example, job_hunt_pipeline marked planned, docs/setup.md removed, setup steps inlined, project status updated to reflect live API
- Add `ResumeResponse` type to `types.ts` and cast output in `/resume` route
- Fix startup log to accurately list routes and middleware

## Test plan
- [ ] `GET /availability` returns 200
- [ ] `POST /match` with a job description returns scored JSON
- [ ] Fire 31 requests to any endpoint within 1 minute → 31st returns 429
- [ ] `POST /resume` without auth key returns 401
- [ ] `npm run build` compiles cleanly (no type errors)