### PR TITLE
fix(mcp): enable JSON response mode to fix SSE streaming incompatibility in Node.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- 2026-03-29 — fix(mcp): enable JSON response mode to fix SSE streaming incompatibility in Node.js
 - 2026-03-29 — fix(mcp): create new McpServer per request to fix 500 on concurrent connections
 - 2026-03-29 — fix(oauth): add RFC 9728 protected-resource metadata and WWW-Authenticate header on 401
 - 2026-03-29 — feat(mcp): port open-brain MCP server to Railway with Auth Code + PKCE OAuth for claude.ai support

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.1.18",
+  "version": "0.1.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.1.18",
+      "version": "0.1.22",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.2.9",
         "@ai-sdk/google": "^1.2.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -759,7 +759,7 @@ mcpRoute.all('*', async (c) => {
   }
 
   const server = buildServer()
-  const transport = new StreamableHTTPTransport()
+  const transport = new StreamableHTTPTransport({ enableJsonResponse: true })
   await server.connect(transport)
 
   const response = await transport.handleRequest(c)


### PR DESCRIPTION
## Summary
- Passes `{ enableJsonResponse: true }` to `StreamableHTTPTransport` constructor
- Root cause: `@hono/mcp` defaults to SSE streaming for MCP responses, which uses `hono/streaming` — this fails in `@hono/node-server` (Node.js) vs edge runtimes (Deno/Cloudflare Workers)
- With `enableJsonResponse: true`, the transport returns plain JSON responses which work correctly in Node.js
- Confirmed via source inspection of `node_modules/@hono/mcp/dist/index.js`

## Test plan
- [ ] `POST https://agent.yuens.me/mcp` with `x-brain-key` + `Accept: application/json, text/event-stream` returns a valid MCP `initialize` JSON response (not 500)
- [ ] `tools/list` call returns all 11 tools