### PR TITLE
docs: catch up CHANGELOG + v2 doc with scorer fixes and Rules 7-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 - 2026-04-07 — feat(resume): implement dual-gen + rubric scorer pipeline achieving 5.82/6 ATS score — two independent LLM models compete per JD, deterministic 6-rule rubric (title mirroring, keyword coverage, quantified bullets, authenticity, bullet prioritization, skills ordering) picks winner, structured failure logging to OB1 for pattern analysis; 16 new unit tests, 34 total passing
+- 2026-04-08 — fix(scorer): handle LLM returning skills as flat string[] instead of Skill[] objects — prevents runtime TypeError crash on Rules 2 and 6
+- 2026-04-08 — fix(scorer): make Rule 4 (banned phrases) a hard veto scoring 0 — resumes containing "proven track record" or "leveraging" now lose to cleaner candidates instead of shipping with a penalty
+- 2026-04-08 — feat(prompt): add Rules 7-8 — self-employment bullets reframed to match JD role (UX work for UX roles, not backend architecture); projects section reserved for technical highlights and scale
 
 ## [0.2.9] — 2026-04-06
 

--- a/docs/resume-pipeline-v2.md
+++ b/docs/resume-pipeline-v2.md
@@ -27,7 +27,7 @@ POST /resume  { job_description, framing_hints? }
   └─ Return winner + _rubric metadata
 ```
 
-## The 6 Rules (ATS-Informed)
+## The 8 Rules (ATS-Informed) — 6 Scored + 2 Prompt-Only
 
 | # | Rule | Measurement | Pass threshold |
 |---|------|-------------|----------------|
@@ -42,7 +42,7 @@ POST /resume  { job_description, framing_hints? }
 
 **Overall pass threshold:** 4.0 / 6.0 total score (Rules 1-6 scored; Rules 7-8 are prompt-only).
 
-**Hard vetoes:** Rule 4 scores 0 (not a penalty) — any banned phrase causes the resume to lose to the other candidate.
+**Hard vetoes:** Rule 4 scores 0 (not a penalty) — any banned phrase causes the resume to lose to the other candidate. Edge case: if both candidates contain banned phrases, the higher-scoring one still ships (with a warning logged). If only one candidate parsed successfully, it ships regardless of Rule 4.
 
 Rules 1-4 are fully deterministic (string matching, regex). Rules 5-6 use keyword overlap (no LLM needed). Rules 7-8 are prompt instructions only (not scored by the rubric).
 
@@ -54,7 +54,7 @@ Rules 1-4 are fully deterministic (string matching, regex). Rules 5-6 use keywor
 | Latency | Sequential (slow on retry) | Parallel (same wall-clock as single) |
 | Quality ceiling | Limited by one chain of thought | Wider sampling |
 | Complexity | Re-prompt construction + state machine | Fire two, score, pick max |
-| Cost | 1-2 LLM calls | 2 LLM calls always ($0.00 with free-tier models via OpenRouter) |
+| Cost | 1-2 LLM calls | 2 LLM calls always (cost varies by model; $0 with OpenRouter free-tier model IDs) |
 
 ## Failure Logging & Learning
 

--- a/docs/resume-pipeline-v2.md
+++ b/docs/resume-pipeline-v2.md
@@ -34,13 +34,17 @@ POST /resume  { job_description, framing_hints? }
 | 1 | Summary opens with JD title | Distinctive title keywords in first sentence | 60% of title words |
 | 2 | Keyword coverage from JD | % of JD terms found across resume | 25%+ |
 | 3 | Bullets have quantified results | % of bullets containing metrics | 40%+ |
-| 4 | No generic/banned phrases | Count of banned phrases found | 0 |
-| 5 | First bullet matches JD primary resp | Keyword overlap with JD opening | 15%+ overlap |
+| 4 | No generic/banned phrases | Count of banned phrases found | 0 (**hard veto** — score 0) |
+| 5 | First bullet matches JD primary resp | Keyword overlap with JD opening | 5%+ overlap |
 | 6 | Top skills match JD requirements | Top 5 skills appearing in JD | 40%+ |
+| 7 | Self-employment framed as JD role | Prompt rule (not scored) | N/A |
+| 8 | Projects section for highlights/scale | Prompt rule (not scored) | N/A |
 
-**Overall pass threshold:** 4.0 / 6.0 total score.
+**Overall pass threshold:** 4.0 / 6.0 total score (Rules 1-6 scored; Rules 7-8 are prompt-only).
 
-Rules 1-4 are fully deterministic (string matching, regex). Rules 5-6 use keyword overlap (no LLM needed).
+**Hard vetoes:** Rule 4 scores 0 (not a penalty) — any banned phrase causes the resume to lose to the other candidate.
+
+Rules 1-4 are fully deterministic (string matching, regex). Rules 5-6 use keyword overlap (no LLM needed). Rules 7-8 are prompt instructions only (not scored by the rubric).
 
 ## Why Dual-Gen Over Retry
 
@@ -50,7 +54,7 @@ Rules 1-4 are fully deterministic (string matching, regex). Rules 5-6 use keywor
 | Latency | Sequential (slow on retry) | Parallel (same wall-clock as single) |
 | Quality ceiling | Limited by one chain of thought | Wider sampling |
 | Complexity | Re-prompt construction + state machine | Fire two, score, pick max |
-| Cost | 1-2 LLM calls | 2 LLM calls always (~$0.004/resume on gpt-4o-mini) |
+| Cost | 1-2 LLM calls | 2 LLM calls always ($0.00 with free-tier models via OpenRouter) |
 
 ## Failure Logging & Learning
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- Add CHANGELOG entries for 3 commits that went direct to main: skills format fix, Rule 4 hard veto, Rules 7-8 prompt update
- Update resume-pipeline-v2.md: expanded rules table (6 → 8), document Rule 4 as hard veto, update cost to reflect free-tier models, clarify scored vs prompt-only rules

## Test plan
- [ ] 36 unit tests passing
- [ ] Typecheck clean
- [ ] Docs-only change — no behavior impact