### PR TITLE
refactor(mcp): normalize OpenRouter helpers to Vercel AI SDK + integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-03-30 — refactor(mcp): normalize extractMetadata + getEmbedding to Vercel AI SDK, add score_match + upsert_project integration tests
+
 - 2026-03-30 — refactor(match): extract scoreMatch to lib, register score_match + upsert_project MCP tools
 
 - 2026-03-29 — fix(api): redirect /.well-known/agent-card.json to /.well-known/agent.json for Google A2A compatibility

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "private": true,
   "type": "module",
   "engines": {
@@ -16,7 +16,7 @@
     "ob1:deploy": "supabase functions deploy open-brain-mcp --no-verify-jwt",
     "ob1:logs": "supabase functions logs open-brain-mcp",
     "test": "echo 'No unit tests. Run npm run test:integration for live integration tests.'",
-    "test:integration": "tsx --env-file=.env.local --test tests/pipeline.test.ts"
+    "test:integration": "tsx --env-file=.env.local --test tests/pipeline.test.ts tests/update-profile.test.ts tests/projects-and-scoring.test.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.2.9",

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -49,7 +49,10 @@ Only extract what's explicitly there.`,
       prompt: text,
     })
     return parseJSON<Record<string, unknown>>(raw)
-  } catch {
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'test') {
+      console.error('extractMetadata failed; returning fallback metadata.', error)
+    }
     return { topics: ['uncategorized'], type: 'observation' }
   }
 }

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -4,7 +4,10 @@ import { StreamableHTTPTransport } from '@hono/mcp'
 import { Hono, type Context } from 'hono'
 import { z } from 'zod'
 import { jwtVerify } from 'jose'
+import { generateText, embed } from 'ai'
+import { createOpenAI } from '@ai-sdk/openai'
 import { supabase } from '../lib/supabase.js'
+import { parseJSON } from '../lib/parse-json.js'
 import { scoreMatch } from '../lib/score-match.js'
 import type { Project } from '../types.js'
 
@@ -16,59 +19,36 @@ const jwtSecretBytes = JWT_SECRET ? new TextEncoder().encode(JWT_SECRET) : null
 if (!OPENROUTER_API_KEY) throw new Error('Missing OPENROUTER_API_KEY')
 if (!MCP_ACCESS_KEY) throw new Error('Missing MCP_ACCESS_KEY')
 
-const OPENROUTER_BASE = 'https://openrouter.ai/api/v1'
+const openrouter = createOpenAI({
+  baseURL: 'https://openrouter.ai/api/v1',
+  apiKey: OPENROUTER_API_KEY,
+})
 
 // ── Helpers ───────────────────────────────────────────────
 
 async function getEmbedding(text: string): Promise<number[]> {
-  const r = await fetch(`${OPENROUTER_BASE}/embeddings`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${OPENROUTER_API_KEY}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ model: 'openai/text-embedding-3-small', input: text }),
+  const { embedding } = await embed({
+    model: openrouter.embedding('openai/text-embedding-3-small'),
+    value: text,
   })
-  if (!r.ok) {
-    const msg = await r.text().catch(() => '')
-    throw new Error(`OpenRouter embeddings failed: ${r.status} ${msg}`)
-  }
-  const d = await r.json()
-  return d.data[0].embedding
+  return embedding
 }
 
 async function extractMetadata(text: string): Promise<Record<string, unknown>> {
-  const r = await fetch(`${OPENROUTER_BASE}/chat/completions`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${OPENROUTER_API_KEY}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      model: 'openai/gpt-4o-mini',
-      response_format: { type: 'json_object' },
-      messages: [
-        {
-          role: 'system',
-          content: `Extract metadata from the user's captured thought. Return JSON with:
+  try {
+    const { text: raw } = await generateText({
+      model: openrouter('openai/gpt-4o-mini'),
+      system: `Extract metadata from the user's captured thought. Respond ONLY with valid JSON — no prose, no markdown fences.
+Return an object with:
 - "people": array of people mentioned (empty if none)
 - "action_items": array of implied to-dos (empty if none)
 - "dates_mentioned": array of dates YYYY-MM-DD (empty if none)
 - "topics": array of 1-3 short topic tags (always at least one)
 - "type": one of "observation", "task", "idea", "reference", "person_note"
 Only extract what's explicitly there.`,
-        },
-        { role: 'user', content: text },
-      ],
-    }),
-  })
-  if (!r.ok) {
-    console.error(`OpenRouter metadata extraction failed: ${r.status}`)
-    return { topics: ['uncategorized'], type: 'observation' }
-  }
-  const d = await r.json()
-  try {
-    return JSON.parse(d.choices[0].message.content)
+      prompt: text,
+    })
+    return parseJSON<Record<string, unknown>>(raw)
   } catch {
     return { topics: ['uncategorized'], type: 'observation' }
   }

