### PR TITLE
feat(sync): docsPath override per repo; use platform/platform.md for artisan-roast-platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## [0.2.5] — 2026-04-05
 
-- 2026-04-05 — feat(sync): support docsPath override per repo; use docs/ARTISAN-ROAST-PLATFORM.md instead of boilerplate README
+- 2026-04-05 — feat(sync): support docsPath override per repo; artisan-roast-platform now syncs from docs/platform/platform.md instead of boilerplate README
 
 ## [0.2.4] — 2026-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.2.5] — 2026-04-05
+
+- 2026-04-05 — feat(sync): support docsPath override per repo; use docs/ARTISAN-ROAST-PLATFORM.md instead of boilerplate README
+
 ## [0.2.4] — 2026-04-05
 
 - 2026-04-05 — fix(sync): correct artisan-roast-platform owner to dev-yuen-agency; guard undefined skill items in buildCandidateStack; tighten ProfileRow types

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "type": "module",
   "engines": {

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -1,7 +1,8 @@
 /**
  * GitHub-to-OB1 project sync
  *
- * 1. Fetches README.md from configured GitHub repos via the GitHub Contents API
+ * 1. Fetches docs from configured GitHub repos via the GitHub Contents API
+ *    (README.md by default; overridden per repo via docsPath)
  * 2. Updates each project's architecture field in public_profile
  * 3. Rebuilds the CANDIDATE_STACK thought from the current profile —
  *    framing.ts in job-hunt-agent reads this at runtime instead of a hardcoded constant
@@ -98,7 +99,7 @@ async function saveProjects(projects: ProfileRow['projects']): Promise<void> {
 
 function syncProject(
   slug: string,
-  readme: string,
+  content: string,
   projects: ProfileRow['projects'],
 ): ProfileRow['projects'] {
   const idx = projects.findIndex(p => p.slug === slug)
@@ -106,8 +107,8 @@ function syncProject(
     console.log(`  ⚠ "${slug}" not found in profile — skipping`)
     return projects
   }
-  // Store the first 3000 chars of README as the architecture summary
-  const architecture = readme.slice(0, 3000)
+  // Store the first 3000 chars as the architecture summary
+  const architecture = content.slice(0, 3000)
   projects[idx] = { ...projects[idx], architecture }
   return projects
 }

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -39,8 +39,9 @@ const openrouter = createOpenAI({
 const PROFILE_ID = '00000000-0000-0000-0000-000000000001'
 
 // Repos to sync — slug must match the project slug in public_profile.projects
+// docsPath overrides README.md when the root README is just boilerplate
 const REPOS = [
-  { slug: 'artisan-roast', owner: 'dev-yuen-agency', repo: 'artisan-roast-platform' },
+  { slug: 'artisan-roast', owner: 'dev-yuen-agency', repo: 'artisan-roast-platform', docsPath: 'docs/platform/platform.md' },
   { slug: 'resume-agent',  owner: 'yuens1002',       repo: 'resume-agent' },
 ]
 
@@ -162,12 +163,13 @@ async function sync(): Promise<void> {
 
   for (const r of REPOS) {
     console.log(`Syncing ${r.slug}...`)
-    const readme = await fetchGitHubFile(r.owner, r.repo, 'README.md')
-    if (readme) {
-      projects = syncProject(r.slug, readme, projects)
-      console.log(`  ✔ architecture updated (${readme.length} chars → capped at 3000)`)
+    const path = r.docsPath ?? 'README.md'
+    const content = await fetchGitHubFile(r.owner, r.repo, path)
+    if (content) {
+      projects = syncProject(r.slug, content, projects)
+      console.log(`  ✔ architecture updated from ${path} (${content.length} chars → capped at 3000)`)
     } else {
-      console.log(`  ⚠ README.md not found — skipping architecture update`)
+      console.log(`  ⚠ ${path} not found — skipping architecture update`)
     }
   }
 


### PR DESCRIPTION
## Summary
- Added optional `docsPath` field to REPOS config — overrides `README.md` when a repo's root README is boilerplate
- `artisan-roast-platform` now syncs from `docs/platform/platform.md` (37KB architecture doc) instead of the `create-next-app` stub README
- Sync output now logs which file was used for easier debugging

## Test plan
- [ ] `npm run sync` — artisan-roast shows `architecture updated from docs/platform/platform.md`
- [ ] `resume-agent` still uses `README.md` (no `docsPath` set)