### PR TITLE
fix(agent-card): A2A v1.0 spec compliance — supportedInterfaces, provider, canonical path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,5 @@ AUTH_MODE=open   # open | key
 
 # Server
 PORT=7000
+PUBLIC_URL=https://your-domain.com           # required — drives supportedInterfaces.url in the A2A agent card
+PROVIDER_HOMEPAGE=https://github.com/your-username  # optional — shown in agent card provider.homepage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## [Unreleased]
 
+- 2026-04-02 — fix(agent-card): full A2A v1.0 spec audit — add `supportedInterfaces` (replaces top-level `url`; carries `protocolBinding` and `protocolVersion`), add `provider` (name, homepage, contact), move `rate_limits`/`endpoints`/`contact` into `capabilities.extensions`, remove non-spec `stateTransitionHistory` from capabilities
+
+- 2026-04-02 — fix(routing): make `/.well-known/agent-card.json` the canonical A2A path (RFC 8615); redirect `/.well-known/agent.json` → `agent-card.json` (was reversed)
+
 - 2026-04-02 — fix(agent-card): add required `version` field, remove non-spec `schema_version` and `auth` fields per A2A protocol spec
 
-- 2026-04-02 — fix(agent-card): conform capabilities to A2A protocol spec (object with streaming/pushNotifications/stateTransitionHistory), add required defaultInputModes, defaultOutputModes, and skills fields
+- 2026-04-02 — fix(agent-card): conform capabilities to A2A protocol spec (object with streaming/pushNotifications), add required defaultInputModes, defaultOutputModes, and skills fields
 
 - 2026-04-01 — fix(agent-card): add output_schema, auth, rate_limits; remove invalid required: false from context property
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # resume-agent
 
