### PR TITLE
chore(config): rename MCP_ACCESS_KEY to OPEN_BRAIN_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,9 @@ SUPA_SERVICE_ROLE=your_supabase_service_role_key_here
 SUPABASE_PROJECT_REF=your-project-ref       # from dashboard URL: supabase.com/dashboard/project/<ref>
 SUPABASE_DB_PASSWORD=your-db-password       # Project Settings → Database → Connection string
 # OB1 (Open Brain) MCP
-MCP_ACCESS_KEY=your_64_char_hex_key_here          # generate: openssl rand -hex 32 (or PowerShell equivalent)
+OPEN_BRAIN_KEY=your_64_char_hex_key_here          # generate: openssl rand -hex 32 (or PowerShell equivalent)
+
+#depricated
 SUPABASE_MCP_URL=https://your-project-ref.supabase.co/functions/v1/open-brain-mcp  # used by npm run test:integration
 
 # Private endpoint protection

--- a/.env.example
+++ b/.env.example
@@ -16,8 +16,8 @@ SUPABASE_DB_PASSWORD=your-db-password       # Project Settings → Database → 
 # OB1 (Open Brain) MCP
 OPEN_BRAIN_KEY=your_64_char_hex_key_here          # generate: openssl rand -hex 32 (or PowerShell equivalent)
 
