### PR TITLE
fix(mcp): create new McpServer per request to fix 500 on concurrent connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- 2026-03-29 — fix(mcp): create new McpServer per request to fix 500 on concurrent connections
 - 2026-03-29 — fix(oauth): add RFC 9728 protected-resource metadata and WWW-Authenticate header on 401
 - 2026-03-29 — feat(mcp): port open-brain MCP server to Railway with Auth Code + PKCE OAuth for claude.ai support
 - 2026-03-29 — feat(pipeline): add job hunt pipeline — 3 tables, 7 MCP tools, auto-scoring, integration tests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -711,9 +711,6 @@ function buildServer(): McpServer {
   return server
 }
 
-// Single server instance — tools registered once at startup
-const mcpServer = buildServer()
-
 // ── Hono App ──────────────────────────────────────────────
 
 const mcpRoute = new Hono()
@@ -762,7 +759,7 @@ mcpRoute.all('*', async (c) => {
   }
 
   const transport = new StreamableHTTPTransport()
-  await mcpServer.connect(transport)
+  await buildServer().connect(transport)
 
   const response = await transport.handleRequest(c)
   if (!response) return c.json({ error: 'No response from MCP transport' }, 500, corsHeaders)

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -758,8 +758,9 @@ mcpRoute.all('*', async (c) => {
     })
   }
 
+  const server = buildServer()
   const transport = new StreamableHTTPTransport()
-  await buildServer().connect(transport)
+  await server.connect(transport)
 
   const response = await transport.handleRequest(c)
   if (!response) return c.json({ error: 'No response from MCP transport' }, 500, corsHeaders)


### PR DESCRIPTION
## Summary
- Reverts the module-level `McpServer` singleton introduced in PR #20 (per Copilot's performance suggestion)
- Creates a fresh `McpServer` per request via `buildServer()` — same pattern as the Supabase Edge Function
- Root cause: `McpServer.connect(transport)` can only be called correctly once per server instance; reusing the singleton across requests caused Internal Server Error (500)

## Test plan
- [ ] `POST https://agent.yuens.me/mcp` with `x-brain-key` + correct Accept header returns valid MCP initialize response
- [ ] Multiple concurrent requests to `/mcp` all succeed (no 500s)