--- a/tests/helpers/mcp.ts
+++ b/tests/helpers/mcp.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared MCP JSON-RPC test helper.
+ * Creates a stateful client that tracks the mcp-session-id across calls.
+ */
+
+export type ToolResult = { content: { type: string; text: string }[]; isError?: boolean }
+
+export function createMcpClient(mcpUrl: string, mcpKey: string) {
+  let sessionId: string | undefined
+
+  async function callTool(name: string, args: Record<string, unknown> = {}): Promise<ToolResult> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      "x-brain-key": mcpKey,
+    }
+    if (sessionId) headers["mcp-session-id"] = sessionId
+
+    const res = await fetch(mcpUrl, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name, arguments: args },
+      }),
+    })
+
+    if (!sessionId) {
+      sessionId = res.headers.get("mcp-session-id") ?? undefined
+    }
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "")
+      throw new Error(`MCP request failed: HTTP ${res.status} — ${body.slice(0, 200)}`)
+    }
+
+    const text = await res.text()
+
+    if (text.includes("data:")) {
+      const lines = text.split("\n").filter((l) => l.startsWith("data:"))
+      for (const line of lines.reverse()) {
+        try {
+          const payload = JSON.parse(line.slice(5).trim())
+          if (payload.result) return payload.result
+          if (payload.error) throw new Error(JSON.stringify(payload.error))
+        } catch { /* skip non-JSON lines */ }
+      }
+      throw new Error(`No result in SSE response: ${text.slice(0, 200)}`)
+    }
+
+    const payload = JSON.parse(text)
+    if (payload.error) throw new Error(JSON.stringify(payload.error))
+    return payload.result
+  }
+
+  function getText(result: ToolResult): string {
+    return result.content.map((c) => c.text).join("\n")
+  }
+
+  return { callTool, getText }
+}

