### PR TITLE
fix(agent-card): add output_schema, auth, rate_limits; remove invalid required: false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-04-01 — fix(agent-card): add output_schema, auth, rate_limits; remove invalid required: false from context property
+
 - 2026-04-01 — feat(api): add robots.txt allowlisting AI crawlers (GPTBot, ClaudeBot, Grok, etc.)
 
 - 2026-04-01 — feat(resume): use configurable RESUME_MODEL env var, default to openai/gpt-4o-mini, increase maxTokens to 4096

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/routes/agent-card.ts
+++ b/src/routes/agent-card.ts
@@ -44,10 +44,13 @@ app.get('/', async (c) => {
           properties: {
             question: { type: 'string', description: 'Natural language question about the candidate.' },
             context: { type: 'string', description: 'Caller type hint — e.g. "ATS", "recruiter", "ai-agent".' },
+            stream: { type: 'boolean', description: 'If true, returns text/plain streaming chunks instead of JSON. Default false.' },
           },
         },
         output_schema: {
           type: 'object',
+          description: 'Applies when stream is false (default). When stream is true, response is text/plain streaming chunks.',
+          required: ['answer', 'confidence', 'sources', 'follow_up_suggestions', 'contact', 'meta'],
           properties: {
             answer: { type: 'string' },
             confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
@@ -73,12 +76,21 @@ app.get('/', async (c) => {
         },
         output_schema: {
           type: 'object',
+          required: ['fit_score', 'matched', 'gaps', 'verdict', 'recommended_action', 'scoring'],
           properties: {
             fit_score: { type: 'number', description: '0.0 – 1.0 weighted fit score.' },
             matched: { type: 'array', items: { type: 'string' } },
             gaps: { type: 'array', items: { type: 'string' } },
             verdict: { type: 'string' },
-            recommended_action: { type: 'string', enum: ['apply', 'apply_with_framing', 'pass'] },
+            recommended_action: { type: 'string', enum: ['apply', 'apply-with-tailoring', 'pass'] },
+            scoring: {
+              type: 'object',
+              properties: {
+                skills: { type: 'object', properties: { matched: { type: 'array', items: { type: 'string' } }, partial: { type: 'array', items: { type: 'string' } }, missing: { type: 'array', items: { type: 'string' } }, score: { type: 'number' } } },
+                experience: { type: 'object', properties: { years: { type: 'number' }, scope: { type: 'number' }, recency: { type: 'number' }, score: { type: 'number' } } },
+                domain: { type: 'object', properties: { industry: { type: 'number' }, product_type: { type: 'number' }, scale: { type: 'number' }, score: { type: 'number' } } },
+              },
+            },
           },
         },
         example: { job_description: 'Senior frontend engineer, React, TypeScript, 5+ years.' },

--- a/src/routes/agent-card.ts
+++ b/src/routes/agent-card.ts
@@ -18,7 +18,9 @@ app.get('/', async (c) => {
     name: data?.contact?.name ?? 'Resume Agent',
     description: 'AI agent representing a professional profile. Query skills, experience, and availability.',
     url: baseUrl,
+    auth: { type: 'none' },
     capabilities: ['query', 'match', 'info', 'availability', 'projects'],
+    rate_limits: { requests_per_minute: 30, scope: 'per_ip' },
     endpoints: {
       info: {
         url: `${baseUrl}/info`,
@@ -41,7 +43,18 @@ app.get('/', async (c) => {
           required: ['question'],
           properties: {
             question: { type: 'string', description: 'Natural language question about the candidate.' },
-            context: { type: 'string', description: 'Caller type hint — e.g. "ATS", "recruiter", "ai-agent".', required: false },
+            context: { type: 'string', description: 'Caller type hint — e.g. "ATS", "recruiter", "ai-agent".' },
+          },
+        },
+        output_schema: {
+          type: 'object',
+          properties: {
+            answer: { type: 'string' },
+            confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+            sources: { type: 'array', items: { type: 'string' } },
+            follow_up_suggestions: { type: 'array', items: { type: 'string' } },
+            contact: { type: 'object', properties: { email: { type: 'string' }, calendly: { type: 'string' } } },
+            meta: { type: 'object', properties: { model: { type: 'string' }, latency_ms: { type: 'number' } } },
           },
         },
         example: { question: 'What is your experience with TypeScript?' },
@@ -56,6 +69,16 @@ app.get('/', async (c) => {
           required: ['job_description'],
           properties: {
             job_description: { type: 'string', description: 'Full or partial job description text.' },
+          },
+        },
+        output_schema: {
+          type: 'object',
+          properties: {
+            fit_score: { type: 'number', description: '0.0 – 1.0 weighted fit score.' },
+            matched: { type: 'array', items: { type: 'string' } },
+            gaps: { type: 'array', items: { type: 'string' } },
+            verdict: { type: 'string' },
+            recommended_action: { type: 'string', enum: ['apply', 'apply_with_framing', 'pass'] },
           },
         },
         example: { job_description: 'Senior frontend engineer, React, TypeScript, 5+ years.' },


### PR DESCRIPTION
## Summary
- Remove `required: false` from `context` property in `input_schema` (invalid JSON Schema — `required` is an array at the parent level, not a boolean on properties)
- Add `output_schema` to `/query` and `/match` endpoints so machine clients know the exact response shape
- Add `auth: { type: 'none' }` — explicit declaration that endpoints are public
- Add `rate_limits: { requests_per_minute: 30, scope: 'per_ip' }` — accurate reflection of the existing middleware

## Test plan
- [ ] `curl https://agent.yuens.me/.well-known/agent.json` returns valid JSON with `output_schema`, `auth`, and `rate_limits` fields
- [ ] `context` property in `query.input_schema.properties` no longer has a `required` key