### PR TITLE
docs(workflow): add workflow doc for employer AI, candidate MCP, and A2A reality check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- 2026-03-28 — docs(workflow): add workflow doc covering employer AI, candidate MCP, and real-world A2A limitations
 - 2026-03-28 — feat(api): add IP-based rate limiting (30 req/min), fix README discrepancies, add ResumeResponse type
 - 2026-03-26 — feat(ob1): add Open Brain MCP server as Supabase Edge Function with thoughts table, pgvector search, and 4 MCP tools
 - 2026-03-26 — feat(query): support GET /query?question= as fallback for GET-only AI agents

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Your AI tools   Employer AI / QR scan
 Claude Desktop  POST /query
 Cursor, etc.    GET /info
 Key-protected   GET /availability
-Full read/write GET /.well-known/agent-card.json
+Full read/write GET /.well-known/agent.json
                 POST /match
                 POST /resume
                 Read-only, rate-limited
@@ -65,7 +65,7 @@ Row Level Security in Supabase enforces the boundary. The public API has no know
 
 ## Public API endpoints
 
-### `GET /.well-known/agent-card.json`
+### `GET /.well-known/agent.json`
 A2A-compliant agent card. The QR code points here. AI systems use this to autodiscover the query endpoint, capabilities, and contact info.
 
 ### `GET /info`
@@ -188,7 +188,7 @@ Then in Claude:
 | Private interface | MCP (Model Context Protocol) via OB1 |
 | Validation | Zod |
 | Deployment | Railway |
-| Agent discovery | A2A agent card spec (`/.well-known/agent-card.json`) |
+| Agent discovery | A2A agent card spec (`/.well-known/agent.json`) |
 
 ---
 
@@ -220,7 +220,7 @@ See [`docs/workflow.md`](docs/workflow.md) for a walkthrough of how employer AI 
 7. `npm run dev`
 8. Deploy to Railway (connect the repo — `railway.toml` handles build + start)
 9. Set env vars in Railway dashboard (see `.env.example` for the full list)
-10. Generate a QR code pointing to `https://your-domain/.well-known/agent-card.json`
+10. Generate a QR code pointing to `https://your-domain/.well-known/agent.json`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ Then in Claude:
 
 ---
 
+## Workflow
+
+See [`docs/workflow.md`](docs/workflow.md) for a walkthrough of how employer AI systems, recruiters, and the candidate each interact with the agent — including an honest account of what works today vs. what's still aspirational.
+
+---
+
 ## Setup
 
 1. Clone this repo

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -70,7 +70,7 @@ Response:
 }
 ```
 
-The `context` field is optional. Accepted values: `"ATS"`, `"recruiter"`, `"ai-agent"`. The agent adjusts tone and verbosity based on who's asking.
+The `context` field is optional and is treated as a free-form hint about who's asking. Suggested values include `"ATS"`, `"recruiter"`, `"ai-agent"`, but any short descriptor string is allowed. The agent adjusts tone and verbosity based on this hint.
 
 ### Step 4 — Score a job description
 
@@ -148,7 +148,7 @@ Once connected, the 4 available tools are:
 "Generate a resume for this staff engineer position at Stripe [paste JD]"
 ```
 