--- a/tests/projects-and-scoring.test.ts
+++ b/tests/projects-and-scoring.test.ts
@@ -1,0 +1,177 @@
+/**
+ * score_match + upsert_project MCP tools — integration tests
+ *
+ * Calls the live MCP server over HTTP against the real Supabase database.
+ * Projects array is snapshotted before and restored after to leave no test data.
+ *
+ * Requirements:
+ *   MCP_URL        — e.g. https://agent.yuens.me/mcp (or http://localhost:3000/mcp)
+ *   MCP_ACCESS_KEY — the x-brain-key value
+ *   SUPA_PROJECT_URL + SUPA_SERVICE_ROLE — for snapshot/restore
+ *
+ * Run:
+ *   npm run test:integration
+ */
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { config } from "dotenv";
+
+config({ path: ".env.local" });
+
+const MCP_URL = process.env.MCP_URL ?? `http://localhost:${process.env.PORT ?? 3000}/mcp`;
+const MCP_KEY = process.env.MCP_ACCESS_KEY;
+
+if (!MCP_KEY) {
+  throw new Error("MCP_ACCESS_KEY must be set in .env.local");
+}
+
+const SUPA_URL = process.env.SUPA_PROJECT_URL;
+const SUPA_ROLE_KEY = process.env.SUPA_SERVICE_ROLE;
+if (!SUPA_URL || !SUPA_ROLE_KEY) {
+  throw new Error("SUPA_PROJECT_URL and SUPA_SERVICE_ROLE must be set in .env.local (required for restore)");
+}
+
+// ── MCP JSON-RPC helper ───────────────────────────────────
+
+let sessionId: string | undefined;
+
+async function callTool(name: string, args: Record<string, unknown> = {}) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+    "x-brain-key": MCP_KEY!,
+  };
+  if (sessionId) headers["mcp-session-id"] = sessionId;
+
+  const res = await fetch(MCP_URL, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name, arguments: args },
+    }),
+  });
+
+  if (!sessionId) {
+    sessionId = res.headers.get("mcp-session-id") ?? undefined;
+  }
+
+  const text = await res.text();
+
+  if (text.includes("data:")) {
+    const lines = text.split("\n").filter((l) => l.startsWith("data:"));
+    for (const line of lines.reverse()) {
+      try {
+        const payload = JSON.parse(line.slice(5).trim());
+        if (payload.result) return payload.result;
+        if (payload.error) throw new Error(JSON.stringify(payload.error));
+      } catch { /* skip non-JSON lines */ }
+    }
+    throw new Error(`No result in SSE response: ${text.slice(0, 200)}`);
+  }
+
+  const payload = JSON.parse(text);
+  if (payload.error) throw new Error(JSON.stringify(payload.error));
+  return payload.result;
+}
+
+function getText(result: { content: { type: string; text: string }[]; isError?: boolean }): string {
+  return result.content.map((c) => c.text).join("\n");
+}
+
+// ── Constants ─────────────────────────────────────────────
+
+const PROFILE_ID = "00000000-0000-0000-0000-000000000001";
+const TEST_SLUG = `__test_project_${Date.now()}`;
+
+const SAMPLE_JD = `
+  Senior TypeScript Engineer — 4+ years required.
+  Required: TypeScript, Node.js, REST API design, PostgreSQL.
+  Nice to have: React, Docker.
+  Remote-first, IC role on a small product team.
+`;
+
+// ── Test state ────────────────────────────────────────────
+
+let originalProjects: unknown[];
+
+// ── Tests ─────────────────────────────────────────────────
+
+describe("score_match + upsert_project MCP tools", () => {
+  before(async () => {
+    const { createClient } = await import("@supabase/supabase-js");
+    const supabase = createClient(SUPA_URL!, SUPA_ROLE_KEY!);
+    const { data, error } = await supabase
+      .from("public_profile")
+      .select("projects")
+      .eq("id", PROFILE_ID)
+      .single();
+    if (error || !data) throw new Error(`Could not snapshot projects: ${error?.message}`);
+    originalProjects = data.projects ?? [];
+  });
+
+  after(async () => {
+    const { createClient } = await import("@supabase/supabase-js");
+    const supabase = createClient(SUPA_URL!, SUPA_ROLE_KEY!);
+    const { error } = await supabase
+      .from("public_profile")
+      .update({ projects: originalProjects })
+      .eq("id", PROFILE_ID);
+    if (error) console.warn(`Restore warning: ${error.message}`);
+  });
+
+  it("score_match — returns a valid fit score for a sample JD", async () => {
+    const result = await callTool("score_match", { job_description: SAMPLE_JD });
+    const text = getText(result);
+    assert.ok(!result.isError, `Expected success, got error: ${text}`);
+    assert.match(text, /Fit score:/, "Response should contain fit score");
+    assert.match(text, /Verdict:/, "Response should contain verdict");
+    assert.match(text, /recommended_action|apply|pass/, "Response should contain recommended action");
+  });
+
+  it("upsert_project — inserts a new project when slug is new", async () => {
+    const result = await callTool("upsert_project", {
+      slug: TEST_SLUG,
+      name: "Test Project",
+      description: "A test project for integration testing",
+      problem: "Verifying upsert works",
+      role: "Author",
+      tech: ["TypeScript", "Node.js"],
+      highlights: ["Created for test purposes"],
+      status: "active",
+    });
+    const text = getText(result);
+    assert.ok(!result.isError, `Expected success, got error: ${text}`);
+    assert.match(text, /added/, "Should confirm project was added");
+    assert.match(text, new RegExp(TEST_SLUG), "Should mention the slug");
+  });
+
+  it("upsert_project — merges an existing project without overwriting unspecified fields", async () => {
+    // Only update the url — all other fields from the previous insert should be preserved
+    const result = await callTool("upsert_project", {
+      slug: TEST_SLUG,
+      url: "https://example.com/test",
+    });
+    const text = getText(result);
+    assert.ok(!result.isError, `Expected success, got error: ${text}`);
+    assert.match(text, /updated/, "Should confirm project was updated");
+
+    // Verify the merge — name and description should still be present
+    const { createClient } = await import("@supabase/supabase-js");
+    const supabase = createClient(SUPA_URL!, SUPA_ROLE_KEY!);
+    const { data, error } = await supabase
+      .from("public_profile")
+      .select("projects")
+      .eq("id", PROFILE_ID)
+      .single();
+    assert.ok(!error && data, "Should be able to read profile");
+    const project = (data.projects as { slug: string; name?: string; url?: string }[])
+      .find((p) => p.slug === TEST_SLUG);
+    assert.ok(project, "Test project should still exist");
+    assert.equal(project.name, "Test Project", "Name should be preserved after merge");
+    assert.equal(project.url, "https://example.com/test", "URL should be updated");
+  });
+});

