### PR TITLE
docs(readme): align MCP section with Railway+OAuth arc, job pipeline, security model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-03-29 — docs(readme): update MCP section to Railway+OAuth, add job pipeline to data tier table, expand security model
+
 - 2026-03-29 — fix(mcp): enforce Origin validation, add GET→405 and DELETE→200 per MCP Streamable HTTP spec
 
 - 2026-03-29 — feat(oauth): add client_credentials grant so claude.ai custom connectors can authenticate with client_id + client_secret

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Full read/write GET /.well-known/agent.json
 |---|---|---|
 | `public_profile` | Public API (read-only) | Skills, experience, projects, availability |
 | `thoughts` | MCP only (private) | Raw notes, captures, work-in-progress |
-| `job_hunt_pipeline` | MCP only (private) — _planned_ | Applications, interviews, contacts |
+| `job_hunt_pipeline` | MCP only (private) | Applications, stages, contacts, follow-up tasks |
 
 Row Level Security in Supabase enforces the boundary. The public API has no knowledge of the private tables and no credentials to reach them.
 
@@ -153,9 +153,23 @@ The private `/resume` endpoint uses the same methodology to generate a resume th
 
 ## Private agentic interface
 
-You interact with your own knowledge base through whichever AI tool you are already using. No browser, no app.
+You interact with your own knowledge base through Claude — no browser, no app, no local config required.
 
-**Claude Desktop** — add to `claude_desktop_config.json`:
+### claude.ai (web + mobile) — recommended
+
+Add a custom connector at `claude.ai → Settings → Connectors → Add custom connector`:
+
+| Field | Value |
+|---|---|
+| Remote MCP server URL | `https://your-agent-domain.com/mcp` |
+| OAuth Client ID | your `OAUTH_CLIENT_ID` env var value |
+| OAuth Client Secret | your `OAUTH_CLIENT_SECRET` env var value |
+
+This connects via OAuth 2.0 Client Credentials flow. Works on web, phone, and Claude Desktop automatically — one connector, all surfaces.
+
+### Claude Desktop (direct API access)
+
+If you prefer a direct connection bypassing OAuth, add to `claude_desktop_config.json`:
 ```json
 {
   "mcpServers": {
@@ -164,7 +178,7 @@ You interact with your own knowledge base through whichever AI tool you are alre
       "args": [
         "-y",
         "mcp-remote",
-        "https://YOUR_PROJECT_REF.supabase.co/functions/v1/open-brain-mcp",
+        "https://your-agent-domain.com/mcp",
         "--header",
         "x-brain-key:YOUR_MCP_ACCESS_KEY"
       ]
@@ -173,13 +187,13 @@ You interact with your own knowledge base through whichever AI tool you are alre
 }
 ```
 