-#depricated
-SUPABASE_MCP_URL=https://your-project-ref.supabase.co/functions/v1/open-brain-mcp  # used by npm run test:integration
+# deprecated — Edge Function backup only; integration tests now use MCP_URL with localhost fallback
+SUPABASE_MCP_URL=https://your-project-ref.supabase.co/functions/v1/open-brain-mcp
 
 # Private endpoint protection
 API_KEY=your_private_api_key_here

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-04-03 — chore(config): rename MCP_ACCESS_KEY to OPEN_BRAIN_KEY across all files and tests
+
 - 2026-04-03 — feat(resume): add optional framing_hints parameter to /resume endpoint
 
 - 2026-04-03 — feat(mcp): switch to SSE streaming transport — session map with 10-min TTL, GET stream handler, proper DELETE teardown, numReplicas=1 in railway.toml

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ If you prefer a direct connection bypassing OAuth, add to `claude_desktop_config
         "mcp-remote",
         "https://your-agent-domain.com/mcp",
         "--header",
-        "x-brain-key:YOUR_MCP_ACCESS_KEY"
+        "x-brain-key:YOUR_OPEN_BRAIN_KEY"
       ]
     }
   }

--- a/docs/mcp-architecture.md
+++ b/docs/mcp-architecture.md
@@ -33,7 +33,7 @@ Once SSE lands, sessions are cached by `mcp-session-id`:
 
 Two paths, checked in order:
 
-1. **Static key** — `x-brain-key` header matches `MCP_ACCESS_KEY` env var (Claude Desktop direct access)
+1. **Static key** — `x-brain-key` header matches `OPEN_BRAIN_KEY` env var (Claude Desktop direct access)
 2. **JWT** — `Authorization: Bearer <token>` verified with `jose` against `JWT_SECRET` (claude.ai OAuth connector)
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "engines": {
@@ -15,7 +15,8 @@
     "db:push": "supabase db push",
     "ob1:deploy": "supabase functions deploy open-brain-mcp --no-verify-jwt",
     "ob1:logs": "supabase functions logs open-brain-mcp",
-    "test": "echo 'No unit tests. Run npm run test:integration for live integration tests.'",
+    "test:unit": "tsx --test tests/resume-framing.test.ts",
+    "test": "echo 'Run npm run test:unit for unit tests, npm run test:integration for live integration tests.'",
     "test:integration": "tsx --env-file=.env.local --test tests/pipeline.test.ts tests/update-profile.test.ts tests/projects-and-scoring.test.ts"
   },
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { serve } from '@hono/node-server'
 import { Hono, type Context } from 'hono'
 import { cors } from 'hono/cors'
 import { logger } from 'hono/logger'
-import crypto from 'crypto'
+import { timingSafeEqual } from './lib/crypto.js'
 
 import infoRoute from './routes/info.js'
 import availabilityRoute from './routes/availability.js'
@@ -15,11 +15,6 @@ import projectsRoute from './routes/projects.js'
 import mcpRoute from './routes/mcp.js'
 import oauthRoute from './routes/oauth.js'
 
-function timingSafeEqual(a: string, b: string): boolean {
-  const aDigest = crypto.createHash('sha256').update(a).digest()
-  const bDigest = crypto.createHash('sha256').update(b).digest()
-  return crypto.timingSafeEqual(aDigest, bDigest)
-}
 
 const app = new Hono({ strict: false })
 

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -1,0 +1,11 @@
+import crypto from 'crypto'
+
+/**
+ * Constant-time string comparison using SHA-256 digests.
+ * Prevents timing attacks on secret comparisons (API keys, tokens).
+ */
+export function timingSafeEqual(a: string, b: string): boolean {
+  const aDigest = crypto.createHash('sha256').update(a).digest()
+  const bDigest = crypto.createHash('sha256').update(b).digest()
+  return crypto.timingSafeEqual(aDigest, bDigest)
+}

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -11,11 +11,11 @@ import { parseJSON } from '../lib/parse-json.js'
 import { scoreMatch } from '../lib/score-match.js'
 import type { Project } from '../types.js'
 
-const MCP_ACCESS_KEY = process.env.MCP_ACCESS_KEY
+const OPEN_BRAIN_KEY = process.env.OPEN_BRAIN_KEY
 const JWT_SECRET = process.env.JWT_SECRET
 const jwtSecretBytes = JWT_SECRET ? new TextEncoder().encode(JWT_SECRET) : null
 
-if (!MCP_ACCESS_KEY) throw new Error('Missing MCP_ACCESS_KEY')
+if (!OPEN_BRAIN_KEY) throw new Error('Missing OPEN_BRAIN_KEY')
 
 // ── Helpers ───────────────────────────────────────────────
 
@@ -759,7 +759,7 @@ function checkOrigin(c: Context): Response | null {
 
 async function authenticate(c: Context): Promise<boolean> {
   const brainKey = c.req.header('x-brain-key')
-  if (brainKey && brainKey === MCP_ACCESS_KEY) return true
+  if (brainKey && brainKey === OPEN_BRAIN_KEY) return true
 
   const authHeader = c.req.header('authorization') ?? ''
   const bearerToken = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -1,4 +1,5 @@
 import '../lib/env.js'
+import { timingSafeEqual } from '../lib/crypto.js'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPTransport } from '@hono/mcp'
 import { Hono, type Context } from 'hono'
@@ -759,7 +760,7 @@ function checkOrigin(c: Context): Response | null {
 
 async function authenticate(c: Context): Promise<boolean> {
   const brainKey = c.req.header('x-brain-key')
-  if (brainKey && brainKey === OPEN_BRAIN_KEY) return true
+  if (brainKey && timingSafeEqual(brainKey, OPEN_BRAIN_KEY!)) return true
 
   const authHeader = c.req.header('authorization') ?? ''
   const bearerToken = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null

--- a/supabase/functions/open-brain-mcp/index.ts
+++ b/supabase/functions/open-brain-mcp/index.ts
@@ -26,7 +26,7 @@ import { jwtVerify } from "jose";
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 const OPENROUTER_API_KEY = Deno.env.get("OPENROUTER_API_KEY")!;
-const MCP_ACCESS_KEY = Deno.env.get("MCP_ACCESS_KEY")!;
+const OPEN_BRAIN_KEY = Deno.env.get("OPEN_BRAIN_KEY")!;
 const JWT_SECRET = Deno.env.get("JWT_SECRET");
 const jwtSecretBytes = JWT_SECRET ? new TextEncoder().encode(JWT_SECRET) : null;
 
@@ -1030,7 +1030,7 @@ app.all("*", async (c) => {
 
   let authenticated = false;
 
-  if (brainKey && brainKey === MCP_ACCESS_KEY) {
+  if (brainKey && brainKey === OPEN_BRAIN_KEY) {
     authenticated = true;
   } else if (bearerToken && jwtSecretBytes) {
     try {

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -1,12 +1,12 @@
 /**
  * Job Hunt Pipeline — integration tests
  *
- * Calls the live OB1 MCP Edge Function over HTTP, exercising all 7 pipeline
+ * Calls the live OB1 MCP server (Railway) over HTTP, exercising all 7 pipeline
  * tools end-to-end against the real Supabase database.
  *
  * Requirements:
- *   SUPABASE_MCP_URL   — e.g. https://<ref>.supabase.co/functions/v1/open-brain-mcp
- *   MCP_ACCESS_KEY     — the x-brain-key value
+ *   MCP_URL        — e.g. https://agent.yuens.me/mcp (or http://localhost:3000/mcp)
+ *   OPEN_BRAIN_KEY — the x-brain-key value
  *
  * Run:
  *   npm run test:integration
@@ -15,14 +15,15 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { config } from "dotenv";
+import { createMcpClient } from "./helpers/mcp.js";
 
 config({ path: ".env.local" });
 
-const MCP_URL = process.env.SUPABASE_MCP_URL;
-const MCP_KEY = process.env.MCP_ACCESS_KEY;
+const MCP_URL = process.env.MCP_URL ?? `http://localhost:${process.env.PORT ?? 3000}/mcp`;
+const MCP_KEY = process.env.OPEN_BRAIN_KEY;
 