--- a/tests/projects-and-scoring.test.ts
+++ b/tests/projects-and-scoring.test.ts
@@ -2,7 +2,7 @@
  * score_match + upsert_project MCP tools — integration tests
  *
  * Calls the live MCP server over HTTP against the real Supabase database.
- * Projects array is snapshotted before and restored after to leave no test data.
+ * Projects array and updated_at are snapshotted before and restored after.
  *
  * Requirements:
  *   MCP_URL        — e.g. https://agent.yuens.me/mcp (or http://localhost:3000/mcp)
@@ -16,6 +16,7 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { config } from "dotenv";
+import { createMcpClient } from "./helpers/mcp.js";
 
 config({ path: ".env.local" });
 
@@ -32,55 +33,7 @@ if (!SUPA_URL || !SUPA_ROLE_KEY) {
   throw new Error("SUPA_PROJECT_URL and SUPA_SERVICE_ROLE must be set in .env.local (required for restore)");
 }
 
-// ── MCP JSON-RPC helper ───────────────────────────────────
-
-let sessionId: string | undefined;
-
-async function callTool(name: string, args: Record<string, unknown> = {}) {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    Accept: "application/json, text/event-stream",
-    "x-brain-key": MCP_KEY!,
-  };
-  if (sessionId) headers["mcp-session-id"] = sessionId;
-
-  const res = await fetch(MCP_URL, {
-    method: "POST",
-    headers,
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: 1,
-      method: "tools/call",
-      params: { name, arguments: args },
-    }),
-  });
-
-  if (!sessionId) {
-    sessionId = res.headers.get("mcp-session-id") ?? undefined;
-  }
-
-  const text = await res.text();
-
-  if (text.includes("data:")) {
-    const lines = text.split("\n").filter((l) => l.startsWith("data:"));
-    for (const line of lines.reverse()) {
-      try {
-        const payload = JSON.parse(line.slice(5).trim());
-        if (payload.result) return payload.result;
-        if (payload.error) throw new Error(JSON.stringify(payload.error));
-      } catch { /* skip non-JSON lines */ }
-    }
-    throw new Error(`No result in SSE response: ${text.slice(0, 200)}`);
-  }
-
-  const payload = JSON.parse(text);
-  if (payload.error) throw new Error(JSON.stringify(payload.error));
-  return payload.result;
-}
-
-function getText(result: { content: { type: string; text: string }[]; isError?: boolean }): string {
-  return result.content.map((c) => c.text).join("\n");
-}
+const { callTool, getText } = createMcpClient(MCP_URL, MCP_KEY);
 
 // ── Constants ─────────────────────────────────────────────
 
