### PR TITLE
feat(mcp): port open-brain MCP to Railway with Auth Code + PKCE OAuth for claude.ai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- 2026-03-29 — feat(mcp): port open-brain MCP server to Railway with Auth Code + PKCE OAuth for claude.ai support
 - 2026-03-29 — feat(pipeline): add job hunt pipeline — 3 tables, 7 MCP tools, auto-scoring, integration tests
 - 2026-03-29 — docs(readme): clarify auth headers — /resume uses `Authorization: Bearer <key>`, MCP uses x-brain-key
 - 2026-03-28 — fix(mcp): replace non-existent server-fetch package with mcp-remote, add Windows config path note

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,24 @@
 {
   "name": "resume-agent",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.2.9",
         "@ai-sdk/google": "^1.2.16",
         "@ai-sdk/openai": "^1.3.19",
+        "@hono/mcp": "^0.1.1",
         "@hono/zod-validator": "^0.4.3",
+        "@modelcontextprotocol/sdk": "^1.12.0",
         "@supabase/supabase-js": "^2.49.1",
         "ai": "^4.3.15",
         "dotenv": "^17.3.1",
         "hono": "^4.7.5",
+        "jose": "^5.9.6",
         "zod": "^3.24.2"
       },
       "devDependencies": {
@@ -589,11 +592,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/@hono/mcp": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@hono/mcp/-/mcp-0.1.5.tgz",
+      "integrity": "sha512-q6Yurx9VUwVEpqnwVXtzIYaq4kgQgWWq9lYLM7NFS2W0sg1RzL+RdKh6jO4/dGyvBLKrahPd2v+NC6rr0XWBvQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "hono": ">=4.0.0"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.11",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
       "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -623,6 +635,56 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.28.0.tgz",
+      "integrity": "sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -744,6 +806,19 @@
         "@types/node": "*"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -780,6 +855,39 @@
         }
       }
     },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/bin-links": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-6.0.0.tgz",
@@ -795,6 +903,68 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/chalk": {
@@ -829,6 +999,77 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -843,7 +1084,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -855,6 +1095,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/dequal": {
@@ -882,6 +1131,65 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -926,6 +1234,126 @@
         "@esbuild/win32-x64": "0.27.4"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
@@ -950,6 +1378,27 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -961,6 +1410,24 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fsevents": {
@@ -978,6 +1445,52 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.13.7",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
@@ -991,6 +1504,42 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/hono": {
       "version": "4.12.9",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
@@ -999,6 +1548,26 @@
       "peer": true,
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -1024,11 +1593,84 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/jsondiffpatch": {
       "version": "0.6.0",
@@ -1045,6 +1687,61 @@
       },
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/minipass": {
@@ -1074,7 +1771,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -1093,6 +1789,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/node-domexception": {
@@ -1145,6 +1850,85 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/proc-log": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
@@ -1153,6 +1937,58 @@
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/react": {
@@ -1175,6 +2011,15 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -1185,11 +2030,177 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/secure-json-parse": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
       "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
