### PR TITLE
fix(agent-card): add required version field, remove non-spec fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-04-02 — fix(agent-card): add required `version` field, remove non-spec `schema_version` and `auth` fields per A2A protocol spec
+
 - 2026-04-02 — fix(agent-card): conform capabilities to A2A protocol spec (object with streaming/pushNotifications/stateTransitionHistory), add required defaultInputModes, defaultOutputModes, and skills fields
 
 - 2026-04-01 — fix(agent-card): add output_schema, auth, rate_limits; remove invalid required: false from context property

--- a/src/routes/agent-card.ts
+++ b/src/routes/agent-card.ts
@@ -14,11 +14,10 @@ app.get('/', async (c) => {
   const baseUrl = process.env.PUBLIC_URL ?? `http://localhost:${process.env.PORT ?? 3000}`
 
   return c.json({
-    schema_version: '1.1',
     name: data?.contact?.name ?? 'Resume Agent',
     description: 'AI agent representing a professional profile. Query skills, experience, and availability.',
     url: baseUrl,
-    auth: { type: 'none' },
+    version: '1.0.0',
     capabilities: {
       streaming: true,
       pushNotifications: false,


### PR DESCRIPTION
## Summary
- Adds the required `version` field (`1.0.0`) per the A2A protocol spec
- Removes invalid `schema_version` field (not in the spec)
- Removes non-spec `auth` field (A2A uses `securitySchemes` instead)

Fixes the `'NoneType' object has no attribute 'get'` error when submitting to the A2A registry — caused by the missing `version` field.

## Test plan
- [ ] Deploy to Railway
- [ ] Verify `curl https://agent.yuens.me/.well-known/agent.json` returns `version: "1.0.0"` and no `schema_version` or `auth` fields
- [ ] Re-submit to A2A registry and confirm validation passes

https://claude.ai/code/session_01WWjtdcfatoqTu4Jf3Zpcxt