### PR TITLE
docs(workflow): genericize examples — remove personal names, write from user perspective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- 2026-03-28 — docs(workflow): genericize workflow doc — remove personal names/details from examples
 - 2026-03-28 — docs(workflow): add workflow doc covering employer AI, candidate MCP, and real-world A2A limitations
 - 2026-03-28 — feat(api): add IP-based rate limiting (30 req/min), fix README discrepancies, add ResumeResponse type
 - 2026-03-26 — feat(ob1): add Open Brain MCP server as Supabase Edge Function with thoughts table, pgvector search, and 4 MCP tools

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,6 +1,6 @@
 # How resume-agent works
 
-Three actors interact with this system: **employer AI systems** (or the humans who run them), **the candidate** (Sunny), and the **API** as the mediator between them. This document walks through each perspective — including what works today and what doesn't yet.
+Three actors interact with this system: **employer AI systems** (or the humans who run them), **the candidate** (whoever deployed this instance), and the **API** as the mediator between them. This document walks through each perspective — including what works today and what doesn't yet.
 
 ---
 
@@ -45,23 +45,23 @@ Content-Type: application/json
 Response:
 ```json
 {
-  "answer": "Yes, extensively. Sunny has shipped multiple production TypeScript systems across diverse domains: a full-stack Next.js application for LAX airport (2023), an open-source e-commerce platform (Artisan Roast, live at artisanroast.app with 118 API routes and 39 Prisma models), and a Resume Agent API (Node.js/Hono/TypeScript). TypeScript is listed as a core language skill and appears across all recent projects.",
+  "answer": "Yes, extensively. The candidate has shipped multiple production TypeScript systems across diverse domains: a full-stack Next.js application, an open-source e-commerce platform with 118 API routes, and this Resume Agent API (Node.js/Hono/TypeScript). TypeScript is listed as a core language skill and appears across all recent projects.",
   "confidence": "high",
   "sources": [
-    "employment.Wipro.bullets[1]",
+    "employment.Company A.bullets[1]",
     "employment.Self-Employed.bullets[1]",
-    "projects.Artisan Roast Platform.tech",
+    "projects.E-Commerce Platform.tech",
     "projects.Resume Agent.tech",
     "skills.Languages"
   ],
   "follow_up_suggestions": [
     "Ask about type safety practices or how TypeScript improved code quality in a specific project",
     "Inquire about experience with advanced TypeScript patterns (generics, utility types, discriminated unions)",
-    "Explore the scale of TypeScript systems shipped — Artisan Roast mentions 638 TypeScript files"
+    "Ask about the scale of TypeScript systems shipped — number of files, routes, or models"
   ],
   "contact": {
-    "email": "syuen@sbgrp.cc",
-    "calendly": "https://calendly.com/syuen-sbgrp/get_to_know_you"
+    "email": "candidate@example.com",
+    "calendly": "https://calendly.com/candidate/intro"
   },
   "meta": {
     "model": "claude-haiku-4-5-20251001",
@@ -89,7 +89,7 @@ Response:
   "fit_score": 0.81,
   "matched": ["TypeScript"],
   "gaps": ["React (partial)"],
-  "verdict": "Strong overall fit on experience and TypeScript, but React is secondary to Vue in this candidate's profile — present and used in multiple roles, though not the primary framework.",
+  "verdict": "Strong overall fit on experience and TypeScript, but React is secondary to Vue in the candidate's profile — present and used in multiple roles, though not the primary framework.",
   "recommended_action": "apply",
   "scoring": {
     "skills": {
@@ -125,7 +125,7 @@ Response:
 
 ## Candidate workflow (private MCP interface)
 
-Sunny interacts with the same knowledge base through Claude Desktop or Cursor — no browser, no app. See the [MCP config in README](../README.md#private-agentic-interface) for setup.
+You interact with your own knowledge base through Claude Desktop or Cursor — no browser, no app. See the [MCP config in README](../README.md#private-agentic-interface) for setup.
 
 Once connected, the 4 available tools are:
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -11,7 +11,7 @@ An AI system or recruiter tool can interact with the agent entirely through HTTP
 ### Step 1 — Discover the agent
 
 ```
