### PR TITLE
fix(sync): correct REPOS mapping for artisan-roast and artisan-roast-platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.2.6] — 2026-04-05
+
+- 2026-04-05 — fix(sync): correct REPOS — artisan-roast → yuens1002/artisan-roast, add artisan-roast-platform as separate entry with platform.md
+
 ## [0.2.5] — 2026-04-05
 
 - 2026-04-05 — feat(sync): support docsPath override per repo; artisan-roast-platform now syncs from docs/platform/platform.md instead of boilerplate README

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "type": "module",
   "engines": {

--- a/scripts/seed-profile.json
+++ b/scripts/seed-profile.json
@@ -145,6 +145,24 @@
       "repo": "https://github.com/yuens1002/artisan-roast"
     },
     {
+      "name": "Artisan Roast SaaS Platform",
+      "slug": "artisan-roast-platform",
+      "description": "Multi-tenant SaaS layer on top of the open-source Artisan Roast store — managed hosting, billing, license enforcement, AI back office, and provisioning automation for independent coffee shop owners.",
+      "problem": "The open-source store requires self-hosting expertise. The SaaS platform removes that barrier: owners get a managed instance, Stripe billing, and AI-powered tools with zero DevOps overhead.",
+      "role": "Sole developer and architect — designed and built the SaaS layer, provisioning pipeline, and all platform services end-to-end.",
+      "tech": ["Next.js", "TypeScript", "Prisma", "Neon PostgreSQL", "Stripe", "NextAuth.js v5", "Tailwind CSS", "shadcn/ui", "MCP protocol", "Claude API", "GitHub Actions", "Vercel"],
+      "highlights": [
+        "Engineered a provisioning pipeline that spins up a fully configured Artisan Roast store instance (database, auth, Stripe, domain) for new customers on checkout completion",
+        "Built an AI back office MCP server — gives store owners natural-language access to orders, inventory, and analytics via Claude Desktop",
+        "Implemented tiered Stripe Billing (Free/Pro/Hosted) with automated license key generation, validation, and a telemetry ingestion system for platform-wide analytics",
+        "Designed an automated data migration pipeline for self-hosted → managed hosting transitions, modeled as a state machine (PENDING → EXPORTING → EXPORTED → IMPORTING → COMPLETED)"
+      ],
+      "status": "in-progress",
+      "started": "2025-11",
+      "url": "https://artisanroast.app",
+      "repo": "https://github.com/dev-yuen-agency/artisan-roast-platform"
+    },
+    {
       "name": "Resume Agent",
       "slug": "resume-agent",
       "description": "A2A-compatible AI agent that represents a professional profile as a machine-queryable JSON API — built for employer AI systems, ATS tools, and personal LLM interfaces.",

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -42,8 +42,9 @@ const PROFILE_ID = '00000000-0000-0000-0000-000000000001'
 // Repos to sync — slug must match the project slug in public_profile.projects
 // docsPath overrides README.md when the root README is just boilerplate
 const REPOS = [
-  { slug: 'artisan-roast', owner: 'dev-yuen-agency', repo: 'artisan-roast-platform', docsPath: 'docs/platform/platform.md' },
-  { slug: 'resume-agent',  owner: 'yuens1002',       repo: 'resume-agent' },
+  { slug: 'artisan-roast',          owner: 'yuens1002',       repo: 'artisan-roast' },
+  { slug: 'artisan-roast-platform', owner: 'dev-yuen-agency', repo: 'artisan-roast-platform', docsPath: 'docs/platform/platform.md' },
+  { slug: 'resume-agent',           owner: 'yuens1002',       repo: 'resume-agent' },
 ]
 
 // ── GitHub ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `artisan-roast` now correctly maps to `yuens1002/artisan-roast` (open-source store)
- `artisan-roast-platform` added as a separate entry → `dev-yuen-agency/artisan-roast-platform` with `docs/platform/platform.md`
- Previously `artisan-roast` was pointing at the platform repo, overwriting the store's architecture with platform docs

## Test plan
- [ ] `npm run sync` — all three repos fetch and update correctly
- [ ] `artisan-roast` architecture reflects the open-source store README
- [ ] `artisan-roast-platform` architecture reflects `docs/platform/platform.md`