### PR TITLE
Fix agent card to conform to A2A protocol spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-04-02 — fix(agent-card): conform capabilities to A2A protocol spec (object with streaming/pushNotifications/stateTransitionHistory), add required defaultInputModes, defaultOutputModes, and skills fields
+
 - 2026-04-01 — fix(agent-card): add output_schema, auth, rate_limits; remove invalid required: false from context property
 
 - 2026-04-01 — feat(api): add robots.txt allowlisting AI crawlers (GPTBot, ClaudeBot, Grok, etc.)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Row Level Security in Supabase enforces the boundary. The public API has no know
 ## Public API endpoints
 
 ### `GET /.well-known/agent.json`
-A2A-compliant agent card. The QR code points here. AI systems use this to autodiscover the query endpoint, capabilities, and contact info.
+A2A-compliant agent card. The QR code points here. AI systems use this to autodiscover the query endpoint, capabilities, and contact info. The card includes `capabilities` (streaming, push notifications, state history), `defaultInputModes`, `defaultOutputModes`, and a `skills` array describing each agent capability — all required by the A2A protocol spec.
 
 ### `GET /info`
 Full structured profile snapshot. Skills, experience, projects, education. No Claude call — raw data from `public_profile`. Fast, cacheable, suitable for ATS systems that want facts without NL processing.

--- a/src/routes/agent-card.ts
+++ b/src/routes/agent-card.ts
@@ -20,12 +20,12 @@ app.get('/', async (c) => {
     url: baseUrl,
     auth: { type: 'none' },
     capabilities: {
-      streaming: false,
+      streaming: true,
       pushNotifications: false,
       stateTransitionHistory: false,
     },
-    defaultInputModes: ['text/plain'],
-    defaultOutputModes: ['application/json'],
+    defaultInputModes: ['application/json'],
+    defaultOutputModes: ['application/json', 'text/plain'],
     skills: [
       {
         id: 'query',

--- a/src/routes/agent-card.ts
+++ b/src/routes/agent-card.ts
@@ -19,7 +19,47 @@ app.get('/', async (c) => {
     description: 'AI agent representing a professional profile. Query skills, experience, and availability.',
     url: baseUrl,
     auth: { type: 'none' },
-    capabilities: ['query', 'match', 'info', 'availability', 'projects'],
+    capabilities: {
+      streaming: false,
+      pushNotifications: false,
+      stateTransitionHistory: false,
+    },
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['application/json'],
+    skills: [
+      {
+        id: 'query',
+        name: 'Query Profile',
+        description: 'Ask natural language questions about this candidate\'s skills, experience, and background.',
+        tags: ['resume', 'profile', 'skills', 'experience'],
+        examples: ['What is your experience with TypeScript?', 'How many years of frontend experience do you have?'],
+      },
+      {
+        id: 'match',
+        name: 'Job Match',
+        description: 'Score this candidate against a job description and return a fit breakdown.',
+        tags: ['matching', 'job-fit', 'scoring'],
+        examples: ['Senior frontend engineer, React, TypeScript, 5+ years.'],
+      },
+      {
+        id: 'info',
+        name: 'Profile Info',
+        description: 'Returns full profile data including skills, employment, education, and projects.',
+        tags: ['profile', 'resume', 'info'],
+      },
+      {
+        id: 'availability',
+        name: 'Availability',
+        description: 'Returns current availability status and preferred roles.',
+        tags: ['availability', 'status'],
+      },
+      {
+        id: 'projects',
+        name: 'Portfolio Projects',
+        description: 'Returns all portfolio projects with tech stack, highlights, and architecture.',
+        tags: ['projects', 'portfolio'],
+      },
+    ],
     rate_limits: { requests_per_minute: 30, scope: 'per_ip' },
     endpoints: {
       info: {


### PR DESCRIPTION
The capabilities field was a plain array of strings but the A2A protocol
requires it to be an object (AgentCapabilities). Also adds the required
top-level fields: defaultInputModes, defaultOutputModes, and skills.

https://claude.ai/code/session_01WWjtdcfatoqTu4Jf3Zpcxt