### PR TITLE
refactor(ai): consolidate all providers to OpenRouter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,9 @@
 # OpenRouter — openrouter.ai/keys
 OPENROUTER_API_KEY=your_openrouter_api_key_here
-AI_MODEL=anthropic/claude-haiku-4-5-20251001   # default model (any OpenRouter model ID)
-MATCH_MODEL=anthropic/claude-sonnet-4-6         # used for job-match scoring
+# default model (any OpenRouter model ID)
+AI_MODEL=anthropic/claude-haiku-4-5-20251001
+# used for job-match scoring
+MATCH_MODEL=anthropic/claude-sonnet-4-6
 
 # Supabase
 SUPA_PROJECT_URL=https://your-project-ref.supabase.co

--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,7 @@
-# AI Provider — anthropic | openai | google (default: anthropic)
-AI_PROVIDER=anthropic
-AI_MODEL=claude-haiku-4-5-20251001
-MATCH_MODEL=claude-sonnet-4-6
-
-# Provider API keys — only the one matching AI_PROVIDER is required
-ANTHROPIC_API_KEY=your_anthropic_api_key_here
-OPENAI_API_KEY=your_openai_api_key_here
-GOOGLE_GENERATIVE_AI_API_KEY=your_google_api_key_here
+# OpenRouter — openrouter.ai/keys
+OPENROUTER_API_KEY=your_openrouter_api_key_here
+AI_MODEL=anthropic/claude-haiku-4-5-20251001   # default model (any OpenRouter model ID)
+MATCH_MODEL=anthropic/claude-sonnet-4-6         # used for job-match scoring
 
 # Supabase
 SUPA_PROJECT_URL=https://your-project-ref.supabase.co
@@ -15,7 +10,6 @@ SUPA_SERVICE_ROLE=your_supabase_service_role_key_here
 SUPABASE_PROJECT_REF=your-project-ref       # from dashboard URL: supabase.com/dashboard/project/<ref>
 SUPABASE_DB_PASSWORD=your-db-password       # Project Settings → Database → Connection string
 # OB1 (Open Brain) MCP
-OPENROUTER_API_KEY=your_openrouter_api_key_here   # openrouter.ai/keys — used for embeddings + metadata extraction
 MCP_ACCESS_KEY=your_64_char_hex_key_here          # generate: openssl rand -hex 32 (or PowerShell equivalent)
 SUPABASE_MCP_URL=https://your-project-ref.supabase.co/functions/v1/open-brain-mcp  # used by npm run test:integration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-04-01 — refactor(ai): consolidate all providers to OpenRouter, remove @ai-sdk/anthropic and @ai-sdk/google
