### PR TITLE
fix(mcp): add refresh_token grant to eliminate reconnection prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-04-30 — fix(mcp): add refresh_token grant to eliminate reconnection prompts — adds `refresh_token` to `grant_types_supported` OAuth metadata, implements RFC 6749 refresh_token grant in `/token`, issues refresh_token alongside access_token in authorization_code flow; tokens use configurable TTLs via `ACCESS_TOKEN_TTL` (default 1h) and `REFRESH_TOKEN_TTL` (default 30d) env vars; verified in production with claude.ai — automatic token refresh works without "reconnect required" prompts
+
 - 2026-04-22 — docs: add mobile-setup caveat to README + workflow connector instructions — claude.ai custom connectors can only be *added* from desktop (web or Claude Desktop app), not the mobile app; once saved they sync automatically. Prevents recruiters from hitting a dead-end trying to add the connector from their phone.
 
 - 2026-04-22 — feat(public-mcp): ship `/public-mcp` endpoint exposing a single unauthenticated tool (`ask_candidate`) that any MCP-aware AI client can add as a custom connector — wraps the existing `/query` handler via a shared `queryProfile` core, supports streaming via MCP progress notifications with client-echoed tokens, and logs every call (HTTP + MCP) to a new `observed_queries` Supabase table; advertised first in the agent card's `supportedInterfaces` (bumped to v1.1.0); 27 ACs defined with 24 automated tests passing, manually verified end-to-end via MCP Inspector including a progressToken routing bug surfaced + fixed during verification

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -744,10 +744,11 @@ async function authenticate(c: Context): Promise<boolean> {
   const bearerToken = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null
   if (bearerToken && jwtSecretBytes) {
     try {
-      await jwtVerify(bearerToken, jwtSecretBytes, { algorithms: ['HS256'] })
+      const result = await jwtVerify(bearerToken, jwtSecretBytes, { algorithms: ['HS256'] })
+      console.log('[mcp] authenticate success', { sub: result.payload.sub, exp: result.payload.exp })
       return true
-    } catch {
-      // fall through
+    } catch (err) {
+      console.log('[mcp] authenticate failure', { error: (err as Error).message })
     }
   }
   return false

--- a/src/routes/oauth.ts
+++ b/src/routes/oauth.ts
@@ -7,6 +7,11 @@ const JWT_SECRET = process.env.JWT_SECRET
 if (!JWT_SECRET) throw new Error('Missing JWT_SECRET')
 const jwtSecretBytes = new TextEncoder().encode(JWT_SECRET)
 
+const ACCESS_TOKEN_TTL = parseInt(process.env.ACCESS_TOKEN_TTL ?? '3600')
+const REFRESH_TOKEN_TTL = parseInt(process.env.REFRESH_TOKEN_TTL ?? '2592000')
+
+const inMemoryRefreshTokens = new Map<string, { client_id: string; expires_at: number }>()
+
 // Allowlist of permitted client IDs — set OAUTH_CLIENT_ID env var (comma-separated for multiple)
 const ALLOWED_CLIENT_IDS = new Set(
   (process.env.OAUTH_CLIENT_ID ?? 'claude-ai-connector').split(',').map((s) => s.trim()).filter(Boolean)
@@ -40,6 +45,9 @@ const cleanupInterval = setInterval(() => {
   for (const [code, data] of authCodes) {
     if (now > data.expires_at) authCodes.delete(code)
   }
+  for (const [token, data] of inMemoryRefreshTokens) {
+    if (now > data.expires_at) inMemoryRefreshTokens.delete(token)
+  }
 }, 60_000)
 cleanupInterval.unref()
 
@@ -52,7 +60,7 @@ oauth.get('/.well-known/oauth-authorization-server', (c) => {
     authorization_endpoint: `${base}/authorize`,
     token_endpoint: `${base}/token`,
     response_types_supported: ['code'],
-    grant_types_supported: ['authorization_code', 'client_credentials'],
+    grant_types_supported: ['authorization_code', 'client_credentials', 'refresh_token'],
     code_challenge_methods_supported: ['S256'],
     token_endpoint_auth_methods_supported: ['none', 'client_secret_post'],
   })
@@ -110,6 +118,7 @@ oauth.post('/token', async (c) => {
   let client_id: string | undefined
   let client_secret: string | undefined
   let redirect_uri: string | undefined
+  let refresh_token: string | undefined
 
   if (contentType.includes('application/x-www-form-urlencoded')) {
     const body = await c.req.formData()
@@ -119,6 +128,7 @@ oauth.post('/token', async (c) => {
     client_id = body.get('client_id')?.toString()
     client_secret = body.get('client_secret')?.toString()
     redirect_uri = body.get('redirect_uri')?.toString()
+    refresh_token = body.get('refresh_token')?.toString()
   } else {
     const body = await c.req.json().catch(() => ({}))
     grant_type = body.grant_type
@@ -127,6 +137,7 @@ oauth.post('/token', async (c) => {
     client_id = body.client_id
     client_secret = body.client_secret
     redirect_uri = body.redirect_uri
+    refresh_token = body.refresh_token
   }
 
   const noCacheHeaders = { 'Cache-Control': 'no-store', Pragma: 'no-cache' } as const
@@ -140,7 +151,7 @@ oauth.post('/token', async (c) => {
     }
 
     const now = Math.floor(Date.now() / 1000)
-    const expiresIn = 3600
+    const expiresIn = ACCESS_TOKEN_TTL
     const access_token = await new SignJWT({ sub: client_id })
       .setProtectedHeader({ alg: 'HS256' })
       .setIssuedAt(now)
@@ -149,6 +160,33 @@ oauth.post('/token', async (c) => {
 
     return c.json(
       { access_token, token_type: 'Bearer', expires_in: expiresIn },
+      200,
+      noCacheHeaders
+    )
+  }
+
+  if (grant_type === 'refresh_token') {
+    if (!refresh_token) {
+      return c.json({ error: 'invalid_request', error_description: 'refresh_token required' }, 400, noCacheHeaders)
+    }
+
+    const stored = inMemoryRefreshTokens.get(refresh_token)
+    if (!stored || Date.now() > stored.expires_at) {
+      console.log('[oauth] refresh_token grant: invalid/expired token')
+      return c.json({ error: 'invalid_grant' }, 400, noCacheHeaders)
+    }
+
+    console.log('[oauth] refresh_token grant success', { client_id: stored.client_id })
+
+    const now = Math.floor(Date.now() / 1000)
+    const newAccessToken = await new SignJWT({ sub: stored.client_id })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setIssuedAt(now)
+      .setExpirationTime(now + ACCESS_TOKEN_TTL)
+      .sign(jwtSecretBytes)
+
+    return c.json(
+      { access_token: newAccessToken, token_type: 'Bearer', expires_in: ACCESS_TOKEN_TTL },
       200,
       noCacheHeaders
     )
@@ -180,7 +218,7 @@ oauth.post('/token', async (c) => {
   authCodes.delete(code)
 
   const now = Math.floor(Date.now() / 1000)
-  const expiresIn = 3600
+  const expiresIn = ACCESS_TOKEN_TTL
 
   const access_token = await new SignJWT({ sub: client_id })
     .setProtectedHeader({ alg: 'HS256' })
@@ -188,8 +226,16 @@ oauth.post('/token', async (c) => {
     .setExpirationTime(now + expiresIn)
     .sign(jwtSecretBytes)
 
+  const refreshToken = crypto.randomBytes(32).toString('hex')
+  inMemoryRefreshTokens.set(refreshToken, {
+    client_id,
+    expires_at: Date.now() + REFRESH_TOKEN_TTL * 1000,
+  })
+
+  console.log('[oauth] authorization_code grant', { client_id, has_refresh: true })
+
   return c.json(
-    { access_token, token_type: 'Bearer', expires_in: expiresIn },
+    { access_token, refresh_token: refreshToken, token_type: 'Bearer', expires_in: expiresIn },
     200,
     { 'Cache-Control': 'no-store', Pragma: 'no-cache' }
   )


### PR DESCRIPTION
## Summary
- Adds `refresh_token` to OAuth `grant_types_supported` metadata
- Implements RFC 6749 refresh_token grant in `/token` endpoint
- Issues refresh_token alongside access_token in authorization_code flow
- Uses configurable TTLs via `ACCESS_TOKEN_TTL` (default 1h) and `REFRESH_TOKEN_TTL` (default 30d) env vars
- Adds logging for auth success/failure in mcp.ts authenticate()

## Root Cause
Claude.ai was showing "reconnect required" because the server didn't advertise `refresh_token` in OAuth metadata. When access tokens expired (1h JWT TTL), claude.ai had no refresh path and re-ran the full OAuth flow.

## Verified (on production main)
- Railway logs confirm refresh_token grant succeeds without /authorize redirect
- No 401 errors after initial auth cycle