### PR TITLE
feat(prompt): keep projects separate, select most JD-relevant

### DIFF
--- a/src/routes/resume.ts
+++ b/src/routes/resume.ts
@@ -72,6 +72,7 @@ Additional rules:
 - Keep to 2 pages worth of content
 - Do NOT include a "contact" key in your JSON — it will be injected server-side
 - Omit employment history that is irrelevant to the target role
+- Each project in the profile is a separate full-stack application — never merge or combine them. Treat each as its own entry. As the portfolio grows, include only the projects most relevant to the target JD.
 
 Respond with structured JSON:
 {


### PR DESCRIPTION
## Summary
- Add prompt rule: each project is a separate full-stack application — never merge or combine them
- As portfolio grows, include only the most JD-relevant projects
- OB1 profile updated: Artisan Roast Store (storefront UX, AI, QA) and Platform (SaaS, billing, admin) now have distinct highlights with no overlap
- Fixed Artisan Roast project URL to point to GitHub repo instead of demo instance

## Test plan
- [ ] 36 unit tests passing, typecheck clean
- [ ] Prompt-only change — no scorer or endpoint behavior change