-[![Agent QR Code](qr.png)](https://agent.yuens.me/.well-known/agent.json)
+[![Agent QR Code](qr.png)](https://agent.yuens.me/.well-known/agent-card.json)
 
-> Scan to load the live agent card — then paste it into any AI and start asking questions, or [open it directly](https://agent.yuens.me/.well-known/agent.json).
+> Scan to load the live agent card — then paste it into any AI and start asking questions, or [open it directly](https://agent.yuens.me/.well-known/agent-card.json).
 
 A machine-queryable AI agent that represents a professional profile. No UI. Two access tiers: a public HTTP API for employer AI systems, and a private MCP server for personal interaction.
 
@@ -50,8 +50,8 @@ Claude Desktop  GET /try  (→ /query demo)
 Cursor, etc.    POST /query
 Key-protected   GET /info
 Full read/write GET /availability
-                GET /.well-known/agent.json
-                GET /.well-known/agent-card.json (→ agent.json, 301)
+                GET /.well-known/agent-card.json
+                GET /.well-known/agent.json (→ agent-card.json, 301)
                 POST /match
                 POST /resume (owner-only, key-protected)
                 Rate-limited (public endpoints)
@@ -71,8 +71,8 @@ Row Level Security in Supabase enforces the boundary. The public API has no know
 
 ## Public API endpoints
 
-### `GET /.well-known/agent.json`
-A2A-compliant agent card. The QR code points here. AI systems use this to autodiscover the query endpoint, capabilities, and contact info. The card includes `capabilities` (streaming, push notifications, state history), `defaultInputModes`, `defaultOutputModes`, and a `skills` array describing each agent capability — all required by the A2A protocol spec.
+### `GET /.well-known/agent-card.json`
+A2A v1.0-compliant agent card (canonical path per RFC 8615). `/.well-known/agent.json` redirects here (301). AI systems use this to autodiscover the agent's supported interfaces, capabilities, and skills. The card includes `supportedInterfaces` (url, protocolBinding, protocolVersion), `provider`, `capabilities` (streaming, pushNotifications, extensions), `defaultInputModes`, `defaultOutputModes`, and a `skills` array — each skill with `id`, `name`, `description`, and `tags` as required by the A2A protocol spec. Custom metadata (rate limits, endpoints, contact) is nested under `capabilities.extensions`.
 
 ### `GET /info`
 Full structured profile snapshot. Skills, experience, projects, education. No Claude call — raw data from `public_profile`. Fast, cacheable, suitable for ATS systems that want facts without NL processing.
@@ -219,7 +219,7 @@ Then in Claude:
 | Private interface | MCP (Model Context Protocol) via OB1 |
 | Validation | Zod |
 | Deployment | Railway |
-| Agent discovery | A2A agent card spec (`/.well-known/agent.json`) |
+| Agent discovery | A2A v1.0 agent card spec (`/.well-known/agent-card.json`) |
 
 ---
 
@@ -254,7 +254,27 @@ See [`docs/workflow.md`](docs/workflow.md) for a walkthrough of how employer AI 
 7. `npm run dev`
 8. Deploy to Railway (connect the repo — `railway.toml` handles build + start)
 9. Set env vars in Railway dashboard (see `.env.example` for the full list)
-10. Generate a QR code pointing to `https://your-domain/.well-known/agent.json`
+10. Generate a QR code pointing to `https://your-domain/.well-known/agent-card.json`
+
+---
+
+## Submitting to A2A registries
+
+Once your instance is live and `/.well-known/agent-card.json` is reachable, submit to any of these:
+
+### [a2aregistry.org](https://a2aregistry.org) — API
+```bash
+curl -X POST https://a2aregistry.org/api/agents/register \
+  -H "Content-Type: application/json" \
+  -d '{"wellKnownURI": "https://your-domain/.well-known/agent-card.json"}'
+```
+The registry fetches your card and validates it. Conformance status is re-checked every 30 minutes.
+
+### [a2agent.net](https://a2agent.net/agent-registry) — UI
+Visit the registry, find the register/submit option, and enter your `/.well-known/agent-card.json` URL.
+
+### [prassanna-ravishankar/a2a-registry](https://github.com/prassanna-ravishankar/a2a-registry) — GitHub PR
+Community-driven open-source directory. Open a PR adding your agent card URL to their directory.
 
 ---
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -11,10 +11,10 @@ An AI system or recruiter tool can interact with the agent entirely through HTTP
 ### Step 1 — Discover the agent
 
 ```
-GET https://your-agent.example.com/.well-known/agent.json
+GET https://your-agent.example.com/.well-known/agent-card.json
 ```
 
-Returns an A2A-compliant agent card: name, capabilities, full endpoint catalog with schemas and examples, and contact info. Designed to be machine-parseable so AI systems can learn what to call and how.
+Returns an A2A v1.0-compliant agent card: name, version, `supportedInterfaces` (url + protocol binding + protocol version), `provider`, `capabilities`, `defaultInputModes`, `defaultOutputModes`, and a `skills` array. Designed to be machine-parseable so AI systems can learn what to call and how. `/.well-known/agent.json` also works via a 301 redirect.
 
 ### Step 2 — Read the profile
 
@@ -181,7 +181,7 @@ The A2A agent card spec is designed for a world where AI systems auto-discover a
 | Cursor / AI coding assistants | ✅ Works | Via MCP or manual HTTP calls |
 | Custom employer AI agent | ✅ Works | If they're given the agent card URL to target |
 | Consumer phone AI apps (Gemini, ChatGPT) | ❌ No HTTP | These apps have no mechanism to make GET/POST requests |
-| A2A auto-discovery | ❌ Not yet | No mainstream consumer app supports `/.well-known/agent.json` discovery |
+| A2A auto-discovery | ❌ Not yet | No mainstream consumer app supports `/.well-known/agent-card.json` discovery |
 | Fabricated responses | ⚠️ Common | Apps that can't call the API often hallucinate a plausible-sounding profile instead |
 
 **The practical gap:** Most consumer AI apps — the ones a recruiter might open on their phone — cannot make outbound HTTP requests. They'll either fail silently or invent a scenario ("this candidate would be...") rather than querying the real data. The conversational interview experience the agent card enables doesn't work in these contexts.
@@ -194,7 +194,7 @@ The A2A agent card spec is designed for a world where AI systems auto-discover a
 
 Since auto-discovery doesn't work in consumer apps, the fallback is manual but still useful:
 
-1. QR code → `https://your-agent.example.com/.well-known/agent.json`
+1. QR code → `https://your-agent.example.com/.well-known/agent-card.json`
 2. Scan surfaces the full agent card JSON
 3. Paste the card into any AI conversation as context
 4. Ask questions — the AI reasons over the structured profile without needing to call the API

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,8 +79,8 @@ app.route('/availability', availabilityRoute)
 app.route('/query', queryRoute)
 app.route('/match', matchRoute)
 app.route('/resume', resumeRoute)
-app.route('/.well-known/agent.json', agentCardRoute)
-app.get('/.well-known/agent-card.json', (c) => c.redirect('/.well-known/agent.json', 301))
+app.route('/.well-known/agent-card.json', agentCardRoute)
+app.get('/.well-known/agent.json', (c) => c.redirect('/.well-known/agent-card.json', 301))
 app.get('/try', (c) => c.redirect('/query?question=Tell+me+about+yourself&stream=true', 302))
 
 app.get('/robots.txt', (c) =>
@@ -115,7 +115,7 @@ const port = parseInt(process.env.PORT ?? '3000')
 serve({ fetch: app.fetch, port }, () => {
   const authMode = process.env.AUTH_MODE ?? 'open'
   console.log(`resume-agent running on http://localhost:${port}`)
-  console.log('[routes] GET /, /info, /availability, /projects, /projects/:slug, /try, /.well-known/agent.json')
+  console.log('[routes] GET /, /info, /availability, /projects, /projects/:slug, /try, /.well-known/agent-card.json (agent.json → 301)')
   console.log(`[routes] POST /query, /match | POST /resume (auth: ${authMode}) | PATCH /profile (auth: key)`)
   console.log('[middleware] rate-limit: 30 req/min per IP (excludes OPTIONS)')
 })

--- a/src/routes/agent-card.ts
+++ b/src/routes/agent-card.ts
@@ -11,7 +11,7 @@ app.get('/', async (c) => {
     .eq('id', '00000000-0000-0000-0000-000000000001')
     .single()
 
-  const baseUrl = process.env.PUBLIC_URL ?? `http://localhost:${process.env.PORT ?? 3000}`
+  const baseUrl = process.env.PUBLIC_URL ?? new URL(c.req.url).origin
 
   return c.json({
     name: data?.contact?.name ?? 'Resume Agent',

--- a/src/routes/agent-card.ts
+++ b/src/routes/agent-card.ts
@@ -16,12 +16,43 @@ app.get('/', async (c) => {
   return c.json({
     name: data?.contact?.name ?? 'Resume Agent',
     description: 'AI agent representing a professional profile. Query skills, experience, and availability.',
-    url: baseUrl,
     version: '1.0.0',
+    supportedInterfaces: [
+      {
+        url: baseUrl,
+        protocolBinding: 'HTTP+JSON',
+        protocolVersion: '1.0',
+      },
+    ],
+    provider: {
+      name: data?.contact?.name ?? 'Resume Agent',
+      homepage: process.env.PROVIDER_HOMEPAGE,
+      contact: data?.contact?.email,
+    },
     capabilities: {
       streaming: true,
       pushNotifications: false,
-      stateTransitionHistory: false,
+      extensions: [
+        {
+          uri: `${baseUrl}/.well-known/agent-card.json#api-docs`,
+          description: 'Custom API documentation, rate limits, and contact metadata.',
+          required: false,
+          params: {
+            rate_limits: { requests_per_minute: 30, scope: 'per_ip' },
+            contact: {
+              email: data?.contact?.email,
+              calendly: data?.contact?.calendly,
+            },
+            endpoints: {
+              info: { url: `${baseUrl}/info`, method: 'GET' },
+              availability: { url: `${baseUrl}/availability`, method: 'GET' },
+              query: { url: `${baseUrl}/query`, method: 'POST' },
+              match: { url: `${baseUrl}/match`, method: 'POST' },
+              projects: { url: `${baseUrl}/projects`, method: 'GET' },
+            },
+          },
+        },
+      ],
     },
     defaultInputModes: ['application/json'],
     defaultOutputModes: ['application/json', 'text/plain'],
@@ -59,91 +90,6 @@ app.get('/', async (c) => {
         tags: ['projects', 'portfolio'],
       },
     ],
-    rate_limits: { requests_per_minute: 30, scope: 'per_ip' },
-    endpoints: {
-      info: {
-        url: `${baseUrl}/info`,
-        method: 'GET',
-        description: 'Returns full profile data including skills, employment, education, and projects.',
-      },
-      availability: {
-        url: `${baseUrl}/availability`,
-        method: 'GET',
-        description: 'Returns current availability status and preferred roles.',
-      },
-      query: {
-        url: `${baseUrl}/query`,
-        method: 'POST',
-        also_supports: `GET ${baseUrl}/query?question=Your+question+here`,
-        content_type: 'application/json',
-        description: 'Ask a natural language question about this candidate. Supports POST with JSON body or GET with ?question= param.',
-        input_schema: {
-          type: 'object',
-          required: ['question'],
-          properties: {
-            question: { type: 'string', description: 'Natural language question about the candidate.' },
-            context: { type: 'string', description: 'Caller type hint — e.g. "ATS", "recruiter", "ai-agent".' },
-            stream: { type: 'boolean', description: 'If true, returns text/plain streaming chunks instead of JSON. Default false.' },
-          },
-        },
-        output_schema: {
-          type: 'object',
-          description: 'Applies when stream is false (default). When stream is true, response is text/plain streaming chunks.',
-          required: ['answer', 'confidence', 'sources', 'follow_up_suggestions', 'contact', 'meta'],
-          properties: {
-            answer: { type: 'string' },
-            confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
-            sources: { type: 'array', items: { type: 'string' } },
-            follow_up_suggestions: { type: 'array', items: { type: 'string' } },
-            contact: { type: 'object', properties: { email: { type: 'string' }, calendly: { type: 'string' } } },
-            meta: { type: 'object', properties: { model: { type: 'string' }, latency_ms: { type: 'number' } } },
-          },
-        },
-        example: { question: 'What is your experience with TypeScript?' },
-      },
-      match: {
-        url: `${baseUrl}/match`,
-        method: 'POST',
-        content_type: 'application/json',
-        description: 'Score this candidate against a job description and return a fit breakdown. This endpoint is POST-only; GET is not supported.',
-        input_schema: {
-          type: 'object',
-          required: ['job_description'],
-          properties: {
-            job_description: { type: 'string', description: 'Full or partial job description text.' },
-          },
-        },
-        output_schema: {
-          type: 'object',
-          required: ['fit_score', 'matched', 'gaps', 'verdict', 'recommended_action', 'scoring'],
-          properties: {
-            fit_score: { type: 'number', description: '0.0 – 1.0 weighted fit score.' },
-            matched: { type: 'array', items: { type: 'string' } },
-            gaps: { type: 'array', items: { type: 'string' } },
-            verdict: { type: 'string' },
-            recommended_action: { type: 'string', enum: ['apply', 'apply-with-tailoring', 'pass'] },
-            scoring: {
-              type: 'object',
-              properties: {
-                skills: { type: 'object', properties: { matched: { type: 'array', items: { type: 'string' } }, partial: { type: 'array', items: { type: 'string' } }, missing: { type: 'array', items: { type: 'string' } }, score: { type: 'number' } } },
-                experience: { type: 'object', properties: { years: { type: 'number' }, scope: { type: 'number' }, recency: { type: 'number' }, score: { type: 'number' } } },
-                domain: { type: 'object', properties: { industry: { type: 'number' }, product_type: { type: 'number' }, scale: { type: 'number' }, score: { type: 'number' } } },
-              },
-            },
-          },
-        },
-        example: { job_description: 'Senior frontend engineer, React, TypeScript, 5+ years.' },
-      },
-      projects: {
-        url: `${baseUrl}/projects`,
-        method: 'GET',
-        description: 'Returns all portfolio projects with tech stack, highlights, and architecture.',
-      },
-    },
-    contact: {
-      email: data?.contact?.email,
-      calendly: data?.contact?.calendly,
-    },
   })
 })
 


### PR DESCRIPTION
## Summary
- Replaces top-level `url` with `supportedInterfaces` array (`url`, `protocolBinding: 'HTTP+JSON'`, `protocolVersion: '1.0'`) — the required A2A v1.0 structure
- Adds `provider` field (`name` from Supabase, `homepage` from `PROVIDER_HOMEPAGE` env var, `contact` from Supabase email)
- Moves non-spec top-level fields (`rate_limits`, `endpoints`, `contact`) into `capabilities.extensions[]` with a URI identifier
- Removes non-spec `stateTransitionHistory` from capabilities
- Makes `/.well-known/agent-card.json` the canonical path (RFC 8615); `/.well-known/agent.json` now 301 redirects to it
- Adds `PUBLIC_URL` and `PROVIDER_HOMEPAGE` to `.env.example` so forkers can produce a valid card without code changes
- Updates README (QR link, agent card section, registry submission section, stack table), CHANGELOG, and docs/workflow.md

## Test plan
- [ ] Deploy to Railway
- [ ] `curl https://agent.yuens.me/.well-known/agent-card.json` — verify `supportedInterfaces`, `provider`, `capabilities.extensions` present; no `url`, `rate_limits`, `endpoints`, `contact` at top level
- [ ] `curl -I https://agent.yuens.me/.well-known/agent.json` — verify 301 redirect to `agent-card.json`
- [ ] Submit to a2aregistry.org and confirm validation passes