@@ -1202,6 +2213,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/supabase": {
@@ -1266,6 +2286,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -1292,6 +2321,20 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1312,6 +2355,15 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -1319,6 +2371,15 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/web-streams-polyfill": {
@@ -1330,6 +2391,27 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/write-file-atomic": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "private": true,
   "type": "module",
   "engines": {
@@ -22,11 +22,14 @@
     "@ai-sdk/anthropic": "^1.2.9",
     "@ai-sdk/google": "^1.2.16",
     "@ai-sdk/openai": "^1.3.19",
+    "@hono/mcp": "^0.1.1",
     "@hono/zod-validator": "^0.4.3",
+    "@modelcontextprotocol/sdk": "^1.12.0",
     "@supabase/supabase-js": "^2.49.1",
     "ai": "^4.3.15",
     "dotenv": "^17.3.1",
     "hono": "^4.7.5",
+    "jose": "^5.9.6",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ import resumeRoute from './routes/resume.js'
 import agentCardRoute from './routes/agent-card.js'
 import profileRoute from './routes/profile.js'
 import projectsRoute from './routes/projects.js'
+import mcpRoute from './routes/mcp.js'
+import oauthRoute from './routes/oauth.js'
 
 const app = new Hono({ strict: false })
 
@@ -67,6 +69,8 @@ app.route('/resume', resumeRoute)
 app.route('/.well-known/agent.json', agentCardRoute)
 app.route('/profile', profileRoute)
 app.route('/projects', projectsRoute)
+app.route('/mcp', mcpRoute)
+app.route('/', oauthRoute)
 
 app.get('/', (c) => c.json({ status: 'ok', agent: 'resume-agent' }))
 

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -1,0 +1,765 @@
+import '../lib/env.js'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StreamableHTTPTransport } from '@hono/mcp'
+import { Hono } from 'hono'
+import { z } from 'zod'
+import { jwtVerify } from 'jose'
+import { supabase } from '../lib/supabase.js'
+
+const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY
+const MCP_ACCESS_KEY = process.env.MCP_ACCESS_KEY
+const JWT_SECRET = process.env.JWT_SECRET
+const jwtSecretBytes = JWT_SECRET ? new TextEncoder().encode(JWT_SECRET) : null
+
+if (!OPENROUTER_API_KEY) throw new Error('Missing OPENROUTER_API_KEY')
+if (!MCP_ACCESS_KEY) throw new Error('Missing MCP_ACCESS_KEY')
+
+const OPENROUTER_BASE = 'https://openrouter.ai/api/v1'
+
+// ── Helpers ───────────────────────────────────────────────
+
+async function getEmbedding(text: string): Promise<number[]> {
+  const r = await fetch(`${OPENROUTER_BASE}/embeddings`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${OPENROUTER_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ model: 'openai/text-embedding-3-small', input: text }),
+  })
+  if (!r.ok) {
+    const msg = await r.text().catch(() => '')
+    throw new Error(`OpenRouter embeddings failed: ${r.status} ${msg}`)
+  }
+  const d = await r.json()
+  return d.data[0].embedding
+}
+
+async function extractMetadata(text: string): Promise<Record<string, unknown>> {
+  const r = await fetch(`${OPENROUTER_BASE}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${OPENROUTER_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: 'openai/gpt-4o-mini',
+      response_format: { type: 'json_object' },
+      messages: [
+        {
+          role: 'system',
+          content: `Extract metadata from the user's captured thought. Return JSON with:
+- "people": array of people mentioned (empty if none)
+- "action_items": array of implied to-dos (empty if none)
+- "dates_mentioned": array of dates YYYY-MM-DD (empty if none)
+- "topics": array of 1-3 short topic tags (always at least one)
+- "type": one of "observation", "task", "idea", "reference", "person_note"
+Only extract what's explicitly there.`,
+        },
+        { role: 'user', content: text },
+      ],
+    }),
+  })
+  if (!r.ok) {
+    console.error(`OpenRouter metadata extraction failed: ${r.status}`)
+    return { topics: ['uncategorized'], type: 'observation' }
+  }
+  const d = await r.json()
+  try {
+    return JSON.parse(d.choices[0].message.content)
+  } catch {
+    return { topics: ['uncategorized'], type: 'observation' }
+  }
+}
+
+interface MatchScoreResult {
+  fit_score: number
+  match_verdict: string
+  match_scoring: Record<string, unknown>
+  recommended_action: string
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+async function scoreMatch(jobDescription: string): Promise<MatchScoreResult | null> {
+  try {
+    const { data: profile, error } = await supabase
+      .from('public_profile')
+      .select('*')
+      .eq('id', '00000000-0000-0000-0000-000000000001')
+      .single()
+
+    if (error || !profile) return null
+
+    const systemPrompt = `You are a precise job fit evaluator. Extract requirements from the job description and score the candidate profile against them using only the discrete values defined below.
+
+--- SCORING RUBRIC ---
+
+SKILLS
+For each skill explicitly marked as REQUIRED in the JD (ignore preferred/nice-to-have):
+- matched (1.0): directly present in candidate profile
+- partial (0.5): adjacent technology (e.g. Vue when React required, MySQL when Postgres required)
+- missing (0.0): absent from profile
+
+EXPERIENCE — score each sub-factor independently:
+- years:    meets or exceeds required (1.0) | 1-2 years short (0.7) | 3-4 years short (0.4) | significantly under (0.1)
+- scope:    IC/lead/manager alignment — exact match (1.0) | similar (0.7) | different (0.3)
+- recency:  relevant exp is current/last role (1.0) | within 3 yrs (0.7) | 3-5 yrs ago (0.4) | 5+ yrs ago (0.1)
+
+DOMAIN — score each sub-factor independently:
+- industry:      same industry (1.0) | adjacent (0.6) | different (0.3)
+- product_type:  same product category (1.0) | similar (0.7) | different (0.3)
+- scale:         company/product scale matches (1.0) | similar (0.7) | different (0.4)
+
+--- OUTPUT ---
+
+Respond ONLY with valid JSON. No prose, no markdown fences.
+
+{
+  "required_skills_extracted": ["skill1", "skill2"],
+  "skills": {
+    "matched": ["skill1"],
+    "partial": ["skill2"],
+    "missing": ["skill3"]
+  },
+  "experience": { "years": 0.7, "scope": 1.0, "recency": 1.0 },
+  "domain": { "industry": 0.6, "product_type": 1.0, "scale": 0.7 },
+  "verdict": "one sentence explaining the overall fit honestly"
+}`
+
+    const r = await fetch(`${OPENROUTER_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${OPENROUTER_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'anthropic/claude-sonnet-4-5',
+        max_tokens: 1024,
+        messages: [
+          { role: 'system', content: systemPrompt },
+          {
+            role: 'user',
+            content: `Candidate profile:\n${JSON.stringify(profile, null, 2)}\n\nJob description:\n${jobDescription}`,
+          },
+        ],
+      }),
+    })
+
+    if (!r.ok) return null
+
+    const d = await r.json()
+    const raw = d.choices[0].message.content as string
+    const json = raw.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim()
+    const scores = JSON.parse(json)
+
+    const total_required = (scores.required_skills_extracted as string[]).length || 1
+    const skills_score =
+      (scores.skills.matched.length * 1.0 + scores.skills.partial.length * 0.5) / total_required
+
+    const { years, scope, recency } = scores.experience
+    const exp_score = (years + scope + recency) / 3
+
+    const { industry, product_type, scale } = scores.domain
+    const domain_score = (industry + product_type + scale) / 3
+
+    const fit_score = round2(0.5 * skills_score + 0.3 * exp_score + 0.2 * domain_score)
+    const recommended_action =
+      fit_score >= 0.8 ? 'apply' : fit_score >= 0.6 ? 'apply-with-tailoring' : 'pass'
+
+    return {
+      fit_score,
+      match_verdict: scores.verdict,
+      match_scoring: {
+        skills: {
+          matched: scores.skills.matched,
+          partial: scores.skills.partial,
+          missing: scores.skills.missing,
+          score: round2(skills_score),
+        },
+        experience: { years, scope, recency, score: round2(exp_score) },
+        domain: { industry, product_type, scale, score: round2(domain_score) },
+      },
+      recommended_action,
+    }
+  } catch {
+    return null
+  }
+}
+
+// ── MCP Server ────────────────────────────────────────────
+
+function buildServer(): McpServer {
+  const server = new McpServer({ name: 'open-brain', version: '1.0.0' })
+
+  // ── Thoughts Tools ────────────────────────────────────────
+
+  server.registerTool(
+    'search_thoughts',
+    {
+      title: 'Search Thoughts',
+      description:
+        'Search captured thoughts by meaning. Use this when the user asks about a topic, person, or idea they\'ve previously captured.',
+      inputSchema: {
+        query: z.string().describe('What to search for'),
+        limit: z.number().int().min(1).max(100).optional().default(10),
+        threshold: z.number().min(0).max(1).optional().default(0.5),
+      },
+    },
+    async ({ query, limit, threshold }) => {
+      try {
+        const qEmb = await getEmbedding(query)
+        const { data, error } = await supabase.rpc('match_thoughts', {
+          query_embedding: qEmb,
+          match_threshold: threshold,
+          match_count: limit,
+          filter: {},
+        })
+
+        if (error) {
+          return { content: [{ type: 'text' as const, text: `Search error: ${error.message}` }], isError: true }
+        }
+        if (!data || data.length === 0) {
+          return { content: [{ type: 'text' as const, text: `No thoughts found matching "${query}".` }] }
+        }
+
+        const results = data.map(
+          (t: { content: string; metadata: Record<string, unknown>; similarity: number; created_at: string }, i: number) => {
+            const m = t.metadata || {}
+            const parts = [
+              `--- Result ${i + 1} (${(t.similarity * 100).toFixed(1)}% match) ---`,
+              `Captured: ${new Date(t.created_at).toLocaleDateString()}`,
+              `Type: ${m.type || 'unknown'}`,
+            ]
+            if (Array.isArray(m.topics) && m.topics.length) parts.push(`Topics: ${(m.topics as string[]).join(', ')}`)
+            if (Array.isArray(m.people) && m.people.length) parts.push(`People: ${(m.people as string[]).join(', ')}`)
+            if (Array.isArray(m.action_items) && m.action_items.length) parts.push(`Actions: ${(m.action_items as string[]).join('; ')}`)
+            parts.push(`\n${t.content}`)
+            return parts.join('\n')
+          }
+        )
+
+        return { content: [{ type: 'text' as const, text: `Found ${data.length} thought(s):\n\n${results.join('\n\n')}` }] }
+      } catch (err: unknown) {
+        return { content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }], isError: true }
+      }
+    }
+  )
+
+  server.registerTool(
+    'list_thoughts',
+    {
+      title: 'List Recent Thoughts',
+      description: 'List recently captured thoughts with optional filters by type, topic, person, or time range.',
+      inputSchema: {
+        limit: z.number().int().min(1).max(100).optional().default(10),
+        type: z.string().optional().describe('Filter by type: observation, task, idea, reference, person_note'),
+        topic: z.string().optional().describe('Filter by topic tag'),
+        person: z.string().optional().describe('Filter by person mentioned'),
+        days: z.number().int().min(1).max(365).optional().describe('Only thoughts from the last N days'),
+      },
+    },
+    async ({ limit, type, topic, person, days }) => {
+      try {
+        const effectiveLimit = Math.min(limit ?? 10, 100)
+        const effectiveDays = days != null ? Math.min(days, 365) : undefined
+
+        let q = supabase
+          .from('thoughts')
+          .select('content, metadata, created_at')
+          .order('created_at', { ascending: false })
+          .limit(effectiveLimit)
+
+        if (type) q = q.contains('metadata', { type })
+        if (topic) q = q.contains('metadata', { topics: [topic] })
+        if (person) q = q.contains('metadata', { people: [person] })
+        if (effectiveDays != null) {
+          const since = new Date()
+          since.setDate(since.getDate() - effectiveDays)
+          q = q.gte('created_at', since.toISOString())
+        }
+
+        const { data, error } = await q
+
+        if (error) return { content: [{ type: 'text' as const, text: `Error: ${error.message}` }], isError: true }
+        if (!data || !data.length) return { content: [{ type: 'text' as const, text: 'No thoughts found.' }] }
+
+        const results = data.map((t: { content: string; metadata: Record<string, unknown>; created_at: string }, i: number) => {
+          const m = t.metadata || {}
+          const tags = Array.isArray(m.topics) ? (m.topics as string[]).join(', ') : ''
+          return `${i + 1}. [${new Date(t.created_at).toLocaleDateString()}] (${m.type || '??'}${tags ? ' - ' + tags : ''})\n   ${t.content}`
+        })
+
+        return { content: [{ type: 'text' as const, text: `${data.length} recent thought(s):\n\n${results.join('\n\n')}` }] }
+      } catch (err: unknown) {
+        return { content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }], isError: true }
+      }
+    }
+  )
+
+  server.registerTool(
+    'thought_stats',
+    {
+      title: 'Thought Statistics',
+      description: 'Get a summary of all captured thoughts: totals, types, top topics, and people.',
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const { count, error: countError } = await supabase.from('thoughts').select('*', { count: 'exact', head: true })
+        if (countError) return { content: [{ type: 'text' as const, text: `Error: ${countError.message}` }], isError: true }
+
+        const { data, error: dataError } = await supabase
+          .from('thoughts')
+          .select('metadata, created_at')
+          .order('created_at', { ascending: false })
+
+        if (dataError) return { content: [{ type: 'text' as const, text: `Error: ${dataError.message}` }], isError: true }
+
+        const types: Record<string, number> = {}
+        const topics: Record<string, number> = {}
+        const people: Record<string, number> = {}
+
+        for (const r of data || []) {
+          const m = (r.metadata || {}) as Record<string, unknown>
+          if (m.type) types[m.type as string] = (types[m.type as string] || 0) + 1
+          if (Array.isArray(m.topics)) for (const t of m.topics) topics[t as string] = (topics[t as string] || 0) + 1
+          if (Array.isArray(m.people)) for (const p of m.people) people[p as string] = (people[p as string] || 0) + 1
+        }
+
+        const sort = (o: Record<string, number>): [string, number][] =>
+          Object.entries(o).sort((a, b) => b[1] - a[1]).slice(0, 10)
+
+        const lines: string[] = [
+          `Total thoughts: ${count}`,
+          `Date range: ${data?.length
+            ? new Date(data[data.length - 1].created_at).toLocaleDateString() + ' → ' + new Date(data[0].created_at).toLocaleDateString()
+            : 'N/A'}`,
+          '',
+          'Types:',
+          ...sort(types).map(([k, v]) => `  ${k}: ${v}`),
+        ]
+
+        if (Object.keys(topics).length) {
+          lines.push('', 'Top topics:')
+          for (const [k, v] of sort(topics)) lines.push(`  ${k}: ${v}`)
+        }
+        if (Object.keys(people).length) {
+          lines.push('', 'People mentioned:')
+          for (const [k, v] of sort(people)) lines.push(`  ${k}: ${v}`)
+        }
+
+        return { content: [{ type: 'text' as const, text: lines.join('\n') }] }
+      } catch (err: unknown) {
+        return { content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }], isError: true }
+      }
+    }
+  )
+
+  server.registerTool(
+    'capture_thought',
+    {
+      title: 'Capture Thought',
+      description:
+        'Save a new thought to the Open Brain. Generates an embedding and extracts metadata automatically. Use this when the user wants to save something to their brain — notes, insights, decisions, or observations.',
+      inputSchema: {
+        content: z.string().describe('The thought to capture — a clear, standalone statement that will make sense when retrieved later'),
+      },
+    },
+    async ({ content }) => {
+      try {
+        const [embedding, metadata] = await Promise.all([getEmbedding(content), extractMetadata(content)])
+
+        const { error } = await supabase.from('thoughts').insert({
+          content,
+          embedding,
+          metadata: { ...metadata, source: 'mcp' },
+        })
+
+        if (error) return { content: [{ type: 'text' as const, text: `Failed to capture: ${error.message}` }], isError: true }
+
+        const meta = metadata as Record<string, unknown>
+        let confirmation = `Captured as ${meta.type || 'thought'}`
+        if (Array.isArray(meta.topics) && meta.topics.length) confirmation += ` — ${(meta.topics as string[]).join(', ')}`
+        if (Array.isArray(meta.people) && meta.people.length) confirmation += ` | People: ${(meta.people as string[]).join(', ')}`
+        if (Array.isArray(meta.action_items) && meta.action_items.length) confirmation += ` | Actions: ${(meta.action_items as string[]).join('; ')}`
+
+        return { content: [{ type: 'text' as const, text: confirmation }] }
+      } catch (err: unknown) {
+        return { content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }], isError: true }
+      }
+    }
+  )
+
+  // ── Pipeline Tools ────────────────────────────────────────
+
+  const STAGES = ['applied', 'phone_screen', 'technical', 'final', 'offer', 'rejected', 'withdrawn'] as const
+
+  server.registerTool(
+    'log_application',
+    {
+      title: 'Log Job Application',
+      description:
+        'Log a new job application. If a job description is provided, automatically scores fit against the candidate profile.',
+      inputSchema: {
+        company: z.string().describe('Company name'),
+        role: z.string().describe('Job title / role name'),
+        job_description: z.string().optional().describe('Full JD text — used to auto-score fit'),
+        source: z.string().optional().describe('Where you found it: LinkedIn, referral, cold, etc.'),
+        url: z.string().optional().describe('Job posting URL'),
+        applied_at: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().describe('Date applied if not today, e.g. 2026-03-25'),
+        notes: z.string().optional().describe('Any initial notes about the role or company'),
+      },
+    },
+    async ({ company, role, job_description, source, url, applied_at, notes }) => {
+      try {
+        let scoreResult: MatchScoreResult | null = null
+        if (job_description) scoreResult = await scoreMatch(job_description)
+
+        const { data, error } = await supabase
+          .from('job_applications')
+          .insert({
+            company, role, job_description, source, url, notes,
+            applied_at: applied_at ? new Date(applied_at).toISOString() : undefined,
+            ...(scoreResult && {
+              fit_score: scoreResult.fit_score,
+              match_verdict: scoreResult.match_verdict,
+              match_scoring: scoreResult.match_scoring,
+              recommended_action: scoreResult.recommended_action,
+            }),
+          })
+          .select('id')
+          .single()
+
+        if (error || !data) {
+          return { content: [{ type: 'text' as const, text: `Failed to log application: ${error?.message}` }], isError: true }
+        }
+
+        const { error: stageError } = await supabase.from('application_stages').insert({
+          application_id: data.id,
+          stage: 'applied',
+          note: 'Application logged',
+        })
+
+        if (stageError) {
+          await supabase.from('job_applications').delete().eq('id', data.id)
+          return { content: [{ type: 'text' as const, text: `Failed to log stage history: ${stageError.message}` }], isError: true }
+        }
+
+        const fitLine = scoreResult
+          ? `Fit: ${scoreResult.fit_score} (${scoreResult.recommended_action})`
+          : 'Fit: not scored (no JD provided)'
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: [`Application logged: ${company} — ${role}`, `Stage: applied | ${fitLine}`, scoreResult ? `Verdict: ${scoreResult.match_verdict}` : '', `ID: ${data.id}`].filter(Boolean).join('\n'),
+          }],
+        }
+      } catch (err: unknown) {
+        return { content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }], isError: true }
+      }
+    }
+  )
+
+  server.registerTool(
+    'update_stage',
+    {
+      title: 'Update Application Stage',
+      description: 'Move a job application to a new stage and record it in the history.',
+      inputSchema: {
+        application_id: z.string().uuid().describe('The application ID'),
+        stage: z.enum(STAGES).describe('New stage'),
+        note: z.string().optional().describe('Optional note about this transition'),
+      },
+    },
+    async ({ application_id, stage, note }) => {
+      try {
+        const { data: app, error: fetchErr } = await supabase
+          .from('job_applications').select('company, role, stage').eq('id', application_id).single()
+
+        if (fetchErr || !app) {
+          return { content: [{ type: 'text' as const, text: `Application not found: ${application_id}` }], isError: true }
+        }
+
+        const { error: updateErr } = await supabase.from('job_applications').update({ stage }).eq('id', application_id)
+        if (updateErr) return { content: [{ type: 'text' as const, text: `Failed to update stage: ${updateErr.message}` }], isError: true }
+
+        const { error: insertErr } = await supabase.from('application_stages').insert({ application_id, stage, note: note ?? null })
+        if (insertErr) {
+          await supabase.from('job_applications').update({ stage: app.stage }).eq('id', application_id)
+          return { content: [{ type: 'text' as const, text: `Failed to record stage history: ${insertErr.message}; stage change rolled back.` }], isError: true }
+        }
+
+        return { content: [{ type: 'text' as const, text: `${app.company} — ${app.role}: ${app.stage} → ${stage}${note ? `\nNote: ${note}` : ''}` }] }
+      } catch (err: unknown) {
+        return { content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }], isError: true }
+      }
+    }
+  )
+
+  server.registerTool(
+    'add_contact',
+    {
+      title: 'Add Contact',
+      description: 'Add a recruiter, hiring manager, or other contact to a job application.',
+      inputSchema: {
+        application_id: z.string().uuid().describe('The application ID'),
+        name: z.string().describe("Contact's full name"),
+        title: z.string().optional().describe('Their job title'),
+        linkedin: z.string().optional().describe('LinkedIn profile URL'),
+        email: z.string().optional().describe('Email address'),
+        notes: z.string().optional().describe('Any notes about this contact'),
+      },
+    },
+    async ({ application_id, name, title, linkedin, email, notes }) => {
+      try {
+        const { data, error } = await supabase
+          .from('job_contacts')
+          .insert({ application_id, name, title, linkedin, email, notes })
+          .select('id')
+          .single()
+
+        if (error || !data) {
+          return { content: [{ type: 'text' as const, text: `Failed to add contact: ${error?.message}` }], isError: true }
+        }
+
+        return { content: [{ type: 'text' as const, text: `Contact added: ${name}${title ? ` (${title})` : ''} | ID: ${data.id}` }] }
+      } catch (err: unknown) {
+        return { content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }], isError: true }
+      }
+    }
+  )
+
+  server.registerTool(
+    'list_applications',
+    {
+      title: 'List Applications',
+      description: "List job applications with optional filters. Use for 'where am I with everything', 'show active applications', 'what needs a follow-up'.",
+      inputSchema: {
+        stage: z.enum(STAGES).optional().describe('Filter by stage'),
+        company: z.string().optional().describe('Filter by company name (partial match)'),
+        limit: z.number().int().min(1).max(100).optional().default(20),
+        days: z.number().int().min(1).optional().describe('Only applications from the last N days'),
+        upcoming_followups: z.boolean().optional().describe('Only applications with a follow-up date in the next 7 days'),
+      },
+    },
+    async ({ stage, company, limit, days, upcoming_followups }) => {
+      try {
+        let q = supabase
+          .from('job_applications')
+          .select('id, company, role, stage, fit_score, recommended_action, follow_up_date, applied_at, notes')
+          .order('applied_at', { ascending: false })
+          .limit(limit ?? 20)
+
+        if (stage) q = q.eq('stage', stage)
+        if (company) q = q.ilike('company', `%${company}%`)
+        if (days != null) {
+          const since = new Date()
+          since.setDate(since.getDate() - days)
+          q = q.gte('applied_at', since.toISOString())
+        }
+        if (upcoming_followups) {
+          const today = new Date().toISOString().slice(0, 10)
+          const in7 = new Date(Date.now() + 7 * 86400_000).toISOString().slice(0, 10)
+          q = q.gte('follow_up_date', today).lte('follow_up_date', in7)
+        }
+
+        const { data, error } = await q
+        if (error) return { content: [{ type: 'text' as const, text: `Error: ${error.message}` }], isError: true }
+        if (!data || !data.length) return { content: [{ type: 'text' as const, text: 'No applications found.' }] }
+
+        const rows = data.map((a: { id: string; company: string; role: string; stage: string; fit_score: number | null; follow_up_date: string | null; applied_at: string; notes: string | null }) => {
+          const date = new Date(a.applied_at).toLocaleDateString()
+          const fit = a.fit_score != null ? ` | fit: ${a.fit_score}` : ''
+          const followup = a.follow_up_date ? ` | follow-up: ${a.follow_up_date}` : ''
+          return `• [${date}] ${a.company} — ${a.role} | ${a.stage}${fit}${followup}${a.notes ? `\n  ${a.notes}` : ''}\n  ID: ${a.id}`
+        })
+
+        return { content: [{ type: 'text' as const, text: `${data.length} application(s):\n\n${rows.join('\n\n')}` }] }
+      } catch (err: unknown) {
+        return { content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }], isError: true }
+      }
+    }
+  )
+
+  server.registerTool(
+    'get_application',
+    {
+      title: 'Get Application Details',
+      description: 'Get the full details of a specific job application including contacts and stage history.',
+      inputSchema: {
+        application_id: z.string().uuid().describe('The application ID'),
+      },
+    },
+    async ({ application_id }) => {
+      try {
+        const [appRes, contactsRes, stagesRes] = await Promise.all([
+          supabase.from('job_applications').select('*').eq('id', application_id).single(),
+          supabase.from('job_contacts').select('name, title, linkedin, email, notes, created_at').eq('application_id', application_id).order('created_at'),
+          supabase.from('application_stages').select('stage, note, occurred_at').eq('application_id', application_id).order('occurred_at'),
+        ])
+
+        if (appRes.error || !appRes.data) {
+          return { content: [{ type: 'text' as const, text: `Application not found: ${application_id}` }], isError: true }
+        }
+
+        const a = appRes.data
+        const lines: string[] = [
+          `${a.company} — ${a.role}`,
+          `Stage: ${a.stage} | Applied: ${new Date(a.applied_at).toLocaleDateString()}`,
+        ]
+
+        if (a.fit_score != null) {
+          lines.push(`Fit score: ${a.fit_score} | Action: ${a.recommended_action}`, `Verdict: ${a.match_verdict}`)
+        }
+        if (a.source) lines.push(`Source: ${a.source}`)
+        if (a.url) lines.push(`URL: ${a.url}`)
+        if (a.follow_up_date) lines.push(`Follow-up: ${a.follow_up_date}`)
+        if (a.notes) lines.push(`Notes: ${a.notes}`)
+
+        if (contactsRes.data?.length) {
+          lines.push('', 'Contacts:')
+          for (const contact of contactsRes.data) {
+            lines.push(`  • ${contact.name}${contact.title ? ` (${contact.title})` : ''}${contact.email ? ` — ${contact.email}` : ''}${contact.linkedin ? ` | ${contact.linkedin}` : ''}${contact.notes ? `\n    ${contact.notes}` : ''}`)
+          }
+        }
+
+        if (stagesRes.data?.length) {
+          lines.push('', 'Stage history:')
+          for (const s of stagesRes.data) {
+            lines.push(`  ${new Date(s.occurred_at).toLocaleDateString()} → ${s.stage}${s.note ? `: ${s.note}` : ''}`)
+          }
+        }
+
+        return { content: [{ type: 'text' as const, text: lines.join('\n') }] }
+      } catch (err: unknown) {
+        return { content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }], isError: true }
+      }
+    }
+  )
+
+  server.registerTool(
+    'set_follow_up',
+    {
+      title: 'Set Follow-up Date',
+      description: "Set or update a follow-up date on a job application. Use when the user says 'follow up Thursday' or 'remind me next week'.",
+      inputSchema: {
+        application_id: z.string().uuid().describe('The application ID'),
+        follow_up_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).describe('Date in YYYY-MM-DD format'),
+        notes: z.string().optional().describe('What to follow up on'),
+      },
+    },
+    async ({ application_id, follow_up_date, notes }) => {
+      try {
+        const { data: app, error: fetchErr } = await supabase
+          .from('job_applications').select('company, role').eq('id', application_id).single()
+
+        if (fetchErr || !app) {
+          return { content: [{ type: 'text' as const, text: `Application not found: ${application_id}` }], isError: true }
+        }
+
+        const update: Record<string, unknown> = { follow_up_date }
+        if (notes) update.notes = notes
+
+        const { error } = await supabase.from('job_applications').update(update).eq('id', application_id)
+        if (error) return { content: [{ type: 'text' as const, text: `Failed to set follow-up: ${error.message}` }], isError: true }
+
+        return { content: [{ type: 'text' as const, text: `Follow-up set: ${app.company} — ${app.role} on ${follow_up_date}${notes ? `\nNote: ${notes}` : ''}` }] }
+      } catch (err: unknown) {
+        return { content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }], isError: true }
+      }
+    }
+  )
+
+  server.registerTool(
+    'search_applications',
+    {
+      title: 'Search Applications',
+      description: 'Search job applications by free text across company name, role, job description, and notes.',
+      inputSchema: {
+        query: z.string().describe('Search term — matches against company, role, job description, and notes'),
+        limit: z.number().int().min(1).max(50).optional().default(10),
+      },
+    },
+    async ({ query, limit }) => {
+      try {
+        const sanitizedQuery = query.replace(/[%'"(),]/g, ' ').trim()
+        const { data, error } = await supabase
+          .from('job_applications')
+          .select('id, company, role, stage, fit_score, applied_at')
+          .or(`company.ilike.%${sanitizedQuery}%,role.ilike.%${sanitizedQuery}%,job_description.ilike.%${sanitizedQuery}%,notes.ilike.%${sanitizedQuery}%`)
+          .order('applied_at', { ascending: false })
+          .limit(limit ?? 10)
+
+        if (error) return { content: [{ type: 'text' as const, text: `Error: ${error.message}` }], isError: true }
+        if (!data || !data.length) return { content: [{ type: 'text' as const, text: `No applications found matching "${query}".` }] }
+
+        const rows = data.map((a: { id: string; company: string; role: string; stage: string; fit_score: number | null; applied_at: string }) =>
+          `• ${a.company} — ${a.role} | ${a.stage}${a.fit_score != null ? ` | fit: ${a.fit_score}` : ''} | ${new Date(a.applied_at).toLocaleDateString()}\n  ID: ${a.id}`
+        )
+
+        return { content: [{ type: 'text' as const, text: `${data.length} result(s) for "${query}":\n\n${rows.join('\n\n')}` }] }
+      } catch (err: unknown) {
+        return { content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }], isError: true }
+      }
+    }
+  )
+
+  return server
+}
+
+// ── Hono App ──────────────────────────────────────────────
+
+const mcpRoute = new Hono()
+
+mcpRoute.options('*', (c) => c.text('ok', 200, {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, content-type, x-brain-key, accept, mcp-session-id',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, DELETE',
+}))
+
+mcpRoute.all('*', async (c) => {
+  const corsHeaders = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'authorization, content-type, x-brain-key, accept, mcp-session-id',
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, DELETE',
+  }
+
+  // Auth: x-brain-key (Claude Desktop) OR Authorization: Bearer <jwt> (claude.ai)
+  const brainKey = c.req.header('x-brain-key') ?? new URL(c.req.url).searchParams.get('key')
+  const authHeader = c.req.header('authorization') ?? ''
+  const bearerToken = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null
+
+  let authenticated = false
+
+  if (brainKey && brainKey === MCP_ACCESS_KEY) {
+    authenticated = true
+  } else if (bearerToken && jwtSecretBytes) {
+    try {
+      await jwtVerify(bearerToken, jwtSecretBytes, { algorithms: ['HS256'] })
+      authenticated = true
+    } catch {
+      // fall through
+    }
+  }
+
+  if (!authenticated) {
+    return c.json({ error: 'Invalid or missing credentials' }, 401, corsHeaders)
+  }
+
+  const server = buildServer()
+  const transport = new StreamableHTTPTransport()
+  await server.connect(transport)
+
+  const response = await transport.handleRequest(c)
+  if (!response) return c.json({ error: 'No response from MCP transport' }, 500, corsHeaders)
+  for (const [key, value] of Object.entries(corsHeaders)) {
+    response.headers.set(key, value)
+  }
+  return response
+})
+
+export default mcpRoute

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -711,6 +711,9 @@ function buildServer(): McpServer {
   return server
 }
 
+// Single server instance — tools registered once at startup
+const mcpServer = buildServer()
+
 // ── Hono App ──────────────────────────────────────────────
 
 const mcpRoute = new Hono()
@@ -728,8 +731,8 @@ mcpRoute.all('*', async (c) => {
     'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, DELETE',
   }
 
-  // Auth: x-brain-key (Claude Desktop) OR Authorization: Bearer <jwt> (claude.ai)
-  const brainKey = c.req.header('x-brain-key') ?? new URL(c.req.url).searchParams.get('key')
+  // Auth: x-brain-key header (Claude Desktop) OR Authorization: Bearer <jwt> (claude.ai)
+  const brainKey = c.req.header('x-brain-key')
   const authHeader = c.req.header('authorization') ?? ''
   const bearerToken = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null
 
@@ -750,9 +753,8 @@ mcpRoute.all('*', async (c) => {
     return c.json({ error: 'Invalid or missing credentials' }, 401, corsHeaders)
   }
 
-  const server = buildServer()
   const transport = new StreamableHTTPTransport()
-  await server.connect(transport)
+  await mcpServer.connect(transport)
 
   const response = await transport.handleRequest(c)
   if (!response) return c.json({ error: 'No response from MCP transport' }, 500, corsHeaders)

--- a/src/routes/oauth.ts
+++ b/src/routes/oauth.ts
@@ -1,0 +1,130 @@
+import '../lib/env.js'
+import { Hono } from 'hono'
+import { SignJWT } from 'jose'
+import crypto from 'crypto'
+
+const JWT_SECRET = process.env.JWT_SECRET
+if (!JWT_SECRET) throw new Error('Missing JWT_SECRET')
+const jwtSecretBytes = new TextEncoder().encode(JWT_SECRET)
+
+const ALLOWED_REDIRECT_URIS = new Set([
+  'https://claude.ai/api/mcp/auth_callback',
+])
+
+// In-memory auth code store (5-min TTL, one-time use)
+const authCodes = new Map<string, {
+  code_challenge: string
+  client_id: string
+  expires_at: number
+}>()
+
+setInterval(() => {
+  const now = Date.now()
+  for (const [code, data] of authCodes) {
+    if (now > data.expires_at) authCodes.delete(code)
+  }
+}, 60_000)
+
+const oauth = new Hono()
+
+oauth.get('/.well-known/oauth-authorization-server', (c) => {
+  const base = process.env.PUBLIC_URL ?? 'https://agent.yuens.me'
+  return c.json({
+    issuer: base,
+    authorization_endpoint: `${base}/authorize`,
+    token_endpoint: `${base}/token`,
+    response_types_supported: ['code'],
+    grant_types_supported: ['authorization_code'],
+    code_challenge_methods_supported: ['S256'],
+    token_endpoint_auth_methods_supported: ['none'],
+  })
+})
+
+oauth.get('/authorize', (c) => {
+  const { response_type, client_id, redirect_uri, state, code_challenge, code_challenge_method } = c.req.query()
+
+  if (response_type !== 'code') {
+    return c.json({ error: 'unsupported_response_type' }, 400)
+  }
+  if (!client_id) {
+    return c.json({ error: 'invalid_request', error_description: 'client_id required' }, 400)
+  }
+  if (!redirect_uri || !ALLOWED_REDIRECT_URIS.has(redirect_uri)) {
+    return c.json({ error: 'invalid_request', error_description: 'redirect_uri not allowed' }, 400)
+  }
+  if (!code_challenge || code_challenge_method !== 'S256') {
+    return c.json({ error: 'invalid_request', error_description: 'PKCE with S256 required' }, 400)
+  }
+
+  const code = crypto.randomBytes(32).toString('hex')
+  authCodes.set(code, {
+    code_challenge,
+    client_id,
+    expires_at: Date.now() + 5 * 60_000,
+  })
+
+  const callbackUrl = new URL(redirect_uri)
+  callbackUrl.searchParams.set('code', code)
+  if (state) callbackUrl.searchParams.set('state', state)
+
+  return c.redirect(callbackUrl.toString(), 302)
+})
+
+oauth.post('/token', async (c) => {
+  const contentType = c.req.header('content-type') ?? ''
+  let grant_type: string | undefined
+  let code: string | undefined
+  let code_verifier: string | undefined
+  let client_id: string | undefined
+
+  if (contentType.includes('application/x-www-form-urlencoded')) {
+    const body = await c.req.formData()
+    grant_type = body.get('grant_type')?.toString()
+    code = body.get('code')?.toString()
+    code_verifier = body.get('code_verifier')?.toString()
+    client_id = body.get('client_id')?.toString()
+  } else {
+    const body = await c.req.json().catch(() => ({}))
+    grant_type = body.grant_type
+    code = body.code
+    code_verifier = body.code_verifier
+    client_id = body.client_id
+  }
+
+  if (grant_type !== 'authorization_code') {
+    return c.json({ error: 'unsupported_grant_type' }, 400)
+  }
+  if (!code || !code_verifier || !client_id) {
+    return c.json({ error: 'invalid_request', error_description: 'code, code_verifier, and client_id required' }, 400)
+  }
+
+  const stored = authCodes.get(code)
+  if (!stored || Date.now() > stored.expires_at || stored.client_id !== client_id) {
+    return c.json({ error: 'invalid_grant' }, 400)
+  }
+
+  // Verify PKCE: SHA-256(code_verifier) base64url === code_challenge
+  const digest = crypto.createHash('sha256').update(code_verifier).digest('base64url')
+  if (digest !== stored.code_challenge) {
+    return c.json({ error: 'invalid_grant', error_description: 'PKCE verification failed' }, 400)
+  }
+
+  authCodes.delete(code)
+
+  const now = Math.floor(Date.now() / 1000)
+  const expiresIn = 3600
+
+  const access_token = await new SignJWT({ sub: client_id })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt(now)
+    .setExpirationTime(now + expiresIn)
+    .sign(jwtSecretBytes)
+
+  return c.json(
+    { access_token, token_type: 'Bearer', expires_in: expiresIn },
+    200,
+    { 'Cache-Control': 'no-store', Pragma: 'no-cache' }
+  )
+})
+
+export default oauth

--- a/src/routes/oauth.ts
+++ b/src/routes/oauth.ts
@@ -7,23 +7,32 @@ const JWT_SECRET = process.env.JWT_SECRET
 if (!JWT_SECRET) throw new Error('Missing JWT_SECRET')
 const jwtSecretBytes = new TextEncoder().encode(JWT_SECRET)
 
+// Allowlist of permitted client IDs — set OAUTH_CLIENT_ID env var (comma-separated for multiple)
+const ALLOWED_CLIENT_IDS = new Set(
+  (process.env.OAUTH_CLIENT_ID ?? 'claude-ai-connector').split(',').map((s) => s.trim()).filter(Boolean)
+)
+
 const ALLOWED_REDIRECT_URIS = new Set([
   'https://claude.ai/api/mcp/auth_callback',
 ])
 
 // In-memory auth code store (5-min TTL, one-time use)
+// Note: single-instance Railway deployment — in-memory is sufficient. For multi-instance,
+// migrate to a shared store (Redis/Supabase table) or use self-contained signed tokens.
 const authCodes = new Map<string, {
   code_challenge: string
+  redirect_uri: string
   client_id: string
   expires_at: number
 }>()
 
-setInterval(() => {
+const cleanupInterval = setInterval(() => {
   const now = Date.now()
   for (const [code, data] of authCodes) {
     if (now > data.expires_at) authCodes.delete(code)
   }
 }, 60_000)
+cleanupInterval.unref()
 
 const oauth = new Hono()
 
@@ -46,8 +55,8 @@ oauth.get('/authorize', (c) => {
   if (response_type !== 'code') {
     return c.json({ error: 'unsupported_response_type' }, 400)
   }
-  if (!client_id) {
-    return c.json({ error: 'invalid_request', error_description: 'client_id required' }, 400)
+  if (!client_id || !ALLOWED_CLIENT_IDS.has(client_id)) {
+    return c.json({ error: 'unauthorized_client', error_description: 'client_id not registered' }, 400)
   }
   if (!redirect_uri || !ALLOWED_REDIRECT_URIS.has(redirect_uri)) {
     return c.json({ error: 'invalid_request', error_description: 'redirect_uri not allowed' }, 400)
@@ -59,6 +68,7 @@ oauth.get('/authorize', (c) => {
   const code = crypto.randomBytes(32).toString('hex')
   authCodes.set(code, {
     code_challenge,
+    redirect_uri,
     client_id,
     expires_at: Date.now() + 5 * 60_000,
   })
@@ -76,6 +86,7 @@ oauth.post('/token', async (c) => {
   let code: string | undefined
   let code_verifier: string | undefined
   let client_id: string | undefined
+  let redirect_uri: string | undefined
 
   if (contentType.includes('application/x-www-form-urlencoded')) {
     const body = await c.req.formData()
@@ -83,12 +94,14 @@ oauth.post('/token', async (c) => {
     code = body.get('code')?.toString()
     code_verifier = body.get('code_verifier')?.toString()
     client_id = body.get('client_id')?.toString()
+    redirect_uri = body.get('redirect_uri')?.toString()
   } else {
     const body = await c.req.json().catch(() => ({}))
     grant_type = body.grant_type
     code = body.code
     code_verifier = body.code_verifier
     client_id = body.client_id
+    redirect_uri = body.redirect_uri
   }
 
   if (grant_type !== 'authorization_code') {
@@ -101,6 +114,11 @@ oauth.post('/token', async (c) => {
   const stored = authCodes.get(code)
   if (!stored || Date.now() > stored.expires_at || stored.client_id !== client_id) {
     return c.json({ error: 'invalid_grant' }, 400)
+  }
+
+  // Verify redirect_uri matches the one used at /authorize (RFC 6749 §4.1.3)
+  if (redirect_uri && redirect_uri !== stored.redirect_uri) {
+    return c.json({ error: 'invalid_grant', error_description: 'redirect_uri mismatch' }, 400)
   }
 
   // Verify PKCE: SHA-256(code_verifier) base64url === code_challenge

--- a/supabase/functions/oauth-token/deno.json
+++ b/supabase/functions/oauth-token/deno.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "hono": "npm:hono@4.9.2",
+    "jose": "npm:jose@5.9.6"
+  }
+}

--- a/supabase/functions/oauth-token/index.ts
+++ b/supabase/functions/oauth-token/index.ts
@@ -1,0 +1,119 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { Hono } from "hono";
+import { SignJWT } from "jose";
+
+const OAUTH_CLIENT_ID     = Deno.env.get("OAUTH_CLIENT_ID")!.trim();
+const OAUTH_CLIENT_SECRET = Deno.env.get("OAUTH_CLIENT_SECRET")!.trim();
+const JWT_SECRET          = Deno.env.get("JWT_SECRET")!.trim();
+
+const secretBytes = new TextEncoder().encode(JWT_SECRET);
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "content-type, authorization",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+};
+
+const app = new Hono();
+
+app.options("*", (c) => c.text("ok", 200, corsHeaders));
+
+// Catch-all: route internally by method + path (matches open-brain-mcp pattern)
+app.all("*", async (c) => {
+  const url = new URL(c.req.url);
+  const path = url.pathname;
+  const method = c.req.method;
+
+  // OAuth Authorization Server Metadata (RFC 8414)
+  if (method === "GET" && path.endsWith("/.well-known/oauth-authorization-server")) {
+    const base = `${url.origin}/functions/v1/oauth-token`;
+    return c.json(
+      {
+        issuer: base,
+        token_endpoint: `${base}/token`,
+        grant_types_supported: ["client_credentials"],
+        token_endpoint_auth_methods_supported: ["client_secret_post"],
+        response_types_supported: ["token"],
+      },
+      200,
+      corsHeaders
+    );
+  }
+
+  // Token endpoint — Client Credentials grant (RFC 6749 §4.4)
+  if (method === "POST" && (path.endsWith("/token") || path === "/functions/v1/oauth-token")) {
+    let client_id: string | undefined;
+    let client_secret: string | undefined;
+    let grant_type: string | undefined;
+
+    const contentType = c.req.header("content-type") ?? "";
+
+    if (contentType.includes("application/x-www-form-urlencoded")) {
+      const body = await c.req.formData();
+      grant_type    = body.get("grant_type")?.toString();
+      client_id     = body.get("client_id")?.toString();
+      client_secret = body.get("client_secret")?.toString();
+    } else {
+      try {
+        const body = await c.req.json();
+        grant_type    = body.grant_type;
+        client_id     = body.client_id;
+        client_secret = body.client_secret;
+      } catch {
+        return c.json(
+          { error: "invalid_request", error_description: "Unreadable body" },
+          400,
+          corsHeaders
+        );
+      }
+    }
+
+    if (grant_type !== "client_credentials") {
+      return c.json({ error: "unsupported_grant_type" }, 400, corsHeaders);
+    }
+    if (!client_id || !client_secret) {
+      return c.json(
+        { error: "invalid_request", error_description: "client_id and client_secret required" },
+        400,
+        corsHeaders
+      );
+    }
+
+    if (!timingSafeEqual(client_id, OAUTH_CLIENT_ID) || !timingSafeEqual(client_secret, OAUTH_CLIENT_SECRET)) {
+      return c.json({ error: "invalid_client" }, 401, corsHeaders);
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    const expiresIn = 3600;
+
+    const access_token = await new SignJWT({ sub: client_id })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt(now)
+      .setExpirationTime(now + expiresIn)
+      .sign(secretBytes);
+
+    return c.json(
+      { access_token, token_type: "Bearer", expires_in: expiresIn },
+      200,
+      { ...corsHeaders, "Cache-Control": "no-store", Pragma: "no-cache" }
+    );
+  }
+
+  return c.json({ error: "not_found" }, 404, corsHeaders);
+});
+
+function timingSafeEqual(a: string, b: string): boolean {
+  const aBytes = new TextEncoder().encode(a);
+  const bBytes = new TextEncoder().encode(b);
+  if (aBytes.length !== bBytes.length) {
+    let dummy = 0;
+    for (let i = 0; i < bBytes.length; i++) dummy |= bBytes[i];
+    void dummy;
+    return false;
+  }
+  let result = 0;
+  for (let i = 0; i < aBytes.length; i++) result |= aBytes[i] ^ bBytes[i];
+  return result === 0;
+}
+
+Deno.serve(app.fetch);

--- a/supabase/functions/oauth-token/index.ts
+++ b/supabase/functions/oauth-token/index.ts
@@ -33,7 +33,6 @@ app.all("*", async (c) => {
         token_endpoint: `${base}/token`,
         grant_types_supported: ["client_credentials"],
         token_endpoint_auth_methods_supported: ["client_secret_post"],
-        response_types_supported: ["token"],
       },
       200,
       corsHeaders

--- a/supabase/functions/open-brain-mcp/deno.json
+++ b/supabase/functions/open-brain-mcp/deno.json
@@ -4,6 +4,7 @@
     "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@1.24.3",
     "hono": "npm:hono@4.9.2",
     "zod": "npm:zod@4.1.13",
-    "@supabase/supabase-js": "npm:@supabase/supabase-js@2.47.10"
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@2.47.10",
+    "jose": "npm:jose@5.9.6"
   }
 }

--- a/supabase/functions/open-brain-mcp/index.ts
+++ b/supabase/functions/open-brain-mcp/index.ts
@@ -5,11 +5,14 @@ import { StreamableHTTPTransport } from "@hono/mcp";
 import { Hono } from "hono";
 import { z } from "zod";
 import { createClient } from "@supabase/supabase-js";
+import { jwtVerify } from "jose";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 const OPENROUTER_API_KEY = Deno.env.get("OPENROUTER_API_KEY")!;
 const MCP_ACCESS_KEY = Deno.env.get("MCP_ACCESS_KEY")!;
+const JWT_SECRET = Deno.env.get("JWT_SECRET");
+const jwtSecretBytes = JWT_SECRET ? new TextEncoder().encode(JWT_SECRET) : null;
 
 const OPENROUTER_BASE = "https://openrouter.ai/api/v1";
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
@@ -1004,9 +1007,26 @@ app.options("*", (c) => {
 });
 
 app.all("*", async (c) => {
-  const provided = c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");
-  if (!provided || provided !== MCP_ACCESS_KEY) {
-    return c.json({ error: "Invalid or missing access key" }, 401, corsHeaders);
+  // Auth: accept x-brain-key (Claude Desktop) OR Authorization: Bearer <jwt> (claude.ai OAuth)
+  const brainKey = c.req.header("x-brain-key") || new URL(c.req.url).searchParams.get("key");
+  const authHeader = c.req.header("authorization") ?? "";
+  const bearerToken = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : null;
+
+  let authenticated = false;
+
+  if (brainKey && brainKey === MCP_ACCESS_KEY) {
+    authenticated = true;
+  } else if (bearerToken && jwtSecretBytes) {
+    try {
+      await jwtVerify(bearerToken, jwtSecretBytes, { algorithms: ["HS256"] });
+      authenticated = true;
+    } catch {
+      // Invalid or expired JWT — fall through to 401
+    }
+  }
+
+  if (!authenticated) {
+    return c.json({ error: "Invalid or missing credentials" }, 401, corsHeaders);
   }
 
   if (!c.req.header("accept")?.includes("text/event-stream")) {


### PR DESCRIPTION
## Summary
- Ports all 11 MCP tools (4 thoughts + 7 pipeline) from the Supabase Edge Function to the Railway Hono app at `agent.yuens.me`
- Adds `src/routes/oauth.ts`: Auth Code + PKCE OAuth server (`/authorize`, `/token`, `/.well-known/oauth-authorization-server`)
- Adds `src/routes/mcp.ts`: full MCP server using `@hono/mcp` + `@modelcontextprotocol/sdk`, same tool logic as Edge Function
- Keeps the Supabase Edge Function intact (Claude Desktop still uses `x-brain-key`)
- claude.ai can now connect as a remote MCP client via OAuth instead of hitting Supabase's disabled auth server

## Test plan
- [ ] `GET https://agent.yuens.me/.well-known/oauth-authorization-server` returns discovery JSON with correct `authorization_endpoint`
- [ ] `GET https://agent.yuens.me/authorize?...&code_challenge_method=S256` redirects to `https://claude.ai/api/mcp/auth_callback?code=...`
- [ ] `POST https://agent.yuens.me/token` with valid `code` + `code_verifier` returns `access_token`
- [ ] `POST https://agent.yuens.me/mcp` with `Authorization: Bearer <token>` returns MCP tools list
- [ ] `POST https://agent.yuens.me/mcp` with `x-brain-key` still works (Claude Desktop compat)
- [ ] Add connector in claude.ai settings pointing to `https://agent.yuens.me/mcp` — OAuth flow completes