### PR TITLE
feat(resume): add optional framing_hints parameter to /resume endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-04-03 — feat(resume): add optional framing_hints parameter to /resume endpoint
+
 - 2026-04-03 — feat(mcp): switch to SSE streaming transport — session map with 10-min TTL, GET stream handler, proper DELETE teardown, numReplicas=1 in railway.toml
 
 - 2026-04-02 — fix(agent-card): full A2A v1.0 spec audit — add `supportedInterfaces` (replaces top-level `url`; carries `protocolBinding` and `protocolVersion`), add `provider` (name, homepage, contact), move `rate_limits`/`endpoints`/`contact` into `capabilities.extensions`, remove non-spec `stateTransitionHistory` from capabilities

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.1.31",
+  "version": "0.1.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.1.31",
+      "version": "0.1.39",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",
@@ -608,7 +608,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.28.0.tgz",
       "integrity": "sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -1241,7 +1240,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1511,7 +1509,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
       "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2428,7 +2425,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/routes/resume.ts
+++ b/src/routes/resume.ts
@@ -13,6 +13,7 @@ const app = new Hono()
 
 const schema = z.object({
   job_description: z.string().min(1),
+  framing_hints: z.array(z.string()).optional(),
 })
 
 // Private endpoint — requires Authorization: Bearer header
@@ -29,7 +30,7 @@ app.use('/', async (c, next) => {
 })
 
 app.post('/', zValidator('json', schema), async (c) => {
-  const { job_description } = c.req.valid('json')
+  const { job_description, framing_hints } = c.req.valid('json')
 
   const { data: profile, error } = await supabase
     .from('public_profile')
@@ -60,11 +61,15 @@ Respond with structured JSON:
   "projects": [...]
 }`
 
-  const userMessage = `Candidate profile:
+  let userMessage = `Candidate profile:
 ${JSON.stringify(profile, null, 2)}
 
 Target job description:
 ${job_description}`
+
+  if (framing_hints?.length) {
+    userMessage += `\n\nFraming guidance:\n${framing_hints.map((h) => `- ${h}`).join('\n')}`
+  }
 
   const { text: raw } = await generateText({
     model: getModel(RESUME_MODEL),

--- a/src/routes/resume.ts
+++ b/src/routes/resume.ts
@@ -13,7 +13,7 @@ const app = new Hono()
 
 const schema = z.object({
   job_description: z.string().min(1),
-  framing_hints: z.array(z.string()).optional(),
+  framing_hints: z.array(z.string().trim().min(1).max(200)).max(10).optional(),
 })
 
 // Private endpoint — requires Authorization: Bearer header
@@ -68,7 +68,7 @@ Target job description:
 ${job_description}`
 
   if (framing_hints?.length) {
-    userMessage += `\n\nFraming guidance:\n${framing_hints.map((h) => `- ${h}`).join('\n')}`
+    userMessage += `\n\nFraming guidance:\n${framing_hints.map((h) => `- ${h.replace(/\n+/g, ' ')}`).join('\n')}`
   }
 
   const { text: raw } = await generateText({


### PR DESCRIPTION
## Summary
- Adds optional `framing_hints: string[]` field to the `/resume` POST schema
- When provided, hints are appended to the AI prompt as a `Framing guidance:` block
- Enables the job-hunt-agent automation pipeline (Phase 2) to pass gap-aware framing context per call

## Test plan
- [ ] POST `/resume` without `framing_hints` — behaviour unchanged
- [ ] POST `/resume` with `framing_hints: ["Emphasize backend experience", "Downplay management gaps"]` — confirm hints appear in generated resume framing
- [ ] POST `/resume` with `framing_hints: []` — empty array, no framing block appended