### PR TITLE
fix(config): correct OpenRouter model IDs to dot-notation format

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
 # OpenRouter — openrouter.ai/keys
 OPENROUTER_API_KEY=your_openrouter_api_key_here
 # default model (any OpenRouter model ID)
-AI_MODEL=anthropic/claude-haiku-4-5-20251001
+AI_MODEL=anthropic/claude-haiku-4.5
 # used for job-match scoring
-MATCH_MODEL=anthropic/claude-sonnet-4-6
+MATCH_MODEL=anthropic/claude-sonnet-4.6
 
 # Supabase
 SUPA_PROJECT_URL=https://your-project-ref.supabase.co

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-04-01 — fix(config): correct OpenRouter model IDs to dot-notation format (claude-haiku-4.5, claude-sonnet-4.6)
+
 - 2026-04-01 — feat(query): add streaming support and owner rate-limit bypass, add /try demo redirect
 
 - 2026-04-01 — refactor(ai): consolidate all providers to OpenRouter, remove @ai-sdk/anthropic and @ai-sdk/google

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Response (default, `stream: false`):
   "sources": ["experience.company_name", "skills.languages"],
   "follow_up_suggestions": ["..."],
   "contact": { "email": "...", "calendly": "..." },
-  "meta": { "model": "anthropic/claude-haiku-4-5-20251001", "latency_ms": 740 }
+  "meta": { "model": "anthropic/claude-haiku-4.5", "latency_ms": 740 }
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -5,7 +5,7 @@ import type { LanguageModel } from 'ai'
 const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY
 if (!OPENROUTER_API_KEY) throw new Error('Missing OPENROUTER_API_KEY')
 
-export const MODEL = process.env.AI_MODEL ?? 'anthropic/claude-haiku-4-5-20251001'
+export const MODEL = process.env.AI_MODEL ?? 'anthropic/claude-haiku-4.5'
 
 export const openrouter = createOpenAI({
   baseURL: 'https://openrouter.ai/api/v1',

--- a/src/lib/score-match.ts
+++ b/src/lib/score-match.ts
@@ -4,7 +4,7 @@ import { supabase } from './supabase.js'
 import { parseJSON } from './parse-json.js'
 import type { MatchResponse, MatchScoring } from '../types.js'
 
-const MATCH_MODEL = process.env.MATCH_MODEL ?? 'anthropic/claude-sonnet-4-6'
+const MATCH_MODEL = process.env.MATCH_MODEL ?? 'anthropic/claude-sonnet-4.6'
 
 export class ProfileNotFoundError extends Error {
   constructor() { super('Profile not found') }


### PR DESCRIPTION
## Summary
- `anthropic/claude-haiku-4-5-20251001` → `anthropic/claude-haiku-4.5`
- `anthropic/claude-sonnet-4-6` → `anthropic/claude-sonnet-4.6`
- Updated in `src/lib/ai.ts`, `src/lib/score-match.ts`, `.env.example`, and `README.md`
- Root cause: OpenRouter uses dot-notation for model versions, not hyphen-notation

## Test plan
- [ ] `GET /query?question=Tell+me+about+yourself` returns 200 with valid JSON
- [ ] `GET /try` streams a live response
- [ ] `POST /match` with a job description returns a fit score (uses sonnet)
- [ ] Update Railway `AI_MODEL=anthropic/claude-haiku-4.5` and `MATCH_MODEL=anthropic/claude-sonnet-4.6`