### PR TITLE
fix(oauth): add RFC 9728 protected-resource metadata and WWW-Authenticate on 401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- 2026-03-29 — fix(oauth): add RFC 9728 protected-resource metadata and WWW-Authenticate header on 401
 - 2026-03-29 — feat(mcp): port open-brain MCP server to Railway with Auth Code + PKCE OAuth for claude.ai support
 - 2026-03-29 — feat(pipeline): add job hunt pipeline — 3 tables, 7 MCP tools, auto-scoring, integration tests
 - 2026-03-29 — docs(readme): clarify auth headers — /resume uses `Authorization: Bearer <key>`, MCP uses x-brain-key

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -750,10 +750,14 @@ mcpRoute.all('*', async (c) => {
   }
 
   if (!authenticated) {
-    const base = process.env.PUBLIC_URL ?? 'https://agent.yuens.me'
+    const baseUrl = process.env.PUBLIC_URL
+      ? new URL(process.env.PUBLIC_URL)
+      : new URL(c.req.url)
+    const realm = baseUrl.origin
+    const resourceMetadataUrl = new URL('/.well-known/oauth-protected-resource', baseUrl).toString()
     return c.json({ error: 'Invalid or missing credentials' }, 401, {
       ...corsHeaders,
-      'WWW-Authenticate': `Bearer realm="${base}", resource_metadata="${base}/.well-known/oauth-protected-resource"`,
+      'WWW-Authenticate': `Bearer realm="${realm}", resource_metadata="${resourceMetadataUrl}"`,
     })
   }
 

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -750,7 +750,11 @@ mcpRoute.all('*', async (c) => {
   }
 
   if (!authenticated) {
-    return c.json({ error: 'Invalid or missing credentials' }, 401, corsHeaders)
+    const base = process.env.PUBLIC_URL ?? 'https://agent.yuens.me'
+    return c.json({ error: 'Invalid or missing credentials' }, 401, {
+      ...corsHeaders,
+      'WWW-Authenticate': `Bearer realm="${base}", resource_metadata="${base}/.well-known/oauth-protected-resource"`,
+    })
   }
 
   const transport = new StreamableHTTPTransport()

--- a/src/routes/oauth.ts
+++ b/src/routes/oauth.ts
@@ -52,7 +52,9 @@ oauth.get('/.well-known/oauth-authorization-server', (c) => {
 // RFC 9728 — OAuth 2.0 Protected Resource Metadata
 // claude.ai fetches this after receiving a 401 to discover which auth server to use
 oauth.get('/.well-known/oauth-protected-resource', (c) => {
-  const base = process.env.PUBLIC_URL ?? 'https://agent.yuens.me'
+  const base = process.env.PUBLIC_URL
+    ? new URL(process.env.PUBLIC_URL).origin
+    : new URL(c.req.url).origin
   return c.json({
     resource: base,
     authorization_servers: [base],

--- a/src/routes/oauth.ts
+++ b/src/routes/oauth.ts
@@ -49,6 +49,17 @@ oauth.get('/.well-known/oauth-authorization-server', (c) => {
   })
 })
 
+// RFC 9728 — OAuth 2.0 Protected Resource Metadata
+// claude.ai fetches this after receiving a 401 to discover which auth server to use
+oauth.get('/.well-known/oauth-protected-resource', (c) => {
+  const base = process.env.PUBLIC_URL ?? 'https://agent.yuens.me'
+  return c.json({
+    resource: base,
+    authorization_servers: [base],
+    bearer_methods_supported: ['header'],
+  })
+})
+
 oauth.get('/authorize', (c) => {
   const { response_type, client_id, redirect_uri, state, code_challenge, code_challenge_method } = c.req.query()
 


### PR DESCRIPTION
## Summary
- Adds `GET /.well-known/oauth-protected-resource` endpoint (RFC 9728) — claude.ai fetches this after a 401 to discover which authorization server protects the resource
- Adds `WWW-Authenticate: Bearer realm=..., resource_metadata=...` header on all 401 responses from `/mcp` — signals to claude.ai where to begin the OAuth flow

## Root cause
Railway logs showed claude.ai hitting `/mcp` → 401, then looking for `/.well-known/oauth-protected-resource` → 404. Without that endpoint, claude.ai couldn't proceed to the OAuth flow and showed "Couldn't reach the MCP server".

## Test plan
- [ ] `GET https://agent.yuens.me/.well-known/oauth-protected-resource` returns `{ resource, authorization_servers, bearer_methods_supported }`
- [ ] `POST https://agent.yuens.me/mcp` with no auth returns 401 with `WWW-Authenticate` header
- [ ] claude.ai connector successfully completes OAuth flow and connects to MCP server