### PR TITLE
feat(resume): configurable RESUME_MODEL, default gpt-4o-mini, 4096 max tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ OPENROUTER_API_KEY=your_openrouter_api_key_here
 AI_MODEL=anthropic/claude-haiku-4.5
 # used for job-match scoring
 MATCH_MODEL=anthropic/claude-sonnet-4.6
+# used for resume generation (needs strong JSON output, gpt-4o-mini is cost-effective)
+RESUME_MODEL=openai/gpt-4o-mini
 
 # Supabase
 SUPA_PROJECT_URL=https://your-project-ref.supabase.co

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- 2026-04-01 — feat(resume): use configurable RESUME_MODEL env var, default to gpt-4o-mini, increase maxTokens to 4096
+- 2026-04-01 — feat(resume): use configurable RESUME_MODEL env var, default to openai/gpt-4o-mini, increase maxTokens to 4096
 
 - 2026-04-01 — fix(config): correct OpenRouter model IDs to dot-notation format (claude-haiku-4.5, claude-sonnet-4.6)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-04-01 — feat(resume): use configurable RESUME_MODEL env var, default to gpt-4o-mini, increase maxTokens to 4096
+
 - 2026-04-01 — fix(config): correct OpenRouter model IDs to dot-notation format (claude-haiku-4.5, claude-sonnet-4.6)
 
 - 2026-04-01 — feat(query): add streaming support and owner rate-limit bypass, add /try demo redirect

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/routes/resume.ts
+++ b/src/routes/resume.ts
@@ -4,10 +4,10 @@ import { z } from 'zod'
 import { supabase } from '../lib/supabase.js'
 import { getModel } from '../lib/ai.js'
 import { generateText } from 'ai'
-
-const RESUME_MODEL = process.env.RESUME_MODEL ?? 'openai/gpt-4o-mini'
 import { parseJSON } from '../lib/parse-json.js'
 import type { ResumeResponse } from '../types.js'
+
+const RESUME_MODEL = process.env.RESUME_MODEL ?? 'openai/gpt-4o-mini'
 
 const app = new Hono()
 

--- a/src/routes/resume.ts
+++ b/src/routes/resume.ts
@@ -4,6 +4,8 @@ import { z } from 'zod'
 import { supabase } from '../lib/supabase.js'
 import { getModel } from '../lib/ai.js'
 import { generateText } from 'ai'
+
+const RESUME_MODEL = process.env.RESUME_MODEL ?? 'openai/gpt-4o-mini'
 import { parseJSON } from '../lib/parse-json.js'
 import type { ResumeResponse } from '../types.js'
 
@@ -65,8 +67,8 @@ Target job description:
 ${job_description}`
 
   const { text: raw } = await generateText({
-    model: getModel(),
-    maxTokens: 2048,
+    model: getModel(RESUME_MODEL),
+    maxTokens: 4096,
     system: systemPrompt,
     prompt: userMessage,
   })


### PR DESCRIPTION
## Summary
- Adds `RESUME_MODEL` env var to control which model generates resumes (defaults to `openai/gpt-4o-mini`)
- Increases `maxTokens` from 2048 → 4096 to prevent truncation on full resume JSON
- `gpt-4o-mini` is ~20x cheaper than Sonnet and reliable for structured JSON output
- Model remains swappable via env var without code changes

## Test plan
- [ ] Deploy to Railway with `RESUME_MODEL=openai/gpt-4o-mini`
- [ ] `POST /resume` with a job description returns valid structured JSON
- [ ] No truncation errors on full profile + JD input
- [ ] Swap `RESUME_MODEL` to another OpenRouter model and verify it respects the override