### PR TITLE
feat(api): add robots.txt allowlisting AI crawlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-04-01 — feat(api): add robots.txt allowlisting AI crawlers (GPTBot, ClaudeBot, Grok, etc.)
+
 - 2026-04-01 — feat(resume): use configurable RESUME_MODEL env var, default to openai/gpt-4o-mini, increase maxTokens to 4096
 
 - 2026-04-01 — fix(config): correct OpenRouter model IDs to dot-notation format (claude-haiku-4.5, claude-sonnet-4.6)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,27 @@ app.route('/resume', resumeRoute)
 app.route('/.well-known/agent.json', agentCardRoute)
 app.get('/.well-known/agent-card.json', (c) => c.redirect('/.well-known/agent.json', 301))
 app.get('/try', (c) => c.redirect('/query?question=Tell+me+about+yourself&stream=true', 302))
+
+app.get('/robots.txt', (c) =>
+  c.text(
+    [
+      'User-agent: *',
+      'Allow: /',
+      '',
+      '# AI assistants — explicitly welcome',
+      'User-agent: GPTBot',
+      'User-agent: ChatGPT-User',
+      'User-agent: Google-Extended',
+      'User-agent: PerplexityBot',
+      'User-agent: ClaudeBot',
+      'User-agent: anthropic-ai',
+      'User-agent: Grok',
+      'User-agent: YouBot',
+      'User-agent: cohere-ai',
+      'Allow: /',
+    ].join('\n'),
+  ),
+)
 app.route('/profile', profileRoute)
 app.route('/projects', projectsRoute)
 app.route('/mcp', mcpRoute)


### PR DESCRIPTION
## Summary
- Adds `GET /robots.txt` endpoint to resume-agent
- Explicitly allowlists major AI crawlers: GPTBot, ChatGPT-User, Google-Extended, PerplexityBot, ClaudeBot, anthropic-ai, Grok, YouBot, cohere-ai
- All other user agents allowed by default

## Test plan
- [ ] `curl https://agent.yuens.me/robots.txt` returns the expected content
- [ ] AI crawlers can index the agent endpoints