### PR TITLE
fix(mcp): enforce Origin validation, GET→405, DELETE→200 per MCP Streamable HTTP spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-03-29 — fix(mcp): enforce Origin validation, add GET→405 and DELETE→200 per MCP Streamable HTTP spec
+
 - 2026-03-29 — feat(oauth): add client_credentials grant so claude.ai custom connectors can authenticate with client_id + client_secret
 
 - 2026-03-29 — fix(mcp): enable JSON response mode to fix SSE streaming incompatibility in Node.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -1,7 +1,7 @@
 import '../lib/env.js'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPTransport } from '@hono/mcp'
-import { Hono } from 'hono'
+import { Hono, type Context } from 'hono'
 import { z } from 'zod'
 import { jwtVerify } from 'jose'
 import { supabase } from '../lib/supabase.js'
@@ -713,48 +713,79 @@ function buildServer(): McpServer {
 
 // ── Hono App ──────────────────────────────────────────────
 
-const mcpRoute = new Hono()
+// Allowed browser origins — prevents DNS rebinding attacks (MCP Streamable HTTP spec MUST)
+// Non-browser clients (curl, Claude Desktop) send no Origin header and are always allowed.
+const ALLOWED_ORIGINS = new Set([
+  'https://claude.ai',
+  ...(process.env.ALLOWED_ORIGINS ?? '').split(',').map((s) => s.trim()).filter(Boolean),
+])
 
-mcpRoute.options('*', (c) => c.text('ok', 200, {
+const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, content-type, x-brain-key, accept, mcp-session-id',
-  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, DELETE',
-}))
+  'Access-Control-Allow-Methods': 'POST, OPTIONS, DELETE',
+} as const
 
