### PR TITLE
docs(sync): document workflow, add nightly bat, fix raw-markdown NO_CHANGE false-positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.2.8] — 2026-04-05
+
+- 2026-04-05 — docs(sync): document npm run sync in workflow.md; add nightly bat script; fix NO_CHANGE false-positive for raw-markdown architecture values
+
 ## [0.2.7] — 2026-04-05
 
 - 2026-04-05 — feat(sync): LLM-powered architecture + highlights reconciliation — strip markdown, semantic diff via claude-haiku-4.5, NO_CHANGE short-circuit to avoid unnecessary rewrites

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -133,7 +133,7 @@ You interact with your own knowledge base through Claude — web, mobile, or des
 
 **Keeping the profile current — `npm run sync`**
 
-Run this from the resume-agent directory to refresh the public profile from GitHub:
+Run this from the resume-agent directory to refresh the public profile from GitHub (requires `.env.local` with `SUPA_PROJECT_URL`, `SUPA_SERVICE_ROLE`, and `OPENROUTER_API_KEY`):
 
 ```bash
 npm run sync
@@ -142,10 +142,10 @@ npm run sync
 What it does per repo (artisan-roast, artisan-roast-platform, resume-agent):
 1. Fetches the architecture doc (README or `docsPath` override) and `CHANGELOG.md` from GitHub
 2. Reconciles the `architecture` field — rewrites only if something material changed (`NO_CHANGE` if already accurate)
-3. Reconciles `highlights` — scans the full changelog for the greatest engineering achievements, enriches the existing list without wiping it
+3. Reconciles `highlights` — scans the full changelog for the greatest engineering achievements, updating, removing, and reordering entries as needed to keep the list accurate and focused
 4. Rebuilds the `CANDIDATE_STACK` thought in OB1 — used by job-hunt-agent at runtime for gap framing
 
-A nightly Windows Task Scheduler job runs this automatically at 2 AM. Run it manually after shipping a significant feature to keep `/info` current without waiting for the nightly run.
+To run this automatically on Windows, configure a Task Scheduler job to run `scripts/sync-nightly.bat` on a nightly schedule. Run it manually after shipping a significant feature to keep `/info` current without waiting for the next scheduled run.
 
 Once connected, 11 tools are available across two groups:
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -131,6 +131,22 @@ You interact with your own knowledge base through Claude — web, mobile, or des
 
 **Connecting via Claude Desktop directly**: use `mcp-remote` with your `x-brain-key` in the config. See README for details.
 
+**Keeping the profile current — `npm run sync`**
+
+Run this from the resume-agent directory to refresh the public profile from GitHub:
+
+```bash
+npm run sync
+```
+
+What it does per repo (artisan-roast, artisan-roast-platform, resume-agent):
+1. Fetches the architecture doc (README or `docsPath` override) and `CHANGELOG.md` from GitHub
+2. Reconciles the `architecture` field — rewrites only if something material changed (`NO_CHANGE` if already accurate)
+3. Reconciles `highlights` — scans the full changelog for the greatest engineering achievements, enriches the existing list without wiping it
+4. Rebuilds the `CANDIDATE_STACK` thought in OB1 — used by job-hunt-agent at runtime for gap framing
+
+A nightly Windows Task Scheduler job runs this automatically at 2 AM. Run it manually after shipping a significant feature to keep `/info` current without waiting for the nightly run.
+
 Once connected, 11 tools are available across two groups:
 
 **Open Brain — personal knowledge capture**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": true,
   "type": "module",
   "engines": {

--- a/scripts/sync-nightly.bat
+++ b/scripts/sync-nightly.bat
@@ -1,5 +1,11 @@
 @echo off
-cd /d C:\Users\yuens\dev\resume-agent
+cd /d "%~dp0.."
+if not exist logs mkdir logs
 echo [%date% %time%] Starting sync >> logs\sync.log 2>&1
-C:\nvm4w\nodejs\npm.cmd run sync >> logs\sync.log 2>&1
+npm run sync >> logs\sync.log 2>&1
+set "SYNC_EXIT_CODE=%ERRORLEVEL%"
+if not "%SYNC_EXIT_CODE%"=="0" (
+  echo [%date% %time%] Sync failed with exit code %SYNC_EXIT_CODE% >> logs\sync.log 2>&1
+  exit /b %SYNC_EXIT_CODE%
+)
 echo [%date% %time%] Sync complete >> logs\sync.log 2>&1

--- a/scripts/sync-nightly.bat
+++ b/scripts/sync-nightly.bat
@@ -1,0 +1,5 @@
+@echo off
+cd /d C:\Users\yuens\dev\resume-agent
+echo [%date% %time%] Starting sync >> logs\sync.log 2>&1
+C:\nvm4w\nodejs\npm.cmd run sync >> logs\sync.log 2>&1
+echo [%date% %time%] Sync complete >> logs\sync.log 2>&1

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -134,7 +134,9 @@ function stripMarkdown(raw: string): string {
 // ── Architecture reconciliation ───────────────────────────
 
 function looksLikeRawMarkdown(text: string): boolean {
-  return /^#{1,6}\s|\|.*\||\[!\[|!\[.*\]\(|```/.test(text)
+  const normalized = text.trim()
+  if (!normalized) return false
+  return /(^|\n)\s*#{1,6}\s+|(^|\n)\s*\|.*\||\[!\[|!\[.*\]\(|```/.test(normalized)
 }
 
 async function reconcileArchitecture(
@@ -173,7 +175,11 @@ Project: ${projectName}`,
   })
 
   const result = text.trim()
-  if (result === 'NO_CHANGE') return { updated: false, value: currentArchitecture }
+  if (result === 'NO_CHANGE') {
+    if (!forceRewrite) return { updated: false, value: currentArchitecture }
+    // Model ignored the force-rewrite instruction — fall back to stripped doc
+    return { updated: true, value: stripMarkdown(doc) }
+  }
   return { updated: true, value: stripMarkdown(result) }
 }
 

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -133,12 +133,19 @@ function stripMarkdown(raw: string): string {
 
 // ── Architecture reconciliation ───────────────────────────
 
+function looksLikeRawMarkdown(text: string): boolean {
+  return /^#{1,6}\s|\|.*\||\[!\[|!\[.*\]\(|```/.test(text)
+}
+
 async function reconcileArchitecture(
   projectName: string,
   currentArchitecture: string,
   archDoc: string,
 ): Promise<{ updated: boolean; value: string }> {
   const doc = stripMarkdown(archDoc).slice(0, 6000)
+
+  // Force rewrite if current value is raw markdown, not a clean prose summary
+  const forceRewrite = !currentArchitecture || looksLikeRawMarkdown(currentArchitecture)
 
   const { text } = await generateText({
     model: openrouter(MODEL),
@@ -150,10 +157,12 @@ ${currentArchitecture || '(empty)'}
 Latest documentation:
 ${doc}
 
-If the current value is already an accurate summary of the documentation, respond with exactly:
-NO_CHANGE
+${forceRewrite
+  ? 'The current value is raw or empty — write a fresh summary.'
+  : 'If the current value is already an accurate plain-prose summary, respond with exactly: NO_CHANGE'
+}
 
-Otherwise, write a new 3–5 sentence plain-prose summary covering:
+Write a 3–5 sentence plain-prose summary covering:
 1. What the project does
 2. Key technical stack and components
 3. Notable engineering decisions or patterns
@@ -165,7 +174,7 @@ Project: ${projectName}`,
 
   const result = text.trim()
   if (result === 'NO_CHANGE') return { updated: false, value: currentArchitecture }
-  return { updated: true, value: result }
+  return { updated: true, value: stripMarkdown(result) }
 }
 
 // ── Highlights reconciliation ─────────────────────────────


### PR DESCRIPTION
## Summary

- Documents \`npm run sync\` in \`docs/workflow.md\` — what it does, when to run it, how nightly scheduling works
- Adds \`scripts/sync-nightly.bat\` — Windows Task Scheduler wrapper with logging to \`logs/sync.log\`
- Fixes false-positive \`NO_CHANGE\` in architecture reconciliation — if current value is raw markdown (headers, tables, badges), force a rewrite instead of skipping
- Strips markdown from LLM output before storing, preventing the model from sneaking in headings

## Test plan

- [x] Sync ran cleanly after fix — artisan-roast-platform architecture rewritten from raw doc to clean prose
- [x] Second run correctly returns \`— architecture unchanged\` (NO_CHANGE working for already-clean values)
- [x] Typecheck passes