-if (!MCP_URL || !MCP_KEY) {
-  throw new Error("SUPABASE_MCP_URL and MCP_ACCESS_KEY must be set in .env.local");
+if (!MCP_KEY) {
+  throw new Error("OPEN_BRAIN_KEY must be set in .env.local");
 }
 
 const SUPA_URL = process.env.SUPA_PROJECT_URL;
@@ -31,56 +32,9 @@ if (!SUPA_URL || !SUPA_ROLE_KEY) {
   throw new Error("SUPA_PROJECT_URL and SUPA_SERVICE_ROLE must be set in .env.local (required for test cleanup)");
 }
 
-// ── MCP JSON-RPC helper ───────────────────────────────────
+// ── MCP helper ───────────────────────────────────────────
 
-let sessionId: string | undefined;
-
-async function callTool(name: string, args: Record<string, unknown> = {}) {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    Accept: "application/json, text/event-stream",
-    "x-brain-key": MCP_KEY!,
-  };
-  if (sessionId) headers["mcp-session-id"] = sessionId;
-
-  const body = JSON.stringify({
-    jsonrpc: "2.0",
-    id: 1,
-    method: "tools/call",
-    params: { name, arguments: args },
-  });
-
-  const res = await fetch(MCP_URL!, { method: "POST", headers, body });
-
-  if (!sessionId) {
-    sessionId = res.headers.get("mcp-session-id") ?? undefined;
-  }
-
-  const text = await res.text();
-
-  // SSE response: extract the last `data:` line that contains a JSON-RPC result
-  if (text.includes("data:")) {
-    const lines = text.split("\n").filter((l) => l.startsWith("data:"));
-    for (const line of lines.reverse()) {
-      try {
-        const payload = JSON.parse(line.slice(5).trim());
-        if (payload.result) return payload.result;
-        if (payload.error) throw new Error(JSON.stringify(payload.error));
-      } catch {
-        /* skip non-JSON lines */
-      }
-    }
-    throw new Error(`No result in SSE response: ${text.slice(0, 200)}`);
-  }
-
-  const payload = JSON.parse(text);
-  if (payload.error) throw new Error(JSON.stringify(payload.error));
-  return payload.result;
-}
-
-function getText(result: { content: { type: string; text: string }[] }): string {
-  return result.content.map((c: { type: string; text: string }) => c.text).join("\n");
-}
+const { callTool, getText } = createMcpClient(MCP_URL, MCP_KEY!);
 
 // ── Test state ────────────────────────────────────────────
 

--- a/tests/projects-and-scoring.test.ts
+++ b/tests/projects-and-scoring.test.ts
@@ -6,7 +6,7 @@
  *
  * Requirements:
  *   MCP_URL        — e.g. https://agent.yuens.me/mcp (or http://localhost:3000/mcp)
- *   MCP_ACCESS_KEY — the x-brain-key value
+ *   OPEN_BRAIN_KEY — the x-brain-key value
  *   SUPA_PROJECT_URL + SUPA_SERVICE_ROLE — for snapshot/restore
  *
  * Run:
@@ -21,10 +21,10 @@ import { createMcpClient } from "./helpers/mcp.js";
 config({ path: ".env.local" });
 
 const MCP_URL = process.env.MCP_URL ?? `http://localhost:${process.env.PORT ?? 3000}/mcp`;
