### PR TITLE
fix(mcp): replace non-existent server-fetch with mcp-remote, add Windows config path note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- 2026-03-28 — fix(mcp): replace non-existent server-fetch package with mcp-remote, add Windows config path note
 - 2026-03-28 — docs(workflow): genericize workflow doc — remove personal names/details from examples
 - 2026-03-28 — docs(workflow): add workflow doc covering employer AI, candidate MCP, and real-world A2A limitations
 - 2026-03-28 — feat(api): add IP-based rate limiting (30 req/min), fix README discrepancies, add ResumeResponse type

--- a/README.md
+++ b/README.md
@@ -159,16 +159,21 @@ You interact with your own knowledge base through whichever AI tool you are alre
 ```json
 {
   "mcpServers": {
-    "resume-agent": {
+    "open-brain": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-fetch"],
-      "env": {
-        "MCP_URL": "https://YOUR_PROJECT_REF.supabase.co/functions/v1/open-brain-mcp?key=YOUR_KEY"
-      }
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://YOUR_PROJECT_REF.supabase.co/functions/v1/open-brain-mcp",
+        "--header",
+        "x-brain-key:YOUR_MCP_ACCESS_KEY"
+      ]
     }
   }
 }
 ```
+
+> On Windows, Claude Desktop is a packaged app — the config file is at `%LOCALAPPDATA%\Packages\Claude_*\LocalCache\Roaming\Claude\claude_desktop_config.json`, not the standard `%APPDATA%\Claude\` path.
 
 Then in Claude:
 > "Am I a good fit for this role? [paste JD]"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- Replaces `@modelcontextprotocol/server-fetch` (does not exist on npm) with `mcp-remote` in the README MCP config example
- Uses `--header` arg for auth key instead of query param (avoids key leaking in logs)
- Adds note about Windows packaged app config path (`%LOCALAPPDATA%\Packages\Claude_*\...` not `%APPDATA%\Claude\`)

## Test plan
- [ ] `npx -y mcp-remote <url> --header x-brain-key:<key>` starts without npm 404 error
- [ ] Claude Desktop connects and lists open-brain tools after restart
- [ ] `thought_stats` returns live DB counts in a new Claude Desktop conversation