@@ -96,7 +49,9 @@ const SAMPLE_JD = `
 
 // ── Test state ────────────────────────────────────────────
 
+let snapshotTaken = false;
 let originalProjects: unknown[];
+let originalUpdatedAt: string;
 
 // ── Tests ─────────────────────────────────────────────────
 
@@ -106,19 +61,22 @@ describe("score_match + upsert_project MCP tools", () => {
     const supabase = createClient(SUPA_URL!, SUPA_ROLE_KEY!);
     const { data, error } = await supabase
       .from("public_profile")
-      .select("projects")
+      .select("projects, updated_at")
       .eq("id", PROFILE_ID)
       .single();
-    if (error || !data) throw new Error(`Could not snapshot projects: ${error?.message}`);
+    if (error || !data) throw new Error(`Could not snapshot profile: ${error?.message}`);
     originalProjects = data.projects ?? [];
+    originalUpdatedAt = data.updated_at;
+    snapshotTaken = true;
   });
 
   after(async () => {
+    if (!snapshotTaken) return;
     const { createClient } = await import("@supabase/supabase-js");
     const supabase = createClient(SUPA_URL!, SUPA_ROLE_KEY!);
     const { error } = await supabase
       .from("public_profile")
-      .update({ projects: originalProjects })
+      .update({ projects: originalProjects, updated_at: originalUpdatedAt })
       .eq("id", PROFILE_ID);
     if (error) console.warn(`Restore warning: ${error.message}`);
   });
@@ -129,7 +87,7 @@ describe("score_match + upsert_project MCP tools", () => {
     assert.ok(!result.isError, `Expected success, got error: ${text}`);
     assert.match(text, /Fit score:/, "Response should contain fit score");
     assert.match(text, /Verdict:/, "Response should contain verdict");
-    assert.match(text, /recommended_action|apply|pass/, "Response should contain recommended action");
+    assert.match(text, /apply|pass/, "Response should contain recommended action");
   });
 
   it("upsert_project — inserts a new project when slug is new", async () => {
@@ -150,7 +108,6 @@ describe("score_match + upsert_project MCP tools", () => {
   });
 
   it("upsert_project — merges an existing project without overwriting unspecified fields", async () => {
-    // Only update the url — all other fields from the previous insert should be preserved
     const result = await callTool("upsert_project", {
       slug: TEST_SLUG,
       url: "https://example.com/test",
@@ -159,7 +116,7 @@ describe("score_match + upsert_project MCP tools", () => {
     assert.ok(!result.isError, `Expected success, got error: ${text}`);
     assert.match(text, /updated/, "Should confirm project was updated");
 
-    // Verify the merge — name and description should still be present
+    // Verify the merge — name should be preserved, url should be new
     const { createClient } = await import("@supabase/supabase-js");
     const supabase = createClient(SUPA_URL!, SUPA_ROLE_KEY!);
     const { data, error } = await supabase

--- a/tests/update-profile.test.ts
+++ b/tests/update-profile.test.ts
@@ -15,6 +15,7 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { config } from "dotenv";
+import { createMcpClient } from "./helpers/mcp.js";
 
 config({ path: ".env.local" });
 
@@ -31,55 +32,7 @@ if (!SUPA_URL || !SUPA_ROLE_KEY) {
   throw new Error("SUPA_PROJECT_URL and SUPA_SERVICE_ROLE must be set in .env.local (required for restore)");
 }
 
-// ── MCP JSON-RPC helper ───────────────────────────────────
-
-let sessionId: string | undefined;
-
-async function callTool(name: string, args: Record<string, unknown> = {}) {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    Accept: "application/json, text/event-stream",
-    "x-brain-key": MCP_KEY!,
-  };
-  if (sessionId) headers["mcp-session-id"] = sessionId;
-
-  const res = await fetch(MCP_URL, {
-    method: "POST",
-    headers,
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: 1,
-      method: "tools/call",
-      params: { name, arguments: args },
-    }),
-  });
-
-  if (!sessionId) {
-    sessionId = res.headers.get("mcp-session-id") ?? undefined;
-  }
-
-  const text = await res.text();
-
-  if (text.includes("data:")) {
-    const lines = text.split("\n").filter((l) => l.startsWith("data:"));
-    for (const line of lines.reverse()) {
-      try {
-        const payload = JSON.parse(line.slice(5).trim());
-        if (payload.result) return payload.result;
-        if (payload.error) throw new Error(JSON.stringify(payload.error));
-      } catch { /* skip */ }
-    }
-    throw new Error(`No result in SSE response: ${text.slice(0, 200)}`);
-  }
-
-  const payload = JSON.parse(text);
-  if (payload.error) throw new Error(JSON.stringify(payload.error));
-  return payload.result;
-}
-
-function getText(result: { content: { type: string; text: string }[] }): string {
-  return result.content.map((c) => c.text).join("\n");
-}
+const { callTool, getText } = createMcpClient(MCP_URL, MCP_KEY);
 
 // ── Tests ─────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Replaces raw `fetch()` calls in `getEmbedding` and `extractMetadata` with Vercel AI SDK (`embed()` + `generateText()`) via a `createOpenAI` adapter pointed at OpenRouter — consistent with how `scoreMatch` and all other routes call the AI layer
- Removes `OPENROUTER_BASE` constant and direct fetch boilerplate from mcp.ts
- Adds `tests/projects-and-scoring.test.ts` with integration tests for `score_match` and `upsert_project` tools, covering: new insert, merge without overwrite, and fit score validation
- Adds `update-profile.test.ts` and the new test file to the `test:integration` script

## Test plan
- [ ] `capture_thought` still generates embeddings and extracts metadata correctly
- [ ] `search_thoughts` still returns semantically relevant results
- [ ] `score_match` returns fit score + verdict + breakdown for a sample JD
- [ ] `upsert_project` inserts a new project when slug is new
- [ ] `upsert_project` merges fields on existing slug without overwriting unspecified fields
- [ ] `npm run test:integration` runs all three test files