-const MCP_KEY = process.env.MCP_ACCESS_KEY;
+const MCP_KEY = process.env.OPEN_BRAIN_KEY;
 
 if (!MCP_KEY) {
-  throw new Error("MCP_ACCESS_KEY must be set in .env.local");
+  throw new Error("OPEN_BRAIN_KEY must be set in .env.local");
 }
 
 const SUPA_URL = process.env.SUPA_PROJECT_URL;

--- a/tests/resume-framing.test.ts
+++ b/tests/resume-framing.test.ts
@@ -11,7 +11,9 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { z } from 'zod'
 
-// ── Schema (mirrors src/routes/resume.ts) ─────────────────
+// ── Schema (copied from src/routes/resume.ts for isolation) ──────────────
+// Partial mirror — only covers framing_hints injection logic, not the full
+// route handler. If the schema or prompt builder changes in the route, update here.
 
 const schema = z.object({
   job_description: z.string().min(1),

--- a/tests/resume-framing.test.ts
+++ b/tests/resume-framing.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Unit tests — /resume framing_hints
+ *
+ * Tests Zod schema validation and prompt injection logic entirely in-process.
+ * No network, no env vars, no Supabase.
+ *
+ * Run: npm run test:unit
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { z } from 'zod'
+
+// ── Schema (mirrors src/routes/resume.ts) ─────────────────
+
+const schema = z.object({
+  job_description: z.string().min(1),
+  framing_hints: z.array(z.string().trim().min(1).max(200)).max(10).optional(),
+})
+
+// ── Prompt builder (mirrors src/routes/resume.ts) ─────────
+
+function buildUserMessage(jd: string, hints?: string[]): string {
+  let msg = `Target job description:\n${jd}`
+  if (hints?.length) {
+    msg += `\n\nFraming guidance:\n${hints.map((h) => `- ${h.replace(/\n+/g, ' ')}`).join('\n')}`
+  }
+  return msg
+}
+
+// ── Schema validation tests ───────────────────────────────
+
+describe('framing_hints schema validation', () => {
+  it('passes when framing_hints is omitted', () => {
+    const result = schema.parse({ job_description: 'Software engineer role' })
+    assert.equal(result.framing_hints, undefined)
+  })
+
+  it('passes with empty array', () => {
+    const result = schema.parse({ job_description: 'some JD', framing_hints: [] })
+    assert.deepEqual(result.framing_hints, [])
+  })
+
+  it('passes with valid hints', () => {
+    const result = schema.parse({
+      job_description: 'some JD',
+      framing_hints: ['Emphasize backend experience', 'Downplay management gaps'],
+    })
+    assert.deepEqual(result.framing_hints, ['Emphasize backend experience', 'Downplay management gaps'])
+  })
+
+  it('trims leading/trailing whitespace from each hint', () => {
+    const result = schema.parse({ job_description: 'some JD', framing_hints: ['  trimmed  '] })
+    assert.deepEqual(result.framing_hints, ['trimmed'])
+  })
+
+  it('rejects whitespace-only strings (min(1) after trim)', () => {
+    assert.throws(
+      () => schema.parse({ job_description: 'some JD', framing_hints: ['   '] }),
+      { message: /String must contain at least 1 character/ }
+    )
+  })
+
+  it('rejects hints over 200 characters', () => {
+    assert.throws(
+      () => schema.parse({ job_description: 'some JD', framing_hints: ['x'.repeat(201)] }),
+      { message: /String must contain at most 200 character/ }
+    )
+  })
+
+  it('accepts a hint of exactly 200 characters', () => {
+    assert.doesNotThrow(() =>
+      schema.parse({ job_description: 'some JD', framing_hints: ['x'.repeat(200)] })
+    )
+  })
+
+  it('rejects more than 10 hints', () => {
+    assert.throws(
+      () => schema.parse({ job_description: 'some JD', framing_hints: Array(11).fill('hint') }),
+      { message: /Array must contain at most 10 element/ }
+    )
+  })
+
+  it('accepts exactly 10 hints', () => {
+    assert.doesNotThrow(() =>
+      schema.parse({ job_description: 'some JD', framing_hints: Array(10).fill('hint') })
+    )
+  })
+
+  it('rejects missing job_description', () => {
+    assert.throws(() => schema.parse({ framing_hints: ['hint'] }))
+  })
+
+  it('rejects empty job_description', () => {
+    assert.throws(() => schema.parse({ job_description: '', framing_hints: ['hint'] }))
+  })
+})
+
+// ── Prompt injection tests ────────────────────────────────
+
+describe('framing_hints prompt injection', () => {
+  it('no hints → no framing block in prompt', () => {
+    const msg = buildUserMessage('some JD')
+    assert.ok(!msg.includes('Framing guidance'), 'Should not add framing block when hints is undefined')
+  })
+
+  it('empty array → no framing block in prompt', () => {
+    const msg = buildUserMessage('some JD', [])
+    assert.ok(!msg.includes('Framing guidance'), 'Should not add framing block when hints is empty')
+  })
+
+  it('single hint → framing block appended', () => {
+    const msg = buildUserMessage('some JD', ['Focus on backend'])
+    assert.ok(msg.includes('Framing guidance:'), 'Should include framing header')
+    assert.ok(msg.includes('- Focus on backend'), 'Should include hint as bullet')
+  })
+
+  it('multiple hints → each on its own bullet line', () => {
+    const msg = buildUserMessage('some JD', ['hint one', 'hint two', 'hint three'])
+    assert.ok(msg.includes('- hint one\n- hint two\n- hint three'))
+  })
+
+  it('hint with internal newlines → newlines replaced with space', () => {
+    const msg = buildUserMessage('some JD', ['line one\nline two'])
+    assert.ok(msg.includes('- line one line two'), 'Newline should be replaced with space')
+    assert.ok(!msg.includes('line one\nline two'), 'Original newline should not survive')
+  })
+
+  it('hint with multiple consecutive newlines → collapsed to single space', () => {
+    const msg = buildUserMessage('some JD', ['line one\n\n\nline two'])
+    assert.ok(msg.includes('- line one line two'))
+  })
+
+  it('framing block appears after job description', () => {
+    const msg = buildUserMessage('my JD text', ['a hint'])
+    const jdPos = msg.indexOf('my JD text')
+    const framingPos = msg.indexOf('Framing guidance:')
+    assert.ok(jdPos < framingPos, 'Framing block should come after job description')
+  })
+})

--- a/tests/update-profile.test.ts
+++ b/tests/update-profile.test.ts
@@ -6,7 +6,7 @@
  *
  * Requirements:
  *   MCP_URL        — e.g. https://agent.yuens.me/mcp (or local http://localhost:3000/mcp)
- *   MCP_ACCESS_KEY — the x-brain-key value
+ *   OPEN_BRAIN_KEY — the x-brain-key value
  *
  * Run:
  *   npm run test:integration
@@ -20,10 +20,10 @@ import { createMcpClient } from "./helpers/mcp.js";
 config({ path: ".env.local" });
 
 const MCP_URL = process.env.MCP_URL ?? `http://localhost:${process.env.PORT ?? 3000}/mcp`;
-const MCP_KEY = process.env.MCP_ACCESS_KEY;
+const MCP_KEY = process.env.OPEN_BRAIN_KEY;
 
 if (!MCP_KEY) {
-  throw new Error("MCP_ACCESS_KEY must be set in .env.local");
+  throw new Error("OPEN_BRAIN_KEY must be set in .env.local");
 }
 
 const SUPA_URL = process.env.SUPA_PROJECT_URL;


### PR DESCRIPTION
## Summary
- Renames `MCP_ACCESS_KEY` → `OPEN_BRAIN_KEY` everywhere: `src/routes/mcp.ts`, `supabase/functions/open-brain-mcp/index.ts`, `.env.example`, `README.md`, `docs/mcp-architecture.md`, and all three integration test files
- Migrates `pipeline.test.ts` from the retired `SUPABASE_MCP_URL` edge function to `MCP_URL` (same pattern as the other tests) and switches to the shared `createMcpClient` helper
- Adds `tests/resume-framing.test.ts` — 18 unit tests covering `framing_hints` schema validation and prompt injection logic (no network, runs via `npm run test:unit`)

## Test plan
- [ ] `npm run test:unit` — 18 unit tests pass
- [ ] `npm run test:integration` (with local server running) — 14 integration tests pass
- [ ] Confirm Railway env var `OPEN_BRAIN_KEY` is set (replaces `MCP_ACCESS_KEY`)