### PR TITLE
feat(mcp): switch to SSE streaming transport with session management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-04-03 — feat(mcp): switch to SSE streaming transport — session map with 10-min TTL, GET stream handler, proper DELETE teardown, numReplicas=1 in railway.toml
+
 - 2026-04-02 — fix(agent-card): full A2A v1.0 spec audit — add `supportedInterfaces` (replaces top-level `url`; carries `protocolBinding` and `protocolVersion`), add `provider` (name, homepage, contact), move `rate_limits`/`endpoints`/`contact` into `capabilities.extensions`, remove non-spec `stateTransitionHistory` from capabilities
 
 - 2026-04-02 — fix(routing): make `/.well-known/agent-card.json` the canonical A2A path (RFC 8615); redirect `/.well-known/agent.json` → `agent-card.json` (was reversed)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "private": true,
   "type": "module",
   "engines": {

--- a/railway.toml
+++ b/railway.toml
@@ -10,3 +10,4 @@ startCommand = "npm start"
 healthcheckPath = "/"
 healthcheckTimeout = 30
 restartPolicyType = "on_failure"
+numReplicas = 1

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -742,7 +742,7 @@ const ALLOWED_ORIGINS = new Set([
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, content-type, x-brain-key, accept, mcp-session-id',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS, DELETE',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, DELETE',
 } as const
 
 function checkOrigin(c: Context): Response | null {
@@ -773,6 +773,31 @@ async function authenticate(c: Context): Promise<boolean> {
   return false
 }
 
+// ── Session management ────────────────────────────────────
+// SSE transport — sessions are persistent; cached by mcp-session-id with 10-minute TTL.
+// Single Railway replica required for session affinity (see railway.toml).
+
+interface McpSession {
+  server: McpServer
+  transport: StreamableHTTPTransport
+  lastUsed: number
+}
+
+const sessions = new Map<string, McpSession>()
+const SESSION_TTL_MS = 10 * 60_000
+
+setInterval(() => {
+  const now = Date.now()
+  for (const [id, session] of sessions) {
+    if (now - session.lastUsed > SESSION_TTL_MS) {
+      session.transport.close?.()
+      sessions.delete(id)
+    }
+  }
+}, 5 * 60_000)
+
+// ── Routes ────────────────────────────────────────────────
+
 const mcpRoute = new Hono()
 
 // CORS preflight
@@ -782,25 +807,45 @@ mcpRoute.options('*', (c) => {
   return c.text('ok', 200, corsHeaders)
 })
 
-// GET — this server uses JSON response mode (no SSE); return 405 per MCP spec
-mcpRoute.get('*', (c) => {
+// GET — opens the SSE stream for an existing session
+mcpRoute.get('*', async (c) => {
   const originErr = checkOrigin(c)
   if (originErr) return originErr
-  return c.json(
-    { error: 'Method not allowed — server operates in JSON response mode, not SSE' },
-    405,
-    { ...corsHeaders, Allow: 'POST, OPTIONS, DELETE' }
-  )
+
+  if (!await authenticate(c)) {
+    return c.json({ error: 'Invalid or missing credentials' }, 401, corsHeaders)
+  }
+
+  const sessionId = c.req.header('mcp-session-id')
+  const session = sessionId ? sessions.get(sessionId) : undefined
+  if (!session) {
+    return c.json({ error: 'Session not found — initiate with a POST first' }, 404, corsHeaders)
+  }
+
+  session.lastUsed = Date.now()
+  const response = await session.transport.handleRequest(c)
+  if (!response) return c.json({ error: 'No response from MCP transport' }, 500, corsHeaders)
+  for (const [key, value] of Object.entries(corsHeaders)) {
+    response.headers.set(key, value)
+  }
+  return response
 })
 
-// DELETE — stateless server, no sessions to track; acknowledge and return 200
+// DELETE — tear down session and close the SSE stream
 mcpRoute.delete('*', (c) => {
   const originErr = checkOrigin(c)
   if (originErr) return originErr
+
+  const sessionId = c.req.header('mcp-session-id')
+  if (sessionId) {
+    const session = sessions.get(sessionId)
+    session?.transport.close?.()
+    sessions.delete(sessionId)
+  }
   return c.body(null, 200, corsHeaders)
 })
 
-// POST — main MCP handler
+// POST — initialize or resume session, then handle the MCP request
 mcpRoute.post('*', async (c) => {
   const originErr = checkOrigin(c)
   if (originErr) return originErr
@@ -816,12 +861,27 @@ mcpRoute.post('*', async (c) => {
     })
   }
 
-  const server = buildServer()
-  const transport = new StreamableHTTPTransport({ enableJsonResponse: true })
-  await server.connect(transport)
+  const incomingSessionId = c.req.header('mcp-session-id')
+  let session = incomingSessionId ? sessions.get(incomingSessionId) : undefined
 
-  const response = await transport.handleRequest(c)
+  if (!session) {
+    const server = buildServer()
+    const transport = new StreamableHTTPTransport()
+    await server.connect(transport)
+    session = { server, transport, lastUsed: Date.now() }
+  }
+
+  session.lastUsed = Date.now()
+
+  const response = await session.transport.handleRequest(c)
   if (!response) return c.json({ error: 'No response from MCP transport' }, 500, corsHeaders)
+
+  // Cache by the session ID the transport assigns on initialization
+  const assignedId = response.headers.get('mcp-session-id')
+  if (assignedId && !sessions.has(assignedId)) {
+    sessions.set(assignedId, session)
+  }
+
   for (const [key, value] of Object.entries(corsHeaders)) {
     response.headers.set(key, value)
   }

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -743,6 +743,7 @@ const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, content-type, x-brain-key, accept, mcp-session-id',
   'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, DELETE',
+  'Access-Control-Expose-Headers': 'mcp-session-id',
 } as const
 
 function checkOrigin(c: Context): Response | null {
@@ -771,6 +772,17 @@ async function authenticate(c: Context): Promise<boolean> {
     }
   }
   return false
+}
+
+function unauthorized(c: Context): Response {
+  const baseUrl = process.env.PUBLIC_URL
+    ? new URL(process.env.PUBLIC_URL)
+    : new URL(c.req.url)
+  const resourceMetadataUrl = new URL('/.well-known/oauth-protected-resource', baseUrl).toString()
+  return c.json({ error: 'Invalid or missing credentials' }, 401, {
+    ...corsHeaders,
+    'WWW-Authenticate': `Bearer realm="${baseUrl.origin}", resource_metadata="${resourceMetadataUrl}"`,
+  }) as Response
 }
 
 // ── Session management ────────────────────────────────────
@@ -812,9 +824,7 @@ mcpRoute.get('*', async (c) => {
   const originErr = checkOrigin(c)
   if (originErr) return originErr
 
-  if (!await authenticate(c)) {
-    return c.json({ error: 'Invalid or missing credentials' }, 401, corsHeaders)
-  }
+  if (!await authenticate(c)) return unauthorized(c)
 
   const sessionId = c.req.header('mcp-session-id')
   const session = sessionId ? sessions.get(sessionId) : undefined
@@ -832,9 +842,11 @@ mcpRoute.get('*', async (c) => {
 })
 
 // DELETE — tear down session and close the SSE stream
-mcpRoute.delete('*', (c) => {
+mcpRoute.delete('*', async (c) => {
   const originErr = checkOrigin(c)
   if (originErr) return originErr
+
+  if (!await authenticate(c)) return unauthorized(c)
 
   const sessionId = c.req.header('mcp-session-id')
   if (sessionId) {
@@ -850,16 +862,7 @@ mcpRoute.post('*', async (c) => {
   const originErr = checkOrigin(c)
   if (originErr) return originErr
 
-  if (!await authenticate(c)) {
-    const baseUrl = process.env.PUBLIC_URL
-      ? new URL(process.env.PUBLIC_URL)
-      : new URL(c.req.url)
-    const resourceMetadataUrl = new URL('/.well-known/oauth-protected-resource', baseUrl).toString()
-    return c.json({ error: 'Invalid or missing credentials' }, 401, {
-      ...corsHeaders,
-      'WWW-Authenticate': `Bearer realm="${baseUrl.origin}", resource_metadata="${resourceMetadataUrl}"`,
-    })
-  }
+  if (!await authenticate(c)) return unauthorized(c)
 
   const incomingSessionId = c.req.header('mcp-session-id')
   let session = incomingSessionId ? sessions.get(incomingSessionId) : undefined
@@ -876,9 +879,9 @@ mcpRoute.post('*', async (c) => {
   const response = await session.transport.handleRequest(c)
   if (!response) return c.json({ error: 'No response from MCP transport' }, 500, corsHeaders)
 
-  // Cache by the session ID the transport assigns on initialization
+  // Cache by the session ID the transport assigns on initialization; overwrite if ID reused
   const assignedId = response.headers.get('mcp-session-id')
-  if (assignedId && !sessions.has(assignedId)) {
+  if (assignedId) {
     sessions.set(assignedId, session)
   }
 


### PR DESCRIPTION
## Summary
- Removes \`enableJsonResponse: true\` — switches MCP transport from stateless JSON response mode to SSE streaming
- Adds session map (\`Map<string, McpSession>\`) with 10-minute TTL eviction; sessions cached by \`mcp-session-id\` header
- GET handler now opens the SSE stream for an existing session (was 405)
- DELETE handler properly tears down the session and closes the transport
- POST handler creates or resumes sessions; caches by the session ID the transport assigns on init
- Adds \`railway.toml\` with \`numReplicas = 1\` for session affinity (sessions live in process memory)
- CORS \`Allow-Methods\` updated to include GET

## Why
The current JSON response mode creates a new \`McpServer\` + transport on every POST, discarding all session state. When Claude's connector sends a \`mcp-session-id\` from a previous call the server doesn't recognise it and surfaces a disconnect. SSE gives a persistent connection per session and eliminates the Railway 5-minute idle timeout issue. Also a prerequisite for the job-hunt-agent automation engine which makes sustained MCP tool calls.

## Test plan
- [ ] Deploy to Railway
- [ ] Connect Claude Desktop via \`x-brain-key\` — verify no disconnects across multiple tool calls with >5 min gaps
- [ ] Connect claude.ai connector via OAuth — verify session persists across tool calls
- [ ] Verify DELETE /mcp with \`mcp-session-id\` header returns 200 and evicts session
- [ ] Verify GET /mcp without \`mcp-session-id\` returns 404
- [ ] Verify Railway stays on single replica (session affinity)