-GET https://agent.yuens.me/.well-known/agent.json
+GET https://your-agent.example.com/.well-known/agent.json
 ```
 
 Returns an A2A-compliant agent card: name, capabilities, full endpoint catalog with schemas and examples, and contact info. Designed to be machine-parseable so AI systems can learn what to call and how.
@@ -19,13 +19,13 @@ Returns an A2A-compliant agent card: name, capabilities, full endpoint catalog w
 ### Step 2 — Read the profile
 
 ```
-GET https://agent.yuens.me/info
+GET https://your-agent.example.com/info
 ```
 
 Full structured snapshot: skills by category, employment history with bullets, education, projects, availability. No AI call — raw data, fast, cacheable. Good for ATS tools that want facts without NL processing.
 
 ```
-GET https://agent.yuens.me/availability
+GET https://your-agent.example.com/availability
 ```
 
 Current job-seeking status, preferred roles, remote preference, and contact links.
@@ -33,7 +33,7 @@ Current job-seeking status, preferred roles, remote preference, and contact link
 ### Step 3 — Ask a question
 
 ```
-POST https://agent.yuens.me/query
+POST https://your-agent.example.com/query
 Content-Type: application/json
 
 {
@@ -48,11 +48,11 @@ Response:
   "answer": "Yes, extensively. The candidate has shipped multiple production TypeScript systems across diverse domains: a full-stack Next.js application, an open-source e-commerce platform with 118 API routes, and this Resume Agent API (Node.js/Hono/TypeScript). TypeScript is listed as a core language skill and appears across all recent projects.",
   "confidence": "high",
   "sources": [
-    "employment.Company A.bullets[1]",
-    "employment.Self-Employed.bullets[1]",
-    "projects.E-Commerce Platform.tech",
-    "projects.Resume Agent.tech",
-    "skills.Languages"
+    "employment.company_a.bullets[1]",
+    "employment.self_employed.bullets[0]",
+    "projects.e_commerce_platform.tech",
+    "projects.resume_agent.tech",
+    "skills.languages"
   ],
   "follow_up_suggestions": [
     "Ask about type safety practices or how TypeScript improved code quality in a specific project",
@@ -75,7 +75,7 @@ The `context` field is optional and is treated as a free-form hint about who's a
 ### Step 4 — Score a job description
 
 ```
-POST https://agent.yuens.me/match
+POST https://your-agent.example.com/match
 Content-Type: application/json
 
 {
@@ -139,13 +139,13 @@ Once connected, the 4 available tools are:
 **Common workflows:**
 
 ```
-"Capture this: had a good call with the DealerOn recruiter today, they're looking for a Vue lead, follow up Thursday"
+"Capture this: had a good call with a recruiter today, they're looking for a Vue lead, follow up Thursday"
 
 "Search for anything about testing or QA work I've shipped"
 
 "Am I a good fit for this role? [paste JD]"
 
-"Generate a resume for this staff engineer position at Stripe [paste JD]"
+"Generate a resume for this staff engineer position [paste JD]"
 ```
 
 The last two trigger Claude to call `GET /info` and `POST /match` / `POST /resume` against the live API (including the required `Authorization: Bearer` header for `/resume`, or anonymously only when `AUTH_MODE=open`), using your captured context to enrich the response.
@@ -176,7 +176,7 @@ The A2A agent card spec is designed for a world where AI systems auto-discover a
 
 Since auto-discovery doesn't work in consumer apps, the fallback is manual but still useful:
 
-1. QR code → `https://agent.yuens.me/.well-known/agent.json`
+1. QR code → `https://your-agent.example.com/.well-known/agent.json`
 2. Scan surfaces the full agent card JSON
 3. Paste the card into any AI conversation as context
 4. Ask questions — the AI reasons over the structured profile without needing to call the API

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- Replace personal name references in example JSON responses with generic placeholders (`"the candidate"`, `"Company A"`, `"candidate@example.com"`, etc.)
- Reframe candidate workflow section from third-person (Sunny) to second-person (you)
- Doc now reads as a universal reference for anyone deploying their own instance

## Test plan
- [ ] `docs/workflow.md` renders correctly on GitHub
- [ ] No personal names visible in the rendered doc