### PR TITLE
feat(query): streaming support, owner rate-limit bypass, /try demo redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-04-01 — feat(query): add streaming support and owner rate-limit bypass, add /try demo redirect
+
 - 2026-04-01 — refactor(ai): consolidate all providers to OpenRouter, remove @ai-sdk/anthropic and @ai-sdk/google
 
 - 2026-03-30 — refactor(mcp): normalize extractMetadata + getEmbedding to Vercel AI SDK, add score_match + upsert_project integration tests

--- a/README.md
+++ b/README.md
@@ -78,18 +78,24 @@ Full structured profile snapshot. Skills, experience, projects, education. No Cl
 ### `GET /availability`
 Current job-seeking status, preferred roles, start date, contact links.
 
-### `POST /query`
-Natural language question → structured JSON answer powered by Claude.
+### `GET /try`
+Demo shortcut — redirects to `/query?question=Tell+me+about+yourself&stream=true`. Shareable CTA for humans and AI systems to see the agent in action.
+
+### `POST /query` · `GET /query?question=`
+Natural language question → structured JSON answer, or streaming plain text.
 
 Request:
 ```json
 {
   "question": "Has this person shipped production systems using TypeScript?",
-  "context": "ATS screening for a senior backend role"
+  "context": "ATS screening for a senior backend role",
+  "stream": false
 }
 ```
 
-Response:
+Set `"stream": true` (or `?stream=true` on GET) to receive a plain text chunked response (`Content-Type: text/plain`) instead of JSON — useful for demo surfaces and human-readable interfaces.
+
+Response (default, `stream: false`):
 ```json
 {
   "answer": "...",
@@ -97,7 +103,7 @@ Response:
   "sources": ["experience.company_name", "skills.languages"],
   "follow_up_suggestions": ["..."],
   "contact": { "email": "...", "calendly": "..." },
-  "meta": { "model": "claude-haiku-4-5-20251001", "latency_ms": 740 }
+  "meta": { "model": "anthropic/claude-haiku-4-5-20251001", "latency_ms": 740 }
 }
 ```
 
@@ -206,7 +212,7 @@ Then in Claude:
 | Layer | Technology |
 |---|---|
 | API framework | Hono (TypeScript) |
-| AI | Anthropic SDK — Haiku (query/resume) + Sonnet (match) |
+| AI | Vercel AI SDK via OpenRouter — Haiku (query/resume) + Sonnet (match) |
 | Database | Supabase (Postgres + pgvector) |
 | Private interface | MCP (Model Context Protocol) via OB1 |
 | Validation | Zod |
@@ -218,7 +224,7 @@ Then in Claude:
 ## Security model
 
 - All secrets in `.env.local`, never committed
-- `public_profile` table: read-only, no auth required, rate-limited by IP
+- `public_profile` table: read-only, no auth required, rate-limited to 30 req/min per IP — bypassed for requests carrying a valid `Authorization: Bearer <API_KEY>` header
 - `/resume` endpoint: when `AUTH_MODE=key`, requires `Authorization: Bearer <key>` header; when `AUTH_MODE=open` (default in `.env.example`), it is publicly accessible
 - MCP server: OAuth 2.0 Client Credentials (claude.ai connector) or `x-brain-key` header (direct API / Claude Desktop)
 - OAuth endpoints: `/authorize`, `/token`, `/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource` (RFC 8414 + RFC 9728)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { serve } from '@hono/node-server'
 import { Hono, type Context } from 'hono'
 import { cors } from 'hono/cors'
 import { logger } from 'hono/logger'
+import crypto from 'crypto'
 
 import infoRoute from './routes/info.js'
 import availabilityRoute from './routes/availability.js'
@@ -13,6 +14,12 @@ import profileRoute from './routes/profile.js'
 import projectsRoute from './routes/projects.js'
 import mcpRoute from './routes/mcp.js'
 import oauthRoute from './routes/oauth.js'
+
+function timingSafeEqual(a: string, b: string): boolean {
+  const aDigest = crypto.createHash('sha256').update(a).digest()
+  const bDigest = crypto.createHash('sha256').update(b).digest()
+  return crypto.timingSafeEqual(aDigest, bDigest)
+}
 
 const app = new Hono({ strict: false })
 