-mcpRoute.all('*', async (c) => {
-  const corsHeaders = {
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Headers': 'authorization, content-type, x-brain-key, accept, mcp-session-id',
-    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, DELETE',
+function checkOrigin(c: Context): Response | null {
+  const origin = c.req.header('origin')
+  if (origin && !ALLOWED_ORIGINS.has(origin)) {
+    return new Response(JSON.stringify({ error: 'Origin not allowed' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    })
   }
+  return null
+}
 
-  // Auth: x-brain-key header (Claude Desktop) OR Authorization: Bearer <jwt> (claude.ai)
+async function authenticate(c: Context): Promise<boolean> {
   const brainKey = c.req.header('x-brain-key')
+  if (brainKey && brainKey === MCP_ACCESS_KEY) return true
+
   const authHeader = c.req.header('authorization') ?? ''
   const bearerToken = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null
-
-  let authenticated = false
-
-  if (brainKey && brainKey === MCP_ACCESS_KEY) {
-    authenticated = true
-  } else if (bearerToken && jwtSecretBytes) {
+  if (bearerToken && jwtSecretBytes) {
     try {
       await jwtVerify(bearerToken, jwtSecretBytes, { algorithms: ['HS256'] })
-      authenticated = true
+      return true
     } catch {
       // fall through
     }
   }
+  return false
+}
 
-  if (!authenticated) {
+const mcpRoute = new Hono()
+
+// CORS preflight
+mcpRoute.options('*', (c) => c.text('ok', 200, corsHeaders))
+
+// GET — this server uses JSON response mode (no SSE); return 405 per MCP spec
+mcpRoute.get('*', (c) => c.json(
+  { error: 'Method not allowed — server operates in JSON response mode, not SSE' },
+  405,
+  { ...corsHeaders, Allow: 'POST, OPTIONS, DELETE' }
+))
+
+// DELETE — stateless server, no sessions to track; acknowledge and return 200
+mcpRoute.delete('*', (c) => {
+  const originErr = checkOrigin(c)
+  if (originErr) return originErr
+  return c.body(null, 200)
+})
+
+// POST — main MCP handler
+mcpRoute.post('*', async (c) => {
+  const originErr = checkOrigin(c)
+  if (originErr) return originErr
+
+  if (!await authenticate(c)) {
     const baseUrl = process.env.PUBLIC_URL
       ? new URL(process.env.PUBLIC_URL)
       : new URL(c.req.url)
-    const realm = baseUrl.origin
     const resourceMetadataUrl = new URL('/.well-known/oauth-protected-resource', baseUrl).toString()
     return c.json({ error: 'Invalid or missing credentials' }, 401, {
       ...corsHeaders,
-      'WWW-Authenticate': `Bearer realm="${realm}", resource_metadata="${resourceMetadataUrl}"`,
+      'WWW-Authenticate': `Bearer realm="${baseUrl.origin}", resource_metadata="${resourceMetadataUrl}"`,
     })
   }
 

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -757,20 +757,28 @@ async function authenticate(c: Context): Promise<boolean> {
 const mcpRoute = new Hono()
 
 // CORS preflight
-mcpRoute.options('*', (c) => c.text('ok', 200, corsHeaders))
+mcpRoute.options('*', (c) => {
+  const originErr = checkOrigin(c)
+  if (originErr) return originErr
+  return c.text('ok', 200, corsHeaders)
+})
 
 // GET — this server uses JSON response mode (no SSE); return 405 per MCP spec
-mcpRoute.get('*', (c) => c.json(
-  { error: 'Method not allowed — server operates in JSON response mode, not SSE' },
-  405,
-  { ...corsHeaders, Allow: 'POST, OPTIONS, DELETE' }
-))
+mcpRoute.get('*', (c) => {
+  const originErr = checkOrigin(c)
+  if (originErr) return originErr
+  return c.json(
+    { error: 'Method not allowed — server operates in JSON response mode, not SSE' },
+    405,
+    { ...corsHeaders, Allow: 'POST, OPTIONS, DELETE' }
+  )
+})
 
 // DELETE — stateless server, no sessions to track; acknowledge and return 200
 mcpRoute.delete('*', (c) => {
   const originErr = checkOrigin(c)
   if (originErr) return originErr
-  return c.body(null, 200)
+  return c.body(null, 200, corsHeaders)
 })
 
 // POST — main MCP handler


### PR DESCRIPTION
## What this fixes

Three spec compliance gaps identified by auditing our Streamable HTTP transport implementation against the [MCP specification](https://modelcontextprotocol.io/docs/concepts/transports).

### 1. Origin header validation (spec **MUST**)

> Servers MUST validate the Origin header on all incoming connections to prevent DNS rebinding attacks.

We now validate the `Origin` header on all POST and DELETE requests. Non-browser clients (curl, Claude Desktop, API tools) don't send an `Origin` header and are always allowed through. Browser requests must come from an allowlisted origin.

**Default allowlist:** `https://claude.ai`  
**Extensible:** set `ALLOWED_ORIGINS=https://your-app.com,https://other.com` env var to add more.

### 2. GET → 405 (spec: return SSE stream or 405)

> The server MUST either return `Content-Type: text/event-stream` in response to this HTTP GET, or else return HTTP 405 Method Not Allowed.

Our server runs in JSON response mode (`enableJsonResponse: true`) — no SSE support. Previously `all('*')` would swallow GET requests silently. Now returns 405 with an `Allow` header.

### 3. DELETE → 200 for stateless session teardown

> The server MAY respond to DELETE with HTTP 405, indicating it does not allow clients to terminate sessions.

We're stateless (new `McpServer` per request, no session tracking). Rather than 405, we return 200 — the session is effectively already gone, so acknowledging the teardown is more correct than refusing it.

## Code cleanup

- Extracted `corsHeaders` constant (was copy-pasted in `options` and `all` handlers)
- Extracted `checkOrigin()` and `authenticate()` helpers
- Replaced `all('*')` with explicit `get`, `post`, `delete` handlers for clarity
- Imported `Context` type from Hono for proper typing

## Auth flow that got us here

This PR is part of a larger milestone: getting `claude.ai` custom connectors working end-to-end with a self-hosted MCP server on Railway. The full OAuth flow we implemented:

- RFC 8414 — OAuth Authorization Server Metadata (`/.well-known/oauth-authorization-server`)
- RFC 9728 — OAuth Protected Resource Metadata (`/.well-known/oauth-protected-resource`)
- Auth Code + PKCE (`/authorize` + `/token`) for Claude Desktop
- **Client Credentials** (`/token` with `client_id` + `client_secret`) for claude.ai custom connectors — the flow the UI actually uses

## Test plan
- [ ] `POST /mcp` with valid `x-brain-key` → tools work as before
- [ ] `POST /mcp` with valid OAuth Bearer JWT → tools work
- [ ] `POST /mcp` with `Origin: https://evil.com` → 403
- [ ] `POST /mcp` with no `Origin` header (curl) → passes through
- [ ] `GET /mcp` → 405 with `Allow: POST, OPTIONS, DELETE`
- [ ] `DELETE /mcp` → 200
- [ ] claude.ai connector still connects and tools are accessible