### PR TITLE
refactor(prompt): genericize system prompt for any OB1 profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - 2026-04-08 — fix(scorer): handle LLM returning skills as flat string[] instead of Skill[] objects — prevents runtime TypeError crash on Rules 2 and 6
 - 2026-04-08 — fix(scorer): make Rule 4 (banned phrases) a hard veto scoring 0 — resumes containing "proven track record" or "leveraging" now lose to cleaner candidates instead of shipping with a penalty
 - 2026-04-08 — feat(prompt): add Rules 7-8 — self-employment bullets reframed to match JD role (UX work for UX roles, not backend architecture); projects section reserved for technical highlights and scale
+- 2026-04-08 — refactor(prompt): remove user-specific examples from system prompt — genericize Rule 3 example and Rule 7 to work for any OB1 profile, not just one candidate
 
 ## [0.2.9] — 2026-04-06
 

--- a/src/routes/resume.ts
+++ b/src/routes/resume.ts
@@ -55,7 +55,7 @@ Rules:
 
 3. IMPACT BULLETS: Every bullet must use "action verb + specific achievement + quantified result". Include real project names, real technologies, and real metrics from the candidate's profile. Never genericize specific accomplishments into vague descriptions.
    Bad: "Optimized front-end performance"
-   Good: "Reduced [project name] page load time by 40% through code splitting and lazy loading across 25+ React components"
+   Good: "Reduced page load time by 40% through code splitting and lazy loading across 25+ React components" (use the candidate's actual project name, technology, and metric)
 
 4. AUTHENTICITY: Vary sentence structure and verb choices across bullets. Never use: "results-driven", "proven track record", "leveraging", "dynamic team player", "synergies", "spearheaded". Every bullet must contain at least one detail specific to THIS candidate's actual experience — a project name, a technology choice, a metric, or a specific outcome.
 

--- a/src/routes/resume.ts
+++ b/src/routes/resume.ts
@@ -55,7 +55,7 @@ Rules:
 
 3. IMPACT BULLETS: Every bullet must use "action verb + specific achievement + quantified result". Include real project names, real technologies, and real metrics from the candidate's profile. Never genericize specific accomplishments into vague descriptions.
    Bad: "Optimized front-end performance"
-   Good: "Reduced Artisan Roast page load time by 40% through code splitting and lazy loading across 25+ React components"
+   Good: "Reduced [project name] page load time by 40% through code splitting and lazy loading across 25+ React components"
 
 4. AUTHENTICITY: Vary sentence structure and verb choices across bullets. Never use: "results-driven", "proven track record", "leveraging", "dynamic team player", "synergies", "spearheaded". Every bullet must contain at least one detail specific to THIS candidate's actual experience — a project name, a technology choice, a metric, or a specific outcome.
 
@@ -63,7 +63,7 @@ Rules:
 
 6. SKILLS ORDERING: List 10-15 skills ordered by relevance to the target role. Skills mentioned in the JD come first. Include both the JD's exact terminology and the candidate's equivalent terms.
 
-7. SELF-EMPLOYMENT FRAMING: For self-employed or solo entrepreneur roles, frame the work as if it were a job matching the JD title. Describe the JD-relevant work performed — the interfaces designed, user workflows built, collaboration patterns, design decisions — not just the technical architecture. If the JD is for a UX Engineer, describe the UX engineering done across those projects (workflows, responsive design, accessibility, user testing). Technical architecture details belong in the Projects section, not Employment bullets.
+7. SELF-EMPLOYMENT FRAMING: For self-employed or solo entrepreneur roles, frame the work as if it were a job matching the JD title. Describe the JD-relevant work performed — not just the technical architecture. If the JD emphasizes design, describe design work; if it emphasizes backend, describe backend work. Technical architecture details belong in the Projects section, not Employment bullets.
 
 8. PROJECTS SECTION: Projects should highlight what makes the work impressive at a glance — key features, scale, and standout achievements. Keep it concise with a brief description and 3-4 bullet highlights. Technical architecture depth is welcome here. This is the "nice-to-have" that demonstrates breadth and initiative.
 


### PR DESCRIPTION
## Summary
- Remove user-specific example from Rule 3 ("Artisan Roast" → "[project name]")
- Remove role-specific example from Rule 7 (UX-specific → generic "if JD emphasizes X, describe X work")
- System prompt now works for any candidate with an OB1 profile, not just one user

## Test plan
- [ ] 36 unit tests passing, typecheck clean
- [ ] Prompt-only change — no scorer or endpoint behavior change