-> On Windows, Claude Desktop is a packaged app — the config file is at `%LOCALAPPDATA%\Packages\Claude_*\LocalCache\Roaming\Claude\claude_desktop_config.json`, not the standard `%APPDATA%\Claude\` path.
+> **Windows:** Claude Desktop (Store app) reads from `%LOCALAPPDATA%\Packages\Claude_*\LocalCache\Roaming\Claude\claude_desktop_config.json`, not the standard `%APPDATA%\Claude\` path.
 
 Then in Claude:
-> "Am I a good fit for this role? [paste JD]"
-> "Add the Acme project to my work history"
-> "Generate a resume for this staff engineer role"
+> "Capture this: had a good call with Acme, following up Thursday"
 > "What have I shipped in the last 6 months?"
+> "Am I a good fit for this role? [paste JD]"
+> "Log an application to Stripe — staff engineer, applied today"
 
 ---
 
@@ -202,7 +216,9 @@ Then in Claude:
 - All secrets in `.env.local`, never committed
 - `public_profile` table: read-only, no auth required, rate-limited by IP
 - `/resume` endpoint: when `AUTH_MODE=key`, requires `Authorization: Bearer <key>` header; when `AUTH_MODE=open` (default in `.env.example`), it is publicly accessible
-- MCP server (OB1): requires `x-brain-key: <key>` header (passed via `--header` arg in `mcp-remote`)
+- MCP server: OAuth 2.0 Client Credentials (claude.ai connector) or `x-brain-key` header (direct API / Claude Desktop)
+- OAuth endpoints: `/authorize`, `/token`, `/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource` (RFC 8414 + RFC 9728)
+- Origin header validation on MCP endpoint (DNS rebinding protection per MCP Streamable HTTP spec)
 - Supabase service role key: server-side only, never returned to clients
 - Postgres Row Level Security enforces public/private table boundary
 - No personal data in this repo — data lives in your Supabase instance

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Full read/write GET /.well-known/agent.json
 |---|---|---|
 | `public_profile` | Public API (read-only) | Skills, experience, projects, availability |
 | `thoughts` | MCP only (private) | Raw notes, captures, work-in-progress |
-| `job_hunt_pipeline` | MCP only (private) | Applications, stages, contacts, follow-up tasks |
+| `job_applications` + `application_stages` + `job_contacts` | MCP only (private) | Job hunt pipeline — applications, stage history, contacts |
 
 Row Level Security in Supabase enforces the boundary. The public API has no knowledge of the private tables and no credentials to reach them.
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -125,9 +125,15 @@ Response:
 
 ## Candidate workflow (private MCP interface)
 
-You interact with your own knowledge base through Claude Desktop or Cursor — no browser, no app. See the [MCP config in README](../README.md#private-agentic-interface) for setup.
+You interact with your own knowledge base through Claude — web, mobile, or desktop. The MCP server lives at `/mcp` on the same Railway deployment as the public API and is protected by OAuth 2.0.
 
-Once connected, the 4 available tools are:
+**Connecting via claude.ai** (recommended — works on web, phone, and desktop automatically): add a custom connector at `Settings → Connectors` with your OAuth client ID and secret. See the [MCP config in README](../README.md#private-agentic-interface) for the full setup.
+
+**Connecting via Claude Desktop directly**: use `mcp-remote` with your `x-brain-key` in the config. See README for details.
+
+Once connected, 11 tools are available across two groups:
+
+**Open Brain — personal knowledge capture**
 
 | Tool | What it does |
 |---|---|
@@ -135,6 +141,18 @@ Once connected, the 4 available tools are:
 | `search_thoughts` | Semantic search by meaning — "find thoughts about accessibility work" |
 | `list_thoughts` | Chronological list with filters by type, topic, person, or date range |
 | `thought_stats` | Aggregate view — total count, distribution by type/topic/people |
+
+**Job Hunt Pipeline — application tracking**
+
+| Tool | What it does |
+|---|---|
+| `log_application` | Record a new job application with company, role, JD, and auto fit-score |
+| `stage_update` | Move an application through stages (applied → screen → interview → offer → closed) |
+| `contact_log` | Log a contact at a company with name, role, and notes |
+| `list_applications` | List all applications with optional stage/company filters |
+| `get_application` | Full detail on one application including stage history and contacts |
+| `follow_up_task` | Create a follow-up reminder tied to an application |
+| `search_applications` | Semantic search across application notes and JD text |
 
 **Common workflows:**
 
@@ -158,8 +176,8 @@ The A2A agent card spec is designed for a world where AI systems auto-discover a
 
 | Scenario | Status | Notes |
 |---|---|---|
-| Claude Desktop with MCP | ✅ Works | Full private interface — capture, search, match, resume |
-| Claude.ai (Web) with WebFetch | ✅ Works | Can call endpoints directly if given the URL |
+| Claude Desktop with MCP | ✅ Works | Via claude.ai custom connector (OAuth) or direct x-brain-key config |
+| Claude.ai (web + mobile) | ✅ Works | Custom connector with OAuth Client Credentials — one setup, all surfaces |
 | Cursor / AI coding assistants | ✅ Works | Via MCP or manual HTTP calls |
 | Custom employer AI agent | ✅ Works | If they're given the agent card URL to target |
 | Consumer phone AI apps (Gemini, ChatGPT) | ❌ No HTTP | These apps have no mechanism to make GET/POST requests |

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -125,7 +125,7 @@ Response:
 
 ## Candidate workflow (private MCP interface)
 
-You interact with your own knowledge base through Claude — web, mobile, or desktop. The MCP server lives at `/mcp` on the same Railway deployment as the public API and is protected by OAuth 2.0.
+You interact with your own knowledge base through Claude — web, mobile, or desktop. The MCP server lives at `/mcp` on the same Railway deployment as the public API, protected by OAuth 2.0 (claude.ai connector) or `x-brain-key` header (direct API access).
 
 **Connecting via claude.ai** (recommended — works on web, phone, and desktop automatically): add a custom connector at `Settings → Connectors` with your OAuth client ID and secret. See the [MCP config in README](../README.md#private-agentic-interface) for the full setup.
 
@@ -147,11 +147,11 @@ Once connected, 11 tools are available across two groups:
 | Tool | What it does |
 |---|---|
 | `log_application` | Record a new job application with company, role, JD, and auto fit-score |
-| `stage_update` | Move an application through stages (applied → screen → interview → offer → closed) |
-| `contact_log` | Log a contact at a company with name, role, and notes |
+| `update_stage` | Move an application through stages (`applied`, `phone_screen`, `technical`, `final`, `offer`, `rejected`, `withdrawn`) |
+| `add_contact` | Log a contact at a company with name, role, and notes |
 | `list_applications` | List all applications with optional stage/company filters |
 | `get_application` | Full detail on one application including stage history and contacts |
-| `follow_up_task` | Create a follow-up reminder tied to an application |
+| `set_follow_up` | Create a follow-up reminder tied to an application |
 | `search_applications` | Semantic search across application notes and JD text |
 
 **Common workflows:**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

Documentation catch-up after a major session that shipped:
- MCP server ported from Supabase Edge Functions → Railway (same deployment as public API)
- OAuth 2.0 (Auth Code + PKCE + Client Credentials) for claude.ai custom connector support
- 11 MCP tools live (4 Open Brain + 7 Job Hunt Pipeline)
- claude.ai connected on web, mobile, and Claude Desktop via single OAuth connector

## Changes

**README.md**
- Private interface section: replaced stale Supabase `mcp-remote` config with claude.ai custom connector setup (OAuth Client Credentials) as the primary path, `mcp-remote` moved to secondary/direct option
- Data tier table: removed "planned" from `job_hunt_pipeline` — it's shipped
- Security model: replaced single MCP bullet with accurate OAuth + x-brain-key + RFC 8414/9728 + Origin validation description

**docs/workflow.md**
- Candidate workflow: updated connection instructions to reflect Railway MCP + OAuth
- MCP tools table: expanded from 4 → 11 tools (added full Job Hunt Pipeline tool set)
- Status table: updated claude.ai row from "WebFetch manual calls" to "custom connector with OAuth Client Credentials"

## Test plan
- [ ] README private interface section accurately describes OAuth connector setup
- [ ] README security model reflects current auth mechanisms
- [ ] workflow.md shows all 11 MCP tools
- [ ] workflow.md candidate workflow describes Railway MCP connection
- [ ] No broken links