### PR TITLE
fix(sync): correct artisan-roast-platform owner, guard undefined skill items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - 2026-04-05 — feat(sync): GitHub-to-OB1 project sync — fetch READMEs, update project architecture, rebuild CANDIDATE_STACK thought
 
+## [0.2.4] — 2026-04-05
+
+- 2026-04-05 — fix(sync): correct artisan-roast-platform owner to dev-yuen-agency; guard against undefined skill items in buildCandidateStack
+
 - 2026-04-03 — chore(config): rename MCP_ACCESS_KEY to OPEN_BRAIN_KEY across all files and tests
 
 - 2026-04-03 — feat(resume): add optional framing_hints parameter to /resume endpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## [Unreleased]
 
-- 2026-04-05 — feat(sync): GitHub-to-OB1 project sync — fetch READMEs, update project architecture, rebuild CANDIDATE_STACK thought
-
 ## [0.2.4] — 2026-04-05
 
-- 2026-04-05 — fix(sync): correct artisan-roast-platform owner to dev-yuen-agency; guard against undefined skill items in buildCandidateStack
+- 2026-04-05 — fix(sync): correct artisan-roast-platform owner to dev-yuen-agency; guard undefined skill items in buildCandidateStack; tighten ProfileRow types
+
+## [0.2.3] — 2026-04-05
+
+- 2026-04-05 — feat(sync): GitHub-to-OB1 project sync — fetch READMEs, update project architecture, rebuild CANDIDATE_STACK thought
 
 - 2026-04-03 — chore(config): rename MCP_ACCESS_KEY to OPEN_BRAIN_KEY across all files and tests
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "type": "module",
   "engines": {

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -69,7 +69,7 @@ async function fetchGitHubFile(owner: string, repo: string, path: string): Promi
 
 interface ProfileRow {
   projects: Array<{ slug: string; status?: string; name?: unknown; tech?: unknown; highlights?: unknown; [key: string]: unknown }>
-  skills: Array<{ category: string; items: string[] }>
+  skills?: Array<{ category?: string; items?: string[] | null }> | null
 }
 
 async function loadProfile(): Promise<ProfileRow | null> {

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -40,8 +40,8 @@ const PROFILE_ID = '00000000-0000-0000-0000-000000000001'
 
 // Repos to sync — slug must match the project slug in public_profile.projects
 const REPOS = [
-  { slug: 'artisan-roast', owner: 'yuens1002', repo: 'artisan-roast-platform' },
-  { slug: 'resume-agent',  owner: 'yuens1002', repo: 'resume-agent' },
+  { slug: 'artisan-roast', owner: 'dev-yuen-agency', repo: 'artisan-roast-platform' },
+  { slug: 'resume-agent',  owner: 'yuens1002',       repo: 'resume-agent' },
 ]
 
 // ── GitHub ────────────────────────────────────────────────
@@ -114,7 +114,9 @@ function syncProject(
 // ── CANDIDATE_STACK ───────────────────────────────────────
 
 function buildCandidateStack(profile: ProfileRow): string {
-  const skillLines = profile.skills.map(s => s.items.join(', '))
+  const skillLines = (profile.skills ?? [])
+    .map(s => Array.isArray(s.items) ? s.items.join(', ') : '')
+    .filter(Boolean)
   const projectLines = profile.projects
     .filter(p => p.status === 'active' || p.status === 'in-progress')
     .map(p => {


### PR DESCRIPTION
## Summary
- Fixed `artisan-roast-platform` GitHub owner from `yuens1002` to `dev-yuen-agency` — the repo lives under the org account
- `buildCandidateStack` now guards against `undefined` `s.items` with `Array.isArray` check and a `?? []` fallback on `profile.skills`

## Notes
- `artisan-roast-platform` is a private org repo — `GITHUB_TOKEN` in `.env.local` must have read access to `dev-yuen-agency` for the README fetch to succeed

## Test plan
- [ ] Run `npm run sync` — confirm artisan-roast README fetches successfully (with `GITHUB_TOKEN` set)
- [ ] Run `npm run sync` — confirm CANDIDATE_STACK thought is written without crashing