+
 - 2026-03-30 — refactor(mcp): normalize extractMetadata + getEmbedding to Vercel AI SDK, add score_match + upsert_project integration tests
 
 - 2026-03-30 — refactor(match): extract scoreMatch to lib, register score_match + upsert_project MCP tools

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,13 @@
 {
   "name": "resume-agent",
-  "version": "0.1.29",
+  "version": "0.1.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.1.29",
+      "version": "0.1.31",
       "dependencies": {
-        "@ai-sdk/anthropic": "^1.2.9",
-        "@ai-sdk/google": "^1.2.16",
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",
         "@hono/zod-validator": "^0.4.3",
@@ -30,38 +28,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/@ai-sdk/anthropic": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-1.2.12.tgz",
-      "integrity": "sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.0.0"
-      }
-    },
-    "node_modules/@ai-sdk/google": {
-      "version": "1.2.22",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-1.2.22.tgz",
-      "integrity": "sha512-Ppxu3DIieF1G9pyQ5O1Z646GYR0gkC57YdBqXJ82qvCdhEhZHu0TWhmnOoeIWe2olSbuDeoOY+MfJrW8dzS3Hw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.0.0"
       }
     },
     "node_modules/@ai-sdk/openai": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "private": true,
   "type": "module",
   "engines": {
@@ -19,8 +19,6 @@
     "test:integration": "tsx --env-file=.env.local --test tests/pipeline.test.ts tests/update-profile.test.ts tests/projects-and-scoring.test.ts"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^1.2.9",
-    "@ai-sdk/google": "^1.2.16",
     "@ai-sdk/openai": "^1.3.19",
     "@hono/mcp": "^0.1.1",
     "@hono/zod-validator": "^0.4.3",

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,23 +1,17 @@
 import './env.js'
-import { anthropic } from '@ai-sdk/anthropic'
-import { openai } from '@ai-sdk/openai'
-import { google } from '@ai-sdk/google'
+import { createOpenAI } from '@ai-sdk/openai'
 import type { LanguageModel } from 'ai'
 
-const PROVIDER = process.env.AI_PROVIDER ?? 'anthropic'
-const MODEL = process.env.AI_MODEL ?? 'claude-haiku-4-5-20251001'
+const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY
+if (!OPENROUTER_API_KEY) throw new Error('Missing OPENROUTER_API_KEY')
+
+export const MODEL = process.env.AI_MODEL ?? 'anthropic/claude-haiku-4-5-20251001'
+
+export const openrouter = createOpenAI({
+  baseURL: 'https://openrouter.ai/api/v1',
+  apiKey: OPENROUTER_API_KEY,
+})
 
 export function getModel(modelOverride?: string): LanguageModel {
-  const model = modelOverride ?? MODEL
-  switch (PROVIDER) {
-    case 'openai':
-      return openai(model)
-    case 'google':
-      return google(model)
-    case 'anthropic':
-    default:
-      return anthropic(model)
-  }
+  return openrouter(modelOverride ?? MODEL)
 }
-
-export { PROVIDER, MODEL }

--- a/src/lib/score-match.ts
+++ b/src/lib/score-match.ts
@@ -4,7 +4,7 @@ import { supabase } from './supabase.js'
 import { parseJSON } from './parse-json.js'
 import type { MatchResponse, MatchScoring } from '../types.js'
 
-const MATCH_MODEL = process.env.MATCH_MODEL ?? 'claude-sonnet-4-6'
+const MATCH_MODEL = process.env.MATCH_MODEL ?? 'anthropic/claude-sonnet-4-6'
 
 export class ProfileNotFoundError extends Error {
   constructor() { super('Profile not found') }

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -5,24 +5,17 @@ import { Hono, type Context } from 'hono'
 import { z } from 'zod'
 import { jwtVerify } from 'jose'
 import { generateText, embed } from 'ai'
-import { createOpenAI } from '@ai-sdk/openai'
+import { openrouter } from '../lib/ai.js'
 import { supabase } from '../lib/supabase.js'
 import { parseJSON } from '../lib/parse-json.js'
 import { scoreMatch } from '../lib/score-match.js'
 import type { Project } from '../types.js'
 
-const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY
 const MCP_ACCESS_KEY = process.env.MCP_ACCESS_KEY
 const JWT_SECRET = process.env.JWT_SECRET
 const jwtSecretBytes = JWT_SECRET ? new TextEncoder().encode(JWT_SECRET) : null
 
-if (!OPENROUTER_API_KEY) throw new Error('Missing OPENROUTER_API_KEY')
 if (!MCP_ACCESS_KEY) throw new Error('Missing MCP_ACCESS_KEY')
-
-const openrouter = createOpenAI({
-  baseURL: 'https://openrouter.ai/api/v1',
-  apiKey: OPENROUTER_API_KEY,
-})
 
 // ── Helpers ───────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Replaces multi-provider setup (`@ai-sdk/anthropic`, `@ai-sdk/google`, `AI_PROVIDER` env var) with a single OpenRouter instance
- Shared `openrouter` client exported from `src/lib/ai.ts`; `mcp.ts` no longer creates its own duplicate instance
- Default model IDs updated to OpenRouter format (`anthropic/claude-haiku-4-5-20251001`, `anthropic/claude-sonnet-4-6`)
- `.env.example` simplified to a single `OPENROUTER_API_KEY`

## Test plan
- [ ] Set `OPENROUTER_API_KEY` in `.env.local`, remove `AI_PROVIDER` and update `AI_MODEL` to `anthropic/claude-haiku-4-5-20251001`
- [ ] Run `npm run dev` — server starts without errors
- [ ] Run `npm run test:integration` — pipeline + scoring tests pass
- [ ] Verify `/query` and `/resume` endpoints respond via OpenRouter