### PR TITLE
chore(mcp): add public/private filter and voice reference guidance to update_profile tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- 2026-03-29 — chore(mcp): add public/private filter and voice reference guidance to update_profile tool
+- 2026-03-29 — chore(mcp): add public/private visibility guidance and voice reference notes to update_profile tool
 - 2026-03-29 — feat(mcp): add update_profile tool — closes OB1 → public profile sync loop
 
 - 2026-03-29 — docs(readme): add live QR code pointing to agent.yuens.me/.well-known/agent.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- 2026-03-29 — chore(mcp): add public/private filter and voice reference guidance to update_profile tool
 - 2026-03-29 — feat(mcp): add update_profile tool — closes OB1 → public profile sync loop
 
 - 2026-03-29 — docs(readme): add live QR code pointing to agent.yuens.me/.well-known/agent.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.1.26",
+  "version": "0.1.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.1.26",
+      "version": "0.1.28",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.2.9",
         "@ai-sdk/google": "^1.2.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -363,7 +363,7 @@ function buildServer(): McpServer {
     {
       title: 'Update Public Profile',
       description:
-        'Update one or more fields of the public-facing profile. All fields are optional — only send what should change. Use this after reviewing recent thoughts to keep the profile current with new skills, projects, roles, or availability.',
+        'Update one or more fields of the public-facing profile. All fields are optional — only send what should change. Use this after reviewing recent thoughts to keep the profile current with new skills, projects, roles, or availability. IMPORTANT: this profile is publicly queryable by employer AI systems — only include professional achievements, skills, projects, and availability. Never include private observations, personal notes, salary expectations, or anything not suitable for a resume. When updating the summary, search Open Brain for a voice reference thought first and write in the candidate\'s own voice.',
       inputSchema: {
         summary:      z.string().optional().describe('Updated professional summary'),
         skills:       z.array(z.unknown()).optional().describe('Full updated skills array (replaces existing)'),

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -363,7 +363,12 @@ function buildServer(): McpServer {
     {
       title: 'Update Public Profile',
       description:
-        'Update one or more fields of the public-facing profile. All fields are optional — only send what should change. Use this after reviewing recent thoughts to keep the profile current with new skills, projects, roles, or availability. IMPORTANT: this profile is publicly queryable by employer AI systems — only include professional achievements, skills, projects, and availability. Never include private observations, personal notes, salary expectations, or anything not suitable for a resume. When updating the summary, search Open Brain for a voice reference thought first and write in the candidate\'s own voice.',
+        'Update one or more fields of the public-facing profile. All fields are optional — only send what should change. ' +
+        'Use this after reviewing recent thoughts to keep the profile current with new skills, projects, roles, or availability. ' +
+        'IMPORTANT: this profile is publicly queryable by employer AI systems — only include professional achievements, skills, projects, and availability. ' +
+        'Never include private observations, personal notes, salary expectations, or anything not suitable for a resume. ' +
+        'When updating the summary, first call the `search_thoughts` tool to query Open Brain for a recent "voice reference" thought ' +
+        '(e.g., using a query about the candidate\'s tone or self-description) and then write the summary in the candidate\'s own voice based on that result.',
       inputSchema: {
         summary:      z.string().optional().describe('Updated professional summary'),
         skills:       z.array(z.unknown()).optional().describe('Full updated skills array (replaces existing)'),


### PR DESCRIPTION
## Summary
- Tightens the `update_profile` tool description to explicitly prohibit private content (personal notes, salary expectations) from reaching the public profile
- Instructs Claude to search Open Brain for a voice reference thought before writing the summary field, ensuring updates match the candidate's own writing style
- No logic changes — description only

## Test plan
- [ ] Existing integration tests pass (`npm run test:integration`)
- [ ] Manually invoke `update_profile` in a Claude session and verify the model's reasoning reflects the new guidance