-The last two trigger Claude to call `GET /info` and `POST /match` / `POST /resume` against the live API, using your captured context to enrich the response.
+The last two trigger Claude to call `GET /info` and `POST /match` / `POST /resume` against the live API (including the required `Authorization: Bearer` header for `/resume`, or anonymously only when `AUTH_MODE=open`), using your captured context to enrich the response.
 
 ---
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,186 @@
+# How resume-agent works
+
+Three actors interact with this system: **employer AI systems** (or the humans who run them), **the candidate** (Sunny), and the **API** as the mediator between them. This document walks through each perspective — including what works today and what doesn't yet.
+
+---
+
+## Employer AI / ATS workflow
+
+An AI system or recruiter tool can interact with the agent entirely through HTTP, with no custom integration required.
+
+### Step 1 — Discover the agent
+
+```
+GET https://agent.yuens.me/.well-known/agent.json
+```
+
+Returns an A2A-compliant agent card: name, capabilities, full endpoint catalog with schemas and examples, and contact info. Designed to be machine-parseable so AI systems can learn what to call and how.
+
+### Step 2 — Read the profile
+
+```
+GET https://agent.yuens.me/info
+```
+
+Full structured snapshot: skills by category, employment history with bullets, education, projects, availability. No AI call — raw data, fast, cacheable. Good for ATS tools that want facts without NL processing.
+
+```
+GET https://agent.yuens.me/availability
+```
+
+Current job-seeking status, preferred roles, remote preference, and contact links.
+
+### Step 3 — Ask a question
+
+```
+POST https://agent.yuens.me/query
+Content-Type: application/json
+
+{
+  "question": "Has this person shipped production TypeScript systems?",
+  "context": "ATS"
+}
+```
+
+Response:
+```json
+{
+  "answer": "Yes, extensively. Sunny has shipped multiple production TypeScript systems across diverse domains: a full-stack Next.js application for LAX airport (2023), an open-source e-commerce platform (Artisan Roast, live at artisanroast.app with 118 API routes and 39 Prisma models), and a Resume Agent API (Node.js/Hono/TypeScript). TypeScript is listed as a core language skill and appears across all recent projects.",
+  "confidence": "high",
+  "sources": [
+    "employment.Wipro.bullets[1]",
+    "employment.Self-Employed.bullets[1]",
+    "projects.Artisan Roast Platform.tech",
+    "projects.Resume Agent.tech",
+    "skills.Languages"
+  ],
+  "follow_up_suggestions": [
+    "Ask about type safety practices or how TypeScript improved code quality in a specific project",
+    "Inquire about experience with advanced TypeScript patterns (generics, utility types, discriminated unions)",
+    "Explore the scale of TypeScript systems shipped — Artisan Roast mentions 638 TypeScript files"
+  ],
+  "contact": {
+    "email": "syuen@sbgrp.cc",
+    "calendly": "https://calendly.com/syuen-sbgrp/get_to_know_you"
+  },
+  "meta": {
+    "model": "claude-haiku-4-5-20251001",
+    "latency_ms": 3788
+  }
+}
+```
+
+The `context` field is optional. Accepted values: `"ATS"`, `"recruiter"`, `"ai-agent"`. The agent adjusts tone and verbosity based on who's asking.
+
+### Step 4 — Score a job description
+
+```
+POST https://agent.yuens.me/match
+Content-Type: application/json
+
+{
+  "job_description": "Senior Frontend Engineer, React and TypeScript required, 5+ years experience, remote"
+}
+```
+
+Response:
+```json
+{
+  "fit_score": 0.81,
+  "matched": ["TypeScript"],
+  "gaps": ["React (partial)"],
+  "verdict": "Strong overall fit on experience and TypeScript, but React is secondary to Vue in this candidate's profile — present and used in multiple roles, though not the primary framework.",
+  "recommended_action": "apply",
+  "scoring": {
+    "skills": {
+      "matched": ["TypeScript"],
+      "partial": ["React"],
+      "missing": [],
+      "score": 0.75
+    },
+    "experience": {
+      "years": 1,
+      "scope": 1,
+      "recency": 1,
+      "score": 1
+    },
+    "domain": {
+      "industry": 0.6,
+      "product_type": 0.7,
+      "scale": 0.7,
+      "score": 0.67
+    }
+  }
+}
+```
+
+`fit_score` is computed deterministically from the model's categorical judgments — not a hallucinated decimal. Scoring weights: skills 50%, experience 30%, domain 20%.
+
+`recommended_action` thresholds:
+- `apply` — score ≥ 0.80
+- `apply-with-tailoring` — score 0.60–0.79
+- `pass` — score < 0.60
+
+---
+
+## Candidate workflow (private MCP interface)
+
+Sunny interacts with the same knowledge base through Claude Desktop or Cursor — no browser, no app. See the [MCP config in README](../README.md#private-agentic-interface) for setup.
+
+Once connected, the 4 available tools are:
+
+| Tool | What it does |
+|---|---|
+| `capture_thought` | Save a note — plain text, metadata (type, topics, people, action items) extracted automatically |
+| `search_thoughts` | Semantic search by meaning — "find thoughts about accessibility work" |
+| `list_thoughts` | Chronological list with filters by type, topic, person, or date range |
+| `thought_stats` | Aggregate view — total count, distribution by type/topic/people |
+
+**Common workflows:**
+
+```
+"Capture this: had a good call with the DealerOn recruiter today, they're looking for a Vue lead, follow up Thursday"
+
+"Search for anything about testing or QA work I've shipped"
+
+"Am I a good fit for this role? [paste JD]"
+
+"Generate a resume for this staff engineer position at Stripe [paste JD]"
+```
+
+The last two trigger Claude to call `GET /info` and `POST /match` / `POST /resume` against the live API, using your captured context to enrich the response.
+
+---
+
+## What actually works today
+
+The A2A agent card spec is designed for a world where AI systems auto-discover and query agents. That world isn't fully here yet.
+
+| Scenario | Status | Notes |
+|---|---|---|
+| Claude Desktop with MCP | ✅ Works | Full private interface — capture, search, match, resume |
+| Claude.ai (Web) with WebFetch | ✅ Works | Can call endpoints directly if given the URL |
+| Cursor / AI coding assistants | ✅ Works | Via MCP or manual HTTP calls |
+| Custom employer AI agent | ✅ Works | If they're given the agent card URL to target |
+| Consumer phone AI apps (Gemini, ChatGPT) | ❌ No HTTP | These apps have no mechanism to make GET/POST requests |
+| A2A auto-discovery | ❌ Not yet | No mainstream consumer app supports `/.well-known/agent.json` discovery |
+| Fabricated responses | ⚠️ Common | Apps that can't call the API often hallucinate a plausible-sounding profile instead |
+
+**The practical gap:** Most consumer AI apps — the ones a recruiter might open on their phone — cannot make outbound HTTP requests. They'll either fail silently or invent a scenario ("this candidate would be...") rather than querying the real data. The conversational interview experience the agent card enables doesn't work in these contexts.
+
+**What actually reaches the agent:** Developer tools (Claude, Cursor), purpose-built ATS platforms, and anyone given the URL and a terminal.
+
+---
+
+## QR code workflow (practical alternative for in-person use)
+
+Since auto-discovery doesn't work in consumer apps, the fallback is manual but still useful:
+
+1. QR code → `https://agent.yuens.me/.well-known/agent.json`
+2. Scan surfaces the full agent card JSON
+3. Paste the card into any AI conversation as context
+4. Ask questions — the AI reasons over the structured profile without needing to call the API
+
+This works in any AI app that accepts pasted text, which is all of them. It's less elegant than auto-discovery but it's reliable today.
+
+The agent card is also human-readable enough that a recruiter can skim it directly and follow the `calendly` link to book time.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- Add `docs/workflow.md` — covers all three perspectives: employer AI/ATS, candidate (private MCP interface), and an honest accounting of what A2A auto-discovery does/doesn't support today
- Includes live curl examples with real response payloads from `agent.yuens.me`
- Documents the QR code manual workflow as the practical fallback for consumer AI apps
- Add Workflow section to README linking to the new doc

## Test plan
- [ ] `docs/workflow.md` renders correctly on GitHub (tables, code blocks)
- [ ] README Workflow section link resolves to the doc
- [ ] Curl examples in the doc work against `https://agent.yuens.me`