### PR TITLE
feat(oauth): add client_credentials grant for claude.ai custom connector auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-03-29 — feat(oauth): add client_credentials grant so claude.ai custom connectors can authenticate with client_id + client_secret
+
 - 2026-03-29 — fix(mcp): enable JSON response mode to fix SSE streaming incompatibility in Node.js
 - 2026-03-29 — fix(mcp): create new McpServer per request to fix 500 on concurrent connections
 - 2026-03-29 — fix(oauth): add RFC 9728 protected-resource metadata and WWW-Authenticate header on 401

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/routes/oauth.ts
+++ b/src/routes/oauth.ts
@@ -12,6 +12,15 @@ const ALLOWED_CLIENT_IDS = new Set(
   (process.env.OAUTH_CLIENT_ID ?? 'claude-ai-connector').split(',').map((s) => s.trim()).filter(Boolean)
 )
 
+const OAUTH_CLIENT_SECRET = process.env.OAUTH_CLIENT_SECRET ?? ''
+
+function timingSafeEqual(a: string, b: string): boolean {
+  const aBytes = Buffer.from(a)
+  const bBytes = Buffer.from(b)
+  if (aBytes.length !== bBytes.length) return false
+  return crypto.timingSafeEqual(aBytes, bBytes)
+}
+
 const ALLOWED_REDIRECT_URIS = new Set([
   'https://claude.ai/api/mcp/auth_callback',
 ])
@@ -43,7 +52,7 @@ oauth.get('/.well-known/oauth-authorization-server', (c) => {
     authorization_endpoint: `${base}/authorize`,
     token_endpoint: `${base}/token`,
     response_types_supported: ['code'],
-    grant_types_supported: ['authorization_code'],
+    grant_types_supported: ['authorization_code', 'client_credentials'],
     code_challenge_methods_supported: ['S256'],
     token_endpoint_auth_methods_supported: ['none'],
   })
@@ -99,6 +108,7 @@ oauth.post('/token', async (c) => {
   let code: string | undefined
   let code_verifier: string | undefined
   let client_id: string | undefined
+  let client_secret: string | undefined
   let redirect_uri: string | undefined
 
   if (contentType.includes('application/x-www-form-urlencoded')) {
@@ -107,6 +117,7 @@ oauth.post('/token', async (c) => {
     code = body.get('code')?.toString()
     code_verifier = body.get('code_verifier')?.toString()
     client_id = body.get('client_id')?.toString()
+    client_secret = body.get('client_secret')?.toString()
     redirect_uri = body.get('redirect_uri')?.toString()
   } else {
     const body = await c.req.json().catch(() => ({}))
@@ -114,7 +125,31 @@ oauth.post('/token', async (c) => {
     code = body.code
     code_verifier = body.code_verifier
     client_id = body.client_id
+    client_secret = body.client_secret
     redirect_uri = body.redirect_uri
+  }
+
+  if (grant_type === 'client_credentials') {
+    if (!client_id || !client_secret) {
+      return c.json({ error: 'invalid_request', error_description: 'client_id and client_secret required' }, 400)
+    }
+    if (!ALLOWED_CLIENT_IDS.has(client_id) || !OAUTH_CLIENT_SECRET || !timingSafeEqual(client_secret, OAUTH_CLIENT_SECRET)) {
+      return c.json({ error: 'invalid_client' }, 401)
+    }
+
+    const now = Math.floor(Date.now() / 1000)
+    const expiresIn = 3600
+    const access_token = await new SignJWT({ sub: client_id })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setIssuedAt(now)
+      .setExpirationTime(now + expiresIn)
+      .sign(jwtSecretBytes)
+
+    return c.json(
+      { access_token, token_type: 'Bearer', expires_in: expiresIn },
+      200,
+      { 'Cache-Control': 'no-store', Pragma: 'no-cache' }
+    )
   }
 
   if (grant_type !== 'authorization_code') {

--- a/src/routes/oauth.ts
+++ b/src/routes/oauth.ts
@@ -15,10 +15,10 @@ const ALLOWED_CLIENT_IDS = new Set(
 const OAUTH_CLIENT_SECRET = process.env.OAUTH_CLIENT_SECRET ?? ''
 
 function timingSafeEqual(a: string, b: string): boolean {
-  const aBytes = Buffer.from(a)
-  const bBytes = Buffer.from(b)
-  if (aBytes.length !== bBytes.length) return false
-  return crypto.timingSafeEqual(aBytes, bBytes)
+  // Compare fixed-length digests to avoid length-based timing differences
+  const aDigest = crypto.createHash('sha256').update(a).digest()
+  const bDigest = crypto.createHash('sha256').update(b).digest()
+  return crypto.timingSafeEqual(aDigest, bDigest)
 }
 
 const ALLOWED_REDIRECT_URIS = new Set([
@@ -54,7 +54,7 @@ oauth.get('/.well-known/oauth-authorization-server', (c) => {
     response_types_supported: ['code'],
     grant_types_supported: ['authorization_code', 'client_credentials'],
     code_challenge_methods_supported: ['S256'],
-    token_endpoint_auth_methods_supported: ['none'],
+    token_endpoint_auth_methods_supported: ['none', 'client_secret_post'],
   })
 })
 
@@ -129,12 +129,14 @@ oauth.post('/token', async (c) => {
     redirect_uri = body.redirect_uri
   }
 
+  const noCacheHeaders = { 'Cache-Control': 'no-store', Pragma: 'no-cache' } as const
+
   if (grant_type === 'client_credentials') {
     if (!client_id || !client_secret) {
-      return c.json({ error: 'invalid_request', error_description: 'client_id and client_secret required' }, 400)
+      return c.json({ error: 'invalid_request', error_description: 'client_id and client_secret required' }, 400, noCacheHeaders)
     }
     if (!ALLOWED_CLIENT_IDS.has(client_id) || !OAUTH_CLIENT_SECRET || !timingSafeEqual(client_secret, OAUTH_CLIENT_SECRET)) {
-      return c.json({ error: 'invalid_client' }, 401)
+      return c.json({ error: 'invalid_client' }, 401, noCacheHeaders)
     }
 
     const now = Math.floor(Date.now() / 1000)
@@ -148,7 +150,7 @@ oauth.post('/token', async (c) => {
     return c.json(
       { access_token, token_type: 'Bearer', expires_in: expiresIn },
       200,
-      { 'Cache-Control': 'no-store', Pragma: 'no-cache' }
+      noCacheHeaders
     )
   }
 


### PR DESCRIPTION
## Summary
- Adds `client_credentials` grant type to the Railway OAuth `/token` endpoint
- Parses `client_secret` alongside existing body fields (single body read, no double-parse bug)
- Updates `/.well-known/oauth-authorization-server` to advertise both `authorization_code` and `client_credentials`
- Adds `timingSafeEqual` helper using Node.js `crypto.timingSafeEqual` to prevent timing attacks on secret comparison

## Why
Claude.ai custom connectors use OAuth Client Credentials flow (not Auth Code + PKCE). The connector form has "OAuth Client ID" and "OAuth Client Secret" fields — this PR enables those fields to work with our Railway MCP server.

## Setup required
Add `OAUTH_CLIENT_SECRET` to Railway environment variables before connecting.

## Test plan
- [ ] `POST /token` with `grant_type=client_credentials`, valid `client_id` and `client_secret` → returns JWT
- [ ] Invalid `client_secret` → 401 `invalid_client`
- [ ] Missing `client_secret` → 400 `invalid_request`
- [ ] `authorization_code` flow still works (no regression)
- [ ] claude.ai connector connects successfully with client_id + client_secret filled in