@@ -45,8 +52,10 @@ app.use('*', async (c, next) => {
   if (c.req.method === 'OPTIONS') return next()
 
   // Owner bypass — valid API_KEY skips rate limiting entirely
-  const token = c.req.header('Authorization')?.replace('Bearer ', '')
-  if (token && token === process.env.API_KEY) return next()
+  const authHeader = c.req.header('Authorization') ?? ''
+  const match = /^bearer\s+(.+)$/i.exec(authHeader)
+  const apiKey = process.env.API_KEY
+  if (match && apiKey && timingSafeEqual(match[1], apiKey)) return next()
 
   const ip = getClientIp(c)
   const now = Date.now()

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,10 @@ app.use('*', async (c, next) => {
   // Skip OPTIONS preflights — don't count them toward the rate limit
   if (c.req.method === 'OPTIONS') return next()
 
+  // Owner bypass — valid API_KEY skips rate limiting entirely
+  const token = c.req.header('Authorization')?.replace('Bearer ', '')
+  if (token && token === process.env.API_KEY) return next()
+
   const ip = getClientIp(c)
   const now = Date.now()
   const windowMs = 60_000
@@ -68,6 +72,7 @@ app.route('/match', matchRoute)
 app.route('/resume', resumeRoute)
 app.route('/.well-known/agent.json', agentCardRoute)
 app.get('/.well-known/agent-card.json', (c) => c.redirect('/.well-known/agent.json', 301))
+app.get('/try', (c) => c.redirect('/query?question=Tell+me+about+yourself&stream=true', 302))
 app.route('/profile', profileRoute)
 app.route('/projects', projectsRoute)
 app.route('/mcp', mcpRoute)
@@ -80,7 +85,7 @@ const port = parseInt(process.env.PORT ?? '3000')
 serve({ fetch: app.fetch, port }, () => {
   const authMode = process.env.AUTH_MODE ?? 'open'
   console.log(`resume-agent running on http://localhost:${port}`)
-  console.log('[routes] GET /, /info, /availability, /projects, /projects/:slug, /.well-known/agent.json')
+  console.log('[routes] GET /, /info, /availability, /projects, /projects/:slug, /try, /.well-known/agent.json')
   console.log(`[routes] POST /query, /match | POST /resume (auth: ${authMode}) | PATCH /profile (auth: key)`)
   console.log('[middleware] rate-limit: 30 req/min per IP (excludes OPTIONS)')
 })

--- a/src/routes/query.ts
+++ b/src/routes/query.ts
@@ -118,9 +118,18 @@ app.get('/', async (c) => {
     method: 'POST',
     also_supports: 'GET ?question=',
     description: 'Ask a natural language question about this candidate.',
-    body: { question: 'string (required)', context: 'string (optional, e.g. "ATS", "recruiter", "ai-agent")', stream: 'boolean (optional, default false)' },
+    body: {
+      question: 'string (required)',
+      context: 'string (optional, e.g. "ATS", "recruiter", "ai-agent")',
+      stream: 'boolean (optional, default false)',
+    },
+    response: {
+      when_stream_false: 'application/json — { answer, confidence, sources, follow_up_suggestions, contact, meta }',
+      when_stream_true: 'text/plain — streamed plain text chunks; response body is not JSON in this mode',
+    },
     get_usage: 'GET /query?question=Your+question+here&stream=true',
-    example: { question: 'What is your experience with TypeScript?' },
+    example: { question: 'What is your experience with TypeScript?', stream: false },
+    example_streaming: { question: 'What is your experience with TypeScript?', stream: true },
   })
 })
 

--- a/src/routes/query.ts
+++ b/src/routes/query.ts
@@ -3,7 +3,7 @@ import { zValidator } from '@hono/zod-validator'
 import { z } from 'zod'
 import { supabase } from '../lib/supabase.js'
 import { getModel, MODEL } from '../lib/ai.js'
-import { generateText } from 'ai'
+import { generateText, streamText } from 'ai'
 import { parseJSON } from '../lib/parse-json.js'
 import { detectCaller, callerContextFromQuery } from '../lib/detect-caller.js'
 import type { QueryResponse } from '../types.js'
@@ -15,7 +15,7 @@ const schema = z.object({
   context: z.string().optional(),
 })
 
-async function handleQuery(c: Context, question: string, context?: string): Promise<Response> {
+async function handleQuery(c: Context, question: string, context?: string, stream = false): Promise<Response> {
   const headerCaller = detectCaller(c)
   const queryCaller = callerContextFromQuery(question)
   const caller = headerCaller.type !== 'unknown'
@@ -32,6 +32,25 @@ async function handleQuery(c: Context, question: string, context?: string): Prom
 
   if (error || !profile) {
     return c.json({ error: 'Profile not found' }, 404)
+  }
+
+  const prompt = `Profile data:
+${JSON.stringify(profile, null, 2)}
+
+Question: ${question}`
+
+  if (stream) {
+    const result = streamText({
+      model: getModel(),
+      maxTokens: 1024,
+      system: `You are an AI agent representing a professional candidate. Answer questions about their profile accurately and honestly. Never fabricate credentials or inflate qualifications.
+
+Caller context: ${callerHint}
+Tailor your response accordingly — adjust tone, verbosity, and framing to suit the caller type.
+Respond in clear, direct prose.`,
+      prompt,
+    })
+    return result.toTextStreamResponse()
   }
 
   const start = Date.now()
@@ -53,11 +72,6 @@ Confidence levels:
 - high: directly supported by profile data
 - medium: inferred from adjacent data
 - low: not well-supported, answering with caveats`
-
-  const prompt = `Profile data:
-${JSON.stringify(profile, null, 2)}
-
-Question: ${question}`
 
   const { text: raw } = await generateText({
     model: getModel(),
@@ -95,7 +109,8 @@ app.get('/', async (c) => {
     if (!result.success) {
       return c.json({ error: 'Invalid query', details: result.error.format() }, 400)
     }
-    return handleQuery(c, result.data.question, result.data.context)
+    const stream = c.req.query('stream') === 'true'
+    return handleQuery(c, result.data.question, result.data.context, stream)
   }
   const url = new URL(c.req.url)
   return c.json({
@@ -103,15 +118,15 @@ app.get('/', async (c) => {
     method: 'POST',
     also_supports: 'GET ?question=',
     description: 'Ask a natural language question about this candidate.',
-    body: { question: 'string (required)', context: 'string (optional, e.g. "ATS", "recruiter", "ai-agent")' },
-    get_usage: 'GET /query?question=Your+question+here',
+    body: { question: 'string (required)', context: 'string (optional, e.g. "ATS", "recruiter", "ai-agent")', stream: 'boolean (optional, default false)' },
+    get_usage: 'GET /query?question=Your+question+here&stream=true',
     example: { question: 'What is your experience with TypeScript?' },
   })
 })
 
-app.post('/', zValidator('json', schema), async (c) => {
-  const { question, context } = c.req.valid('json')
-  return handleQuery(c, question, context)
+app.post('/', zValidator('json', schema.extend({ stream: z.boolean().optional() })), async (c) => {
+  const { question, context, stream } = c.req.valid('json')
+  return handleQuery(c, question, context, stream ?? false)
 })
 
 export default app


### PR DESCRIPTION
## Summary
- `GET /query?stream=true` and `POST /query` with `"stream": true` now stream the answer as plain text via SSE using Vercel AI SDK `streamText`
- `GET /try` → redirects to `/query?question=Tell+me+about+yourself&stream=true` for a live demo CTA (e.g. LinkedIn posts)
- Requests carrying `Authorization: Bearer <API_KEY>` bypass the 30 req/min rate limit entirely (owner use)
- Existing JSON response path on `/query` is unchanged — fully backward compatible

## Test plan
- [ ] `curl "agent.yuens.me/try"` follows redirect and streams a live answer
- [ ] `GET /query?question=What+are+your+skills&stream=true` returns chunked plain text
- [ ] `POST /query` with `{"question":"...", "stream": true}` streams correctly
- [ ] `POST /query` without `stream` still returns structured JSON
- [ ] Requests with valid `Authorization: Bearer <API_KEY>` are not rate-limited after 30 req/min