### PR TITLE
feat(mcp): add update_profile tool — closes OB1 → public profile sync loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-03-29 — feat(mcp): add update_profile tool — closes OB1 → public profile sync loop
+
 - 2026-03-29 — docs(readme): add live QR code pointing to agent.yuens.me/.well-known/agent.json
 
 - 2026-03-29 — docs(readme): update MCP section to Railway+OAuth, add job pipeline to data tier table, expand security model

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -359,6 +359,49 @@ function buildServer(): McpServer {
   )
 
   server.registerTool(
+    'update_profile',
+    {
+      title: 'Update Public Profile',
+      description:
+        'Update one or more fields of the public-facing profile. All fields are optional — only send what should change. Use this after reviewing recent thoughts to keep the profile current with new skills, projects, roles, or availability.',
+      inputSchema: {
+        summary:      z.string().optional().describe('Updated professional summary'),
+        skills:       z.array(z.unknown()).optional().describe('Full updated skills array (replaces existing)'),
+        employment:   z.array(z.unknown()).optional().describe('Full updated employment array (replaces existing)'),
+        projects:     z.array(z.unknown()).optional().describe('Full updated projects array (replaces existing)'),
+        education:    z.array(z.unknown()).optional().describe('Full updated education array (replaces existing)'),
+        availability: z.record(z.unknown()).optional().describe('Updated availability object (status, roles, start_date, etc.)'),
+        contact:      z.record(z.unknown()).optional().describe('Updated contact object (email, calendly, linkedin, etc.)'),
+      },
+    },
+    async (delta) => {
+      try {
+        const updates = Object.fromEntries(
+          Object.entries(delta).filter(([, v]) => v !== undefined)
+        )
+
+        if (Object.keys(updates).length === 0) {
+          return { content: [{ type: 'text' as const, text: 'No fields provided — nothing updated.' }] }
+        }
+
+        const { error } = await supabase
+          .from('public_profile')
+          .update({ ...updates, updated_at: new Date().toISOString() })
+          .eq('id', '00000000-0000-0000-0000-000000000001')
+
+        if (error) {
+          return { content: [{ type: 'text' as const, text: `Failed to update profile: ${error.message}` }], isError: true }
+        }
+
+        const updated = Object.keys(updates).join(', ')
+        return { content: [{ type: 'text' as const, text: `Profile updated — fields changed: ${updated}` }] }
+      } catch (err: unknown) {
+        return { content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }], isError: true }
+      }
+    }
+  )
+
+  server.registerTool(
     'capture_thought',
     {
       title: 'Capture Thought',

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -384,13 +384,16 @@ function buildServer(): McpServer {
           return { content: [{ type: 'text' as const, text: 'No fields provided — nothing updated.' }] }
         }
 
-        const { error } = await supabase
+        const { data, error } = await supabase
           .from('public_profile')
           .update({ ...updates, updated_at: new Date().toISOString() })
           .eq('id', '00000000-0000-0000-0000-000000000001')
+          .select('id')
+          .single()
 
-        if (error) {
-          return { content: [{ type: 'text' as const, text: `Failed to update profile: ${error.message}` }], isError: true }
+        if (error || !data) {
+          const message = error?.message ?? 'Profile not found or not updated.'
+          return { content: [{ type: 'text' as const, text: `Failed to update profile: ${message}` }], isError: true }
         }
 
         const updated = Object.keys(updates).join(', ')

--- a/tests/update-profile.test.ts
+++ b/tests/update-profile.test.ts
@@ -1,0 +1,128 @@
+/**
+ * update_profile MCP tool — integration tests
+ *
+ * Calls the live MCP server over HTTP, exercises `update_profile` end-to-end
+ * against the real Supabase database, and restores the original value after.
+ *
+ * Requirements:
+ *   MCP_URL        — e.g. https://agent.yuens.me/mcp (or local http://localhost:3000/mcp)
+ *   MCP_ACCESS_KEY — the x-brain-key value
+ *
+ * Run:
+ *   npm run test:integration
+ */
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { config } from "dotenv";
+
+config({ path: ".env.local" });
+
+const MCP_URL = process.env.MCP_URL ?? `http://localhost:${process.env.PORT ?? 3000}/mcp`;
+const MCP_KEY = process.env.MCP_ACCESS_KEY;
+
+if (!MCP_KEY) {
+  throw new Error("MCP_ACCESS_KEY must be set in .env.local");
+}
+
+const SUPA_URL = process.env.SUPA_PROJECT_URL;
+const SUPA_ROLE_KEY = process.env.SUPA_SERVICE_ROLE;
+if (!SUPA_URL || !SUPA_ROLE_KEY) {
+  throw new Error("SUPA_PROJECT_URL and SUPA_SERVICE_ROLE must be set in .env.local (required for restore)");
+}
+
+// ── MCP JSON-RPC helper ───────────────────────────────────
+
+let sessionId: string | undefined;
+
+async function callTool(name: string, args: Record<string, unknown> = {}) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+    "x-brain-key": MCP_KEY!,
+  };
+  if (sessionId) headers["mcp-session-id"] = sessionId;
+
+  const res = await fetch(MCP_URL, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name, arguments: args },
+    }),
+  });
+
+  if (!sessionId) {
+    sessionId = res.headers.get("mcp-session-id") ?? undefined;
+  }
+
+  const text = await res.text();
+
+  if (text.includes("data:")) {
+    const lines = text.split("\n").filter((l) => l.startsWith("data:"));
+    for (const line of lines.reverse()) {
+      try {
+        const payload = JSON.parse(line.slice(5).trim());
+        if (payload.result) return payload.result;
+        if (payload.error) throw new Error(JSON.stringify(payload.error));
+      } catch { /* skip */ }
+    }
+    throw new Error(`No result in SSE response: ${text.slice(0, 200)}`);
+  }
+
+  const payload = JSON.parse(text);
+  if (payload.error) throw new Error(JSON.stringify(payload.error));
+  return payload.result;
+}
+
+function getText(result: { content: { type: string; text: string }[] }): string {
+  return result.content.map((c) => c.text).join("\n");
+}
+
+// ── Tests ─────────────────────────────────────────────────
+
+const PROFILE_ID = "00000000-0000-0000-0000-000000000001";
+let originalSummary: string;
+
+describe("update_profile MCP tool", () => {
+  before(async () => {
+    // Snapshot current summary so we can restore it after
+    const { createClient } = await import("@supabase/supabase-js");
+    const supabase = createClient(SUPA_URL!, SUPA_ROLE_KEY!);
+    const { data, error } = await supabase
+      .from("public_profile")
+      .select("summary")
+      .eq("id", PROFILE_ID)
+      .single();
+    if (error || !data) throw new Error(`Could not read profile for snapshot: ${error?.message}`);
+    originalSummary = data.summary;
+  });
+
+  after(async () => {
+    // Restore original summary
+    const { createClient } = await import("@supabase/supabase-js");
+    const supabase = createClient(SUPA_URL!, SUPA_ROLE_KEY!);
+    const { error } = await supabase
+      .from("public_profile")
+      .update({ summary: originalSummary })
+      .eq("id", PROFILE_ID);
+    if (error) console.warn(`Restore warning: ${error.message}`);
+  });
+
+  it("update_profile — updates a field and confirms success", async () => {
+    const testSummary = `__test_summary_${Date.now()}`;
+    const result = await callTool("update_profile", { summary: testSummary });
+    const text = getText(result);
+    assert.ok(text.includes("summary"), `Expected 'summary' in response, got: ${text}`);
+    assert.ok(!result.isError, `Expected success, got error: ${text}`);
+  });
+
+  it("update_profile — no fields returns informational message, not error", async () => {
+    const result = await callTool("update_profile", {});
+    const text = getText(result);
+    assert.ok(text.toLowerCase().includes("no fields"), `Expected 'no fields' message, got: ${text}`);
+    assert.ok(!result.isError, `Should not be an error response`);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `update_profile` as the 12th MCP tool in `buildServer()`
- Accepts all `public_profile` fields as optional — only fields provided get updated
- Writes directly to Supabase (consistent with all other MCP tools, no HTTP hop)
- `updated_at` always refreshed on write

## Why
The public profile was seeded once and has gone stale. Open Brain captures thoughts continuously across all Claude surfaces. This tool closes the loop:

```
OB1 thoughts → Claude synthesizes delta → update_profile → Supabase public_profile
```

Usage is conversational — no commands needed:
> "Review my last 14 days of thoughts and update my profile with anything new"

Claude calls `list_thoughts`/`search_thoughts`, reasons over the result, then calls `update_profile` with only the changed fields.

## Test plan
- [ ] In Claude (any surface): "Update my profile — set availability status to passive-looking"
- [ ] `GET https://agent.yuens.me/info` → confirm `availability.status` updated
- [ ] `updated_at` is fresh
- [ ] Sending no fields returns "No fields provided" without error
- [ ] All 12 tools appear in `tools/list` response