### PR TITLE
docs(readme): clean up architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ Cursor, etc.    POST /query
 Key-protected   GET /info
 Full read/write GET /availability
                 GET /.well-known/agent.json
-                GET /.well-known/agent-card.json
+                GET /.well-known/agent-card.json (→ agent.json, 301)
                 POST /match
-                POST /resume
-                Read-only, rate-limited
+                POST /resume (owner-only, key-protected)
+                Rate-limited (public endpoints)
 ```
 
 ### Data tiers

--- a/README.md
+++ b/README.md
@@ -39,22 +39,22 @@ The public endpoint is not a portfolio site. It is not a chatbot. It is an agent
   thoughts table (private)
   public_profile table (read-only)
             |
-     -------+----------+-------
-     |                 |               |
-     v                 v               v
-MCP Server      job-hunt-agent    Resume Agent API
-(PRIVATE)        (LOCAL CLI)         (PUBLIC)
+     -------+-------
+     |               |
+     v               v
+MCP Server      Resume Agent API
+(PRIVATE)       (PUBLIC)
 
-Your AI tools   npm run apply     Employer AI / QR scan
-Claude Desktop  --jd <url>        GET /try  (→ /query demo)
-Cursor, etc.    --to <email>      POST /query
-Key-protected   --send            GET /info
-Full read/write                   GET /availability
-                POST /match       GET /.well-known/agent.json
-                POST /resume      GET /.well-known/agent-card.json
-                OB1 log           POST /match
-                                  POST /resume
-                                  Read-only, rate-limited
+Your AI tools   Employer AI / QR scan
+Claude Desktop  GET /try  (→ /query demo)
+Cursor, etc.    POST /query
+Key-protected   GET /info
+Full read/write GET /availability
+                GET /.well-known/agent.json
+                GET /.well-known/agent-card.json
+                POST /match
+                POST /resume
+                Read-only, rate-limited
 ```
 
 ### Data tiers


### PR DESCRIPTION
## Summary

- Reverted job-hunt-agent from the diagram — it's a private consumer, not part of this repo's architecture
- Added missing public endpoints: `GET /try` and `GET /.well-known/agent-card.json`