### PR TITLE
fix(resume): pin contact block from profile for consistent output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.2.9] — 2026-04-06
+
+- 2026-04-06 — fix(resume): pin contact block from profile in system prompt so LLM returns it verbatim instead of choosing which fields to include — fixes inconsistent contact info on generated resumes
+
 ## [0.2.8] — 2026-04-05
 
 - 2026-04-05 — docs(sync): document npm run sync in workflow.md; add nightly bat script; fix NO_CHANGE false-positive for raw-markdown architecture values

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/routes/resume.ts
+++ b/src/routes/resume.ts
@@ -42,8 +42,6 @@ app.post('/', zValidator('json', schema), async (c) => {
     return c.json({ error: 'Profile not found' }, 404)
   }
 
-  const contactBlock = JSON.stringify(profile.contact)
-
   const systemPrompt = `You are a professional resume writer. Generate a tailored resume for the candidate based on their profile and the target job description.
 
 Rules:
@@ -52,11 +50,10 @@ Rules:
 - Omit irrelevant history
 - Never fabricate credentials, titles, dates, or skills
 - Keep to 2 pages worth of content
-- IMPORTANT: Return the contact block EXACTLY as provided below — do not omit or reorder fields
+- Do NOT include a "contact" key in your JSON — it will be injected server-side
 
 Respond with structured JSON:
 {
-  "contact": ${contactBlock},
   "summary": "...",
   "skills": [...],
   "employment": [...],
@@ -87,6 +84,9 @@ ${job_description}`
   } catch {
     return c.json({ error: 'Failed to parse resume response' }, 500)
   }
+
+  // Override contact server-side — never trust the LLM to return it correctly
+  parsed.contact = profile.contact
 
   return c.json(parsed)
 })

--- a/src/routes/resume.ts
+++ b/src/routes/resume.ts
@@ -42,6 +42,8 @@ app.post('/', zValidator('json', schema), async (c) => {
     return c.json({ error: 'Profile not found' }, 404)
   }
 
+  const contactBlock = JSON.stringify(profile.contact)
+
   const systemPrompt = `You are a professional resume writer. Generate a tailored resume for the candidate based on their profile and the target job description.
 
 Rules:
@@ -50,10 +52,11 @@ Rules:
 - Omit irrelevant history
 - Never fabricate credentials, titles, dates, or skills
 - Keep to 2 pages worth of content
+- IMPORTANT: Return the contact block EXACTLY as provided below — do not omit or reorder fields
 
 Respond with structured JSON:
 {
-  "contact": { ... },
+  "contact": ${contactBlock},
   "summary": "...",
   "skills": [...],
   "employment": [...],


### PR DESCRIPTION
## Summary
- Pin the contact JSON from the Supabase profile directly into the LLM system prompt so it returns it verbatim
- Previously the LLM decided which contact fields to include on each run, resulting in inconsistent resume headers

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] Manual test: `POST /resume` returns exact contact block from profile on every call
- [x] Verified DOCX output: `sunny@yuens.me | github.com/yuens1002 | linkedin.com/in/yuens-me`