### PR TITLE
docs(readme): clarify auth headers — /resume vs MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- 2026-03-29 — docs(readme): clarify auth headers — /resume uses Authorization Bearer, MCP uses x-brain-key
 - 2026-03-28 — fix(mcp): replace non-existent server-fetch package with mcp-remote, add Windows config path note
 - 2026-03-28 — docs(workflow): genericize workflow doc — remove personal names/details from examples
 - 2026-03-28 — docs(workflow): add workflow doc covering employer AI, candidate MCP, and real-world A2A limitations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- 2026-03-29 — docs(readme): clarify auth headers — /resume uses Authorization Bearer, MCP uses x-brain-key
+- 2026-03-29 — docs(readme): clarify auth headers — /resume uses `Authorization: Bearer <key>`, MCP uses x-brain-key
 - 2026-03-28 — fix(mcp): replace non-existent server-fetch package with mcp-remote, add Windows config path note
 - 2026-03-28 — docs(workflow): genericize workflow doc — remove personal names/details from examples
 - 2026-03-28 — docs(workflow): add workflow doc covering employer AI, candidate MCP, and real-world A2A limitations

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Then in Claude:
 
 - All secrets in `.env.local`, never committed
 - `public_profile` table: read-only, no auth required, rate-limited by IP
-- `/resume` endpoint: requires `Authorization: Bearer <key>` header
+- `/resume` endpoint: when `AUTH_MODE=key`, requires `Authorization: Bearer <key>` header; when `AUTH_MODE=open` (default in `.env.example`), it is publicly accessible
 - MCP server (OB1): requires `x-brain-key: <key>` header (passed via `--header` arg in `mcp-remote`)
 - Supabase service role key: server-side only, never returned to clients
 - Postgres Row Level Security enforces public/private table boundary

--- a/README.md
+++ b/README.md
@@ -201,7 +201,8 @@ Then in Claude:
 
 - All secrets in `.env.local`, never committed
 - `public_profile` table: read-only, no auth required, rate-limited by IP
-- Private endpoints (`/resume`, MCP): require `Authorization: Bearer` header
+- `/resume` endpoint: requires `Authorization: Bearer <key>` header
+- MCP server (OB1): requires `x-brain-key: <key>` header (passed via `--header` arg in `mcp-remote`)
 - Supabase service role key: server-side only, never returned to clients
 - Postgres Row Level Security enforces public/private table boundary
 - No personal data in this repo — data lives in your Supabase instance

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.1.12",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.1.12",
+      "version": "0.1.17",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.2.9",
         "@ai-sdk/google": "^1.2.16",
@@ -996,6 +996,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
       "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1379,6 +1380,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- Security model section previously conflated auth for `/resume` and MCP under a single `Authorization: Bearer` bullet
- Splits into two explicit lines: `/resume` uses `Authorization: Bearer`, MCP uses `x-brain-key` header
- Addresses Copilot inline comment from PR #17

## Test plan
- [ ] README security model section clearly distinguishes the two auth mechanisms
- [ ] No functional code changes