### PR TITLE
docs: add mobile-setup caveat to connector instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-04-22 — docs: add mobile-setup caveat to README + workflow connector instructions — claude.ai custom connectors can only be *added* from desktop (web or Claude Desktop app), not the mobile app; once saved they sync automatically. Prevents recruiters from hitting a dead-end trying to add the connector from their phone.
+
 - 2026-04-22 — feat(public-mcp): ship `/public-mcp` endpoint exposing a single unauthenticated tool (`ask_candidate`) that any MCP-aware AI client can add as a custom connector — wraps the existing `/query` handler via a shared `queryProfile` core, supports streaming via MCP progress notifications with client-echoed tokens, and logs every call (HTTP + MCP) to a new `observed_queries` Supabase table; advertised first in the agent card's `supportedInterfaces` (bumped to v1.1.0); 27 ACs defined with 24 automated tests passing, manually verified end-to-end via MCP Inspector including a progressToken routing bug surfaced + fixed during verification
 
 - 2026-04-22 — chore: remove retired Supabase Edge Function artifacts and clarify Railway as the runtime tier — deletes `supabase/functions/open-brain-mcp/` and `supabase/functions/oauth-token/` (source preserved in git history), removes dead `ob1:deploy` / `ob1:logs` npm scripts and `SUPABASE_MCP_URL` env var, rewrites README architecture diagram to show Railway as the runtime host with Supabase scoped to data tier only; eliminates the recurring misread that conflates the retired Edge Function runtime with the active Postgres database

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ The private `/resume` endpoint uses the same match methodology as context, then 
 
 ## Add as a custom connector in Claude
 
-The public MCP endpoint lets any AI client with custom-connector support (Claude.ai web + mobile, Claude Desktop, Cursor, etc.) ask natural-language questions about this candidate directly.
+The public MCP endpoint lets any AI client with custom-connector support (claude.ai web + mobile, Claude Desktop, Cursor, etc.) ask natural-language questions about this candidate directly.
 
 **Connector URL:** `https://<your-agent-domain>/public-mcp`
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ No authentication required. Rate-limited to 30 req/min per IP (shared bucket wit
 
 **Setup in claude.ai:** Settings → Connectors → Add custom connector → paste the URL above. Leave auth fields blank.
 
+> **Mobile note:** Custom connectors must be **added from claude.ai on desktop** (web browser or Claude Desktop app). The mobile app can *use* connectors you've added but cannot *add* new ones. Once saved on desktop, the tool syncs automatically and appears in every new conversation on mobile.
+
 **What to ask once connected:**
 
 - "Does this candidate have production TypeScript experience?"

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -123,7 +123,7 @@ Response:
 
 ### Alternative: MCP connector path
 
-For AI clients that support Model Context Protocol connectors (Claude.ai web + mobile, Claude Desktop, Cursor), the public MCP endpoint lets the calling AI invoke a single tool — `ask_candidate` — as a first-class callable.
+For AI clients that support Model Context Protocol connectors (claude.ai web + mobile, Claude Desktop, Cursor), the public MCP endpoint lets the calling AI invoke a single tool — `ask_candidate` — as a first-class callable.
 
 ```
 POST https://your-agent.example.com/public-mcp
@@ -151,7 +151,7 @@ The MCP interface is advertised in the agent card's `supportedInterfaces` (liste
 
 No authentication required. Rate-limited to 30 req/min per IP (shared bucket with the HTTP endpoints). Every call is logged to the `observed_queries` Supabase table for observability.
 
-**Mobile caveat:** claude.ai's custom connector setup is desktop-only — the mobile app can use connectors but cannot add them. Recruiters on mobile should be pointed at claude.ai desktop (or Claude Desktop app) for the initial setup; the tool syncs automatically once saved.
+**Mobile caveat:** claude.ai custom connectors can only be *added* from claude.ai in a desktop browser (or the Claude Desktop app). The claude.ai mobile app can use connectors but cannot add them. Recruiters on mobile should be pointed at the desktop flow for initial setup; the tool syncs automatically once saved.
 
 ---
 
@@ -237,7 +237,7 @@ The A2A agent card spec is designed for a world where AI systems auto-discover a
 | Scenario | Status | Notes |
 |---|---|---|
 | Claude Desktop with MCP | ✅ Works | Via claude.ai custom connector (OAuth) or direct x-brain-key config |
-| Claude.ai (web + mobile) | ✅ Works | Custom connector with OAuth Client Credentials — one setup, all surfaces |
+| claude.ai (web + mobile) | ✅ Works | Custom connector with OAuth Client Credentials — one setup, all surfaces |
 | Cursor / AI coding assistants | ✅ Works | Via MCP or manual HTTP calls |
 | Custom employer AI agent | ✅ Works | If they're given the agent card URL to target |
 | Consumer phone AI apps (Gemini, ChatGPT) | ❌ No HTTP | These apps have no mechanism to make GET/POST requests |

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -151,6 +151,8 @@ The MCP interface is advertised in the agent card's `supportedInterfaces` (liste
 
 No authentication required. Rate-limited to 30 req/min per IP (shared bucket with the HTTP endpoints). Every call is logged to the `observed_queries` Supabase table for observability.
 
+**Mobile caveat:** claude.ai's custom connector setup is desktop-only — the mobile app can use connectors but cannot add them. Recruiters on mobile should be pointed at claude.ai desktop (or Claude Desktop app) for the initial setup; the tool syncs automatically once saved.
+
 ---
 
 ## Candidate workflow (private MCP interface)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

Adds a short "Mobile note" to the README "Add as a custom connector" section and a matching caveat in `docs/workflow.md`:

> claude.ai's custom connectors must be **added from desktop** (web or Claude Desktop app). The mobile app can use connectors but cannot add them. Once saved on desktop, the tool syncs automatically and appears in every mobile conversation.

Caught live — the dead-end was confusing enough to warrant a prominent doc note so future recruiters (and forkers of the repo) don't hit it.

## Test plan

- [x] `npx tsc --noEmit` passes (no code changes)
- [ ] README renders cleanly on GitHub
- [ ] Mobile instruction visible in the right scroll position under "Add as a custom connector"