### PR TITLE
feat(mcp): add summarize_observed_queries tool for public query traffic analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-04-30 — feat(mcp): add summarize_observed_queries tool for public query traffic analytics — aggregate stats from observed_queries table showing total queries, source split (MCP/HTTP), latency percentiles, top caller hints, top user-agents, top questions, top models, time-bucketed trend; supports filtering by source, caller_hint prefix, time bucket (hour/day/week), top_n count; output as human-readable text (default) or JSON envelope; hard cap at 10k rows with truncated flag; 11 new unit tests
+
 - 2026-04-22 — docs: add mobile-setup caveat to README + workflow connector instructions — claude.ai custom connectors can only be *added* from desktop (web or Claude Desktop app), not the mobile app; once saved they sync automatically. Prevents recruiters from hitting a dead-end trying to add the connector from their phone.
 
 - 2026-04-22 — feat(public-mcp): ship `/public-mcp` endpoint exposing a single unauthenticated tool (`ask_candidate`) that any MCP-aware AI client can add as a custom connector — wraps the existing `/query` handler via a shared `queryProfile` core, supports streaming via MCP progress notifications with client-echoed tokens, and logs every call (HTTP + MCP) to a new `observed_queries` Supabase table; advertised first in the agent card's `supportedInterfaces` (bumped to v1.1.0); 27 ACs defined with 24 automated tests passing, manually verified end-to-end via MCP Inspector including a progressToken routing bug surfaced + fixed during verification

--- a/README.md
+++ b/README.md
@@ -297,6 +297,36 @@ Then in Claude:
 > "Am I a good fit for this role? [paste JD]"
 > "Log an application to Stripe — staff engineer, applied today"
 
+### Available private MCP tools
+
+The private `/mcp` endpoint exposes these tools for your personal use:
+
+**Open Brain tools:**
+- `search_thoughts` — Semantic search over your captured thoughts
+- `list_thoughts` — List recent thoughts with filters (type, topic, person, time)
+- `thought_stats` — Get summary stats of all thoughts (totals, types, top topics, people)
+- `capture_thought` — Save a new thought with auto-generated embedding + metadata
+- `update_profile` — Update your public profile (summary, skills, employment, projects, education, availability, contact)
+- `upsert_project` — Add or update a portfolio project by slug
+
+**Job pipeline tools:**
+- `score_match` — Score a job description against your profile
+- `log_application` — Log a new job application (auto-scores if JD provided)
+- `update_stage` — Move an application to a new stage (applied → phone_screen → technical → final → offer → rejected → withdrawn)
+- `add_contact` — Add a recruiter or contact to an application
+- `list_applications` — List your applications with filters
+- `get_application` — Get full details of an application (contacts, stage history)
+- `set_follow_up` — Set a follow-up date with notes
+- `search_applications` — Search applications by company, role, JD, or notes
+
+**Observability tools:**
+- `summarize_observed_queries` — Get aggregated stats on public query traffic (MCP + HTTP). Useful for understanding how external AI clients are discovering and querying you.
+
+Example queries:
+> "Summarize the public query traffic for the last week"
+> "Which ATS tools have been hitting me most this month?"
+> "Show me the trend of questions over the past 7 days by day"
+
 ---
 
 ## Stack

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,9 +16,9 @@ See [ROADMAP.md](../ROADMAP.md) for what's shipped and what's in progress.
 - [mcp-architecture.md](mcp-architecture.md) — MCP transport architecture (stateless Streamable HTTP, auth, Railway runtime)
 - [resume-pipeline-v2.md](resume-pipeline-v2.md) — `/resume` endpoint's dual-gen + rubric scorer pipeline
 - [workflow.md](workflow.md) — how employer AI, recruiters, and the candidate each interact with the agent
+- [plans/private-mcp-summarize-observed-queries.md](plans/private-mcp-summarize-observed-queries.md) — private MCP `summarize_observed_queries` tool for public query traffic analytics
 
 ### In progress (plans)
 
-- [plans/private-mcp-summarize-observed-queries.md](plans/private-mcp-summarize-observed-queries.md) — private MCP `summarize_observed_queries` tool for public query traffic analytics
 - [plans/public-mcp-query-only.md](plans/public-mcp-query-only.md) — public `/public-mcp` endpoint with `ask_candidate` tool
 - [plans/a2a-trust-layer.md](plans/a2a-trust-layer.md) — exploring: signed agent cards, invocation receipts, `/verify` endpoint

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,5 +19,6 @@ See [ROADMAP.md](../ROADMAP.md) for what's shipped and what's in progress.
 
 ### In progress (plans)
 
+- [plans/private-mcp-summarize-observed-queries.md](plans/private-mcp-summarize-observed-queries.md) — private MCP `summarize_observed_queries` tool for public query traffic analytics
 - [plans/public-mcp-query-only.md](plans/public-mcp-query-only.md) — public `/public-mcp` endpoint with `ask_candidate` tool
 - [plans/a2a-trust-layer.md](plans/a2a-trust-layer.md) — exploring: signed agent cards, invocation receipts, `/verify` endpoint

--- a/docs/plans/private-mcp-summarize-observed-queries.md
+++ b/docs/plans/private-mcp-summarize-observed-queries.md
@@ -1,0 +1,180 @@
+# Plan: Private MCP — `summarize_observed_queries` Tool
+
+**Branch:** `claude/verify-mcp-usage-logging-0oj2B` (this plan)
+**Status:** Doc-only — implementation deferred
+**Scope:** Add a single read-only aggregation tool to the private (authenticated) MCP server that surfaces stats over the `observed_queries` table, so the candidate can ask the LLM things like "what did people ask this week?" or "which ATSes hit me most?" without leaving chat.
+
+---
+
+## Context
+
+The public MCP (`src/routes/public-mcp.ts`) and HTTP `POST /query` both write a row per call to `observed_queries` (see `supabase/migrations/20260422000000_observed_queries.sql`). The table has RLS enabled and is `service_role` only (`supabase/migrations/20260422000001_observed_queries_rls.sql`), so today the data is reachable only via the Supabase dashboard.
+
+The private MCP server already runs with `service_role` access and is the natural surface for the candidate's own admin/observability tools (`thought_stats`, `match_search`, `update_profile`, etc.). Adding a stats tool here closes the loop: traffic in → stored → queryable in chat.
+
+This plan covers only `summarize_observed_queries`. A row-level reader (`list_observed_queries`) is intentionally deferred — most questions the candidate will ask are aggregate ("how many", "top N", "trend over time"), and surfacing raw question text per row carries a small privacy/cost footprint we can postpone until there's a concrete need.
+
+---
+
+## Goals
+
+1. Let the candidate query `observed_queries` aggregates from chat without writing SQL or opening Supabase.
+2. Cover the questions most likely to be asked: volume, source split, top callers, latency health, top user-agents, time-bucketed trend.
+3. Keep the tool stateless and read-only — no schema changes to `observed_queries`, no new write paths.
+4. Return a compact, LLM-friendly text summary by default; structured JSON available behind a flag for downstream tooling.
+5. Reuse the existing `thought_stats` shape as a stylistic template so the private MCP stays internally consistent.
+
+## Non-goals
+
+- Exposing raw question/answer text or `ip_hash`/`user_agent` per-row. Aggregates only.
+- Public MCP exposure. This is admin-only; lives behind the existing `/mcp` auth.
+- Mirroring write logging onto private-MCP tool calls. Tracked separately — different dataset (own usage vs. external traffic), different threat model.
+- Cross-table joins (e.g. correlating to `job_applications`). Out of scope; revisit if a real question needs it.
+- Clustering/semantic grouping of question text. Exact-string top-N is enough for v1; embedding-based clustering is a follow-up if traffic ever justifies it.
+
+---
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                   resume-agent (Hono app)                             │
+│                                                                       │
+│   /mcp  (PRIVATE — auth required)                                     │
+│     └─ buildPrivateServer()                                           │
+│           ├─ … existing tools …                                       │
+│           └─ summarize_observed_queries  ← NEW                        │
+│                 │                                                     │
+│                 └─ reads observed_queries (service_role)              │
+│                                                                       │
+│   /public-mcp  (PUBLIC)  ──writes──▶  observed_queries                │
+│   /query       (PUBLIC)  ──writes──▶  observed_queries                │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+No new tables, no migrations, no new env vars. The tool is a read-only view onto an existing table that's already populated by both public surfaces.
+
+---
+
+## Tool shape
+
+**Name:** `summarize_observed_queries`
+**Title:** "Summarize Public Query Traffic"
+**File:** `src/routes/mcp.ts` (new `server.registerTool` block, sibling to `thought_stats`)
+
+### Input schema
+
+```ts
+{
+  since:        z.string().datetime().optional()
+                  .describe('ISO timestamp lower bound. Defaults to 7 days ago.'),
+  until:        z.string().datetime().optional()
+                  .describe('ISO timestamp upper bound. Defaults to now.'),
+  source:       z.enum(['mcp', 'http']).optional()
+                  .describe('Filter to one surface. Omit for both.'),
+  caller_hint:  z.string().optional()
+                  .describe('Filter by caller_hint prefix (e.g. "ATS", "recruiter").'),
+  bucket:       z.enum(['hour', 'day', 'week']).optional().default('day')
+                  .describe('Time bucket for the trend series.'),
+  top_n:        z.number().int().min(1).max(50).optional().default(10)
+                  .describe('How many rows to include in top-N lists.'),
+  format:       z.enum(['text', 'json']).optional().default('text')
+                  .describe('"text" returns a human summary; "json" returns the raw envelope.'),
+}
+```
+
+### Output envelope (when `format: 'json'`)
+
+```ts
+{
+  window: { since: string, until: string, days: number },
+  totals: {
+    count: number,
+    by_source: { mcp: number, http: number },
+    distinct_user_agents: number,
+    distinct_ip_hashes: number,
+  },
+  latency: {
+    avg_ms: number,
+    p50_ms: number,
+    p95_ms: number,
+    max_ms: number,
+  },
+  top_caller_hints:  Array<{ caller_hint: string | null, count: number }>,
+  top_user_agents:   Array<{ user_agent: string | null, count: number }>,
+  top_questions:     Array<{ question: string, count: number }>,  // exact-string match
+  top_models:        Array<{ model: string | null, count: number }>,
+  trend:             Array<{ bucket_start: string, count: number }>,
+}
+```
+
+For `format: 'text'` (default), the tool serializes the envelope to a compact markdown block — matches the `thought_stats` precedent so the LLM can render it directly in chat.
+
+### Default behavior
+
+- No args → last 7 days, day buckets, top 10, text output. The shortest useful question ("how's traffic?") gets a useful answer.
+- `top_questions` truncates each question to ~120 chars in the text rendering to keep responses scannable; full text is preserved in `format: 'json'`.
+
+---
+
+## Implementation options
+
+Two viable paths. Recommend **Option A** for v1.
+
+### Option A — TypeScript aggregation in the handler
+
+- Single `select()` over `observed_queries` with the time-window + filters applied.
+- Aggregate in-process: counts, percentiles, top-N via `Map`, trend via bucket-key reduction.
+- Hard cap the row pull at e.g. 10k; if the window exceeds the cap, return a `truncated: true` flag in the envelope and a soft warning in the text rendering.
+
+**Pros:** zero migration, zero RPC plumbing, easy to iterate on the shape, mirrors `thought_stats`.
+**Cons:** O(rows) memory in the worker for big windows. Fine until volume grows past ~10k/week.
+
+### Option B — Postgres view or RPC function
+
+- New `observed_queries_summary(since, until, source, caller_hint, bucket, top_n)` SQL function returning the envelope as JSON.
+- Tool becomes a thin `supabase.rpc()` wrapper.
+
+**Pros:** scales; aggregation runs in Postgres. Reusable from future surfaces (e.g. an admin web UI).
+**Cons:** new migration, harder to iterate while we're still discovering the right shape.
+
+**Recommendation:** start with A. Promote to B only after the envelope stabilizes and either (a) row volume crosses a threshold where in-process aggregation hurts, or (b) we want to reuse the same summary in a non-MCP surface.
+
+---
+
+## Privacy & safety
+
+- The tool is on the **private** MCP — already gated by the existing auth middleware. No additional access control needed.
+- `ip_hash` is never returned in the envelope; only `distinct_ip_hashes` (a count) is exposed. This matches the original "no PII in observability" intent of the salt-hashing scheme in `src/lib/log-observed-query.ts:54`.
+- `top_questions` does surface raw question text. That's intentional — answering "what are people asking?" is the whole point — but worth noting if we ever add lower-trust readers to the private surface.
+- Read-only: no `update`/`insert`/`delete` paths added. Tool can't be repurposed for tampering.
+
+---
+
+## Testing
+
+- Unit: handler with a stubbed Supabase client returning fixed rows; assert envelope math (counts, p50/p95, top-N ordering, bucket assignment across DST boundary).
+- Integration: hit the private `/mcp` route with the tool call after seeding a handful of `observed_queries` rows; assert the text rendering contains the expected sections and the JSON envelope round-trips.
+- Edge cases:
+  - Empty window → envelope with all zeros, friendly text ("No queries in this window.").
+  - `since > until` → input validation rejects with a clear MCP error.
+  - Window pulling > 10k rows → `truncated: true` and the trend/top-N still computed over the capped sample with a note in the text output.
+
+No new migrations, so no migration test pass needed.
+
+---
+
+## Open questions
+
+1. **Exact-string top questions vs. normalized:** lowercase + trim before grouping? v1 says yes (cheap, matches user intuition); call out in docs that "Tell me about yourself" and "tell me about yourself!" group together.
+2. **Bucket time zone:** UTC for v1 to keep aggregation deterministic; the LLM can re-interpret in the user's TZ when it renders.
+3. **Should `format: 'json'` also be the default once we know the LLM can render structured output reliably?** Defer — text default keeps token cost predictable and matches sibling tools.
+4. **Companion `list_observed_queries` (row reader):** explicitly out of scope here. Add when there's a concrete question aggregates can't answer.
+
+---
+
+## Out-of-scope follow-ups (tracked separately)
+
+- Mirror logging onto the private MCP for own-usage stats (different dataset, different table or `source='mcp-private'` enum extension).
+- Embedding-based clustering of question text for "what topics are people asking about?" once exact-string top-N stops being informative.
+- Surface the same summary in an authenticated web admin view (would justify promoting to Option B).

--- a/docs/plans/private-mcp-summarize-observed-queries.md
+++ b/docs/plans/private-mcp-summarize-observed-queries.md
@@ -1,7 +1,7 @@
 # Plan: Private MCP — `summarize_observed_queries` Tool
 
 **Branch:** `claude/verify-mcp-usage-logging-0oj2B` (this plan)
-**Status:** Doc-only — implementation deferred
+**Status:** ✅ Shipped
 **Scope:** Add a single read-only aggregation tool to the private (authenticated) MCP server that surfaces stats over the `observed_queries` table, so the candidate can ask the LLM things like "what did people ask this week?" or "which ATSes hit me most?" without leaving chat.
 
 ---
@@ -178,3 +178,30 @@ No new migrations, so no migration test pass needed.
 - Mirror logging onto the private MCP for own-usage stats (different dataset, different table or `source='mcp-private'` enum extension).
 - Embedding-based clustering of question text for "what topics are people asking about?" once exact-string top-N stops being informative.
 - Surface the same summary in an authenticated web admin view (would justify promoting to Option B).
+
+---
+
+## Acceptance Criteria (AC-1 through AC-11)
+
+### Unit tests — `tests/summarize-observed-queries.test.ts`
+
+- **AC-1:** Empty window returns friendly message "No queries in this window."
+- **AC-2:** `since > until` — returns valid envelope (caller should validate)
+- **AC-3:** Window > 10k rows sets `truncated: true` flag
+- **AC-4:** Source filter (`mcp` or `http`) works correctly
+- **AC-5:** `caller_hint` prefix filter works correctly
+- **AC-6:** Time bucket parameter (`hour`, `day`, `week`) groups correctly
+- **AC-7:** `top_n` parameter limits lists to specified count
+- **AC-8:** `format: 'json'` returns full envelope with all fields
+- **AC-9:** `format: 'text'` (default) renders human-readable markdown
+- **AC-10:** Latency stats (avg, p50, p95, max) computed correctly
+- **AC-11:** Question normalization groups "Tell me about yourself" and "tell me about yourself!" together (lowercase + trim + strip trailing punctuation)
+
+### Integration tests (to be added)
+
+- **AC-12:** Tool appears in `tools/list` response from private `/mcp` endpoint
+- **AC-13:** Calling the tool returns aggregated data from `observed_queries` table
+- **AC-14:** Text output contains expected sections (Total queries, by source, Top caller hints, Trend)
+- **AC-15:** JSON envelope round-trips correctly
+- **AC-16:** Empty table returns "No queries in this window."
+- **AC-17:** Invalid input (e.g., malformed datetime) returns clear error message

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.2.18",
+      "version": "0.2.19",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "private": true,
   "type": "module",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "seed": "tsx --env-file=.env.local scripts/seed.ts",
     "db:link": "supabase link --project-ref $SUPABASE_PROJECT_REF",
     "db:push": "supabase db push",
-    "test:unit": "tsx --test tests/resume-framing.test.ts tests/score-resume.test.ts tests/strip-banned.test.ts tests/sync-enrichment.test.ts",
+    "test:unit": "tsx --test tests/resume-framing.test.ts tests/score-resume.test.ts tests/strip-banned.test.ts tests/sync-enrichment.test.ts tests/summarize-observed-queries.test.ts",
     "test:rubric": "tsx --test tests/score-resume.test.ts",
     "test": "echo 'Run npm run test:unit for unit tests, npm run test:integration for live integration tests.'",
     "test:integration": "tsx --env-file=.env.local --test tests/pipeline.test.ts tests/update-profile.test.ts tests/projects-and-scoring.test.ts",

--- a/src/lib/summarize-observed-queries.ts
+++ b/src/lib/summarize-observed-queries.ts
@@ -53,10 +53,14 @@ export interface SummarizeEnvelope {
 export function aggregateObservedQueries(rows: ObservedQuery[], input: SummarizeInput): SummarizeEnvelope {
   const top_n = input.top_n ?? 10
   const bucket = input.bucket ?? 'day'
-  const format = input.format ?? 'text'
 
   const until = input.until ? new Date(input.until) : new Date()
   const since = input.since ? new Date(input.since) : new Date(until.getTime() - 7 * 24 * 60 * 60 * 1000)
+
+  // Validate: since must not be after until
+  if (input.since && input.until && new Date(input.since) > new Date(input.until)) {
+    throw new Error('Invalid window: "since" must not be after "until"')
+  }
 
   // Filter rows
   let filtered = rows.filter(r => {
@@ -245,11 +249,27 @@ export async function summarizeObservedQueries(input: SummarizeInput): Promise<{
     const parsed = SummarizeInputSchema.parse(input)
 
     // Fetch rows from observed_queries (service_role access)
-    const { data: rows, error } = await supabase
+    let query = supabase
       .from('observed_queries')
       .select('source, question, caller_hint, user_agent, ip_hash, model, latency_ms, created_at')
       .order('created_at', { ascending: false })
       .limit(10000)
+
+    // Apply filters in SQL for efficiency
+    if (parsed.since) {
+      query = query.gte('created_at', parsed.since)
+    }
+    if (parsed.until) {
+      query = query.lte('created_at', parsed.until)
+    }
+    if (parsed.source) {
+      query = query.eq('source', parsed.source)
+    }
+    if (parsed.caller_hint) {
+      query = query.like('caller_hint', `${parsed.caller_hint}%`)
+    }
+
+    const { data: rows, error } = await query
 
     if (error) {
       return { content: [{ type: 'text', text: `Failed to fetch observed_queries: ${error.message}` }], isError: true }
@@ -261,6 +281,11 @@ export async function summarizeObservedQueries(input: SummarizeInput): Promise<{
 
     // Aggregate
     const envelope = aggregateObservedQueries(rows as ObservedQuery[], parsed)
+
+    // Check if no rows matched the window after aggregation
+    if (envelope.totals.count === 0) {
+      return { content: [{ type: 'text', text: 'No queries in this window.' }] }
+    }
 
     // Return in requested format
     if (parsed.format === 'json') {

--- a/src/lib/summarize-observed-queries.ts
+++ b/src/lib/summarize-observed-queries.ts
@@ -1,0 +1,277 @@
+import { supabase } from './supabase.js'
+import { z } from 'zod'
+
+// ── Types ───────────────────────────────────────────────────
+
+export interface ObservedQuery {
+  source: 'mcp' | 'http'
+  question: string
+  caller_hint: string | null
+  user_agent: string | null
+  ip_hash: string | null
+  model: string | null
+  latency_ms: number | null
+  created_at: string
+}
+
+export const SummarizeInputSchema = z.object({
+  since: z.string().datetime().optional().describe('ISO timestamp lower bound. Defaults to 7 days ago.'),
+  until: z.string().datetime().optional().describe('ISO timestamp upper bound. Defaults to now.'),
+  source: z.enum(['mcp', 'http']).optional().describe('Filter to one surface. Omit for both.'),
+  caller_hint: z.string().optional().describe('Filter by caller_hint prefix (e.g. "ATS", "recruiter").'),
+  bucket: z.enum(['hour', 'day', 'week']).optional().default('day').describe('Time bucket for the trend series.'),
+  top_n: z.number().int().min(1).max(50).optional().default(10).describe('How many rows to include in top-N lists.'),
+  format: z.enum(['text', 'json']).optional().default('text').describe('"text" returns a human summary; "json" returns the raw envelope.'),
+})
+
+export type SummarizeInput = z.infer<typeof SummarizeInputSchema>
+
+export interface SummarizeEnvelope {
+  window: { since: string; until: string; days: number }
+  totals: {
+    count: number
+    by_source: { mcp: number; http: number }
+    distinct_user_agents: number
+    distinct_ip_hashes: number
+  }
+  latency: {
+    avg_ms: number
+    p50_ms: number
+    p95_ms: number
+    max_ms: number
+  }
+  top_caller_hints: { caller_hint: string | null; count: number }[]
+  top_user_agents: { user_agent: string | null; count: number }[]
+  top_questions: { question: string; count: number }[]
+  top_models: { model: string | null; count: number }[]
+  trend: { bucket_start: string; count: number }[]
+  truncated?: boolean
+}
+
+// ── Core aggregation function ───────────────────────────────
+
+export function aggregateObservedQueries(rows: ObservedQuery[], input: SummarizeInput): SummarizeEnvelope {
+  const top_n = input.top_n ?? 10
+  const bucket = input.bucket ?? 'day'
+  const format = input.format ?? 'text'
+
+  const until = input.until ? new Date(input.until) : new Date()
+  const since = input.since ? new Date(input.since) : new Date(until.getTime() - 7 * 24 * 60 * 60 * 1000)
+
+  // Filter rows
+  let filtered = rows.filter(r => {
+    const created = new Date(r.created_at)
+    if (created < since || created > until) return false
+    if (input.source && r.source !== input.source) return false
+    if (input.caller_hint && !(r.caller_hint?.startsWith(input.caller_hint))) return false
+    return true
+  })
+
+  // Hard cap at 10k rows
+  let truncated = false
+  if (filtered.length > 10000) {
+    filtered = filtered.slice(0, 10000)
+    truncated = true
+  }
+
+  // Count by source
+  const bySource = { mcp: 0, http: 0 }
+  for (const r of filtered) {
+    if (r.source === 'mcp') bySource.mcp++
+    else bySource.http++
+  }
+
+  // Distinct user_agents and ip_hashes
+  const userAgents = new Set(filtered.map(r => r.user_agent).filter(Boolean))
+  const ipHashes = new Set(filtered.map(r => r.ip_hash).filter(Boolean))
+
+  // Latency stats
+  const latencies = filtered.map(r => r.latency_ms).filter((l): l is number => l !== null)
+  const sortedLatencies = [...latencies].sort((a, b) => a - b)
+  const avgMs = latencies.length ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length) : 0
+  const p50Ms = sortedLatencies[Math.floor(sortedLatencies.length * 0.5)] ?? 0
+  const p95Ms = sortedLatencies[Math.floor(sortedLatencies.length * 0.95)] ?? 0
+  const maxMs = sortedLatencies[sortedLatencies.length - 1] ?? 0
+
+  // Top caller_hints
+  const callerHintCounts = new Map<string | null, number>()
+  for (const r of filtered) {
+    const key = r.caller_hint
+    callerHintCounts.set(key, (callerHintCounts.get(key) ?? 0) + 1)
+  }
+  const topCallerHints = [...callerHintCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, top_n)
+    .map(([caller_hint, count]) => ({ caller_hint, count }))
+
+  // Top user_agents
+  const userAgentCounts = new Map<string | null, number>()
+  for (const r of filtered) {
+    const key = r.user_agent
+    userAgentCounts.set(key, (userAgentCounts.get(key) ?? 0) + 1)
+  }
+  const topUserAgents = [...userAgentCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, top_n)
+    .map(([user_agent, count]) => ({ user_agent, count }))
+
+  // Top questions (normalized: lowercase + trim + strip trailing punctuation)
+  const stripPunctuation = (s: string) => s.replace(/[.!?,:;]+$/, '')
+  const questionCounts = new Map<string, { original: string; count: number }>()
+  for (const r of filtered) {
+    const normalized = stripPunctuation(r.question.toLowerCase().trim())
+    const existing = questionCounts.get(normalized)
+    if (existing) {
+      existing.count++
+    } else {
+      questionCounts.set(normalized, { original: r.question, count: 1 })
+    }
+  }
+  const topQuestions = [...questionCounts.values()]
+    .sort((a, b) => b.count - a.count)
+    .slice(0, top_n)
+    .map(({ original, count }) => ({ question: original, count }))
+
+  // Top models
+  const modelCounts = new Map<string | null, number>()
+  for (const r of filtered) {
+    const key = r.model
+    modelCounts.set(key, (modelCounts.get(key) ?? 0) + 1)
+  }
+  const topModels = [...modelCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, top_n)
+    .map(([model, count]) => ({ model, count }))
+
+  // Trend (time bucketing)
+  const bucketMs = bucket === 'hour' ? 60 * 60 * 1000 : bucket === 'week' ? 7 * 24 * 60 * 60 * 1000 : 24 * 60 * 60 * 1000
+  const trendMap = new Map<string, number>()
+  for (const r of filtered) {
+    const created = new Date(r.created_at)
+    const bucketTime = Math.floor(created.getTime() / bucketMs) * bucketMs
+    const bucketStart = bucket === 'day' || bucket === 'week'
+      ? new Date(bucketTime).toISOString().slice(0, 10)
+      : new Date(bucketTime).toISOString()
+    trendMap.set(bucketStart, (trendMap.get(bucketStart) ?? 0) + 1)
+  }
+  const trend = [...trendMap.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([bucket_start, count]) => ({ bucket_start, count }))
+
+  const days = Math.round((until.getTime() - since.getTime()) / (24 * 60 * 60 * 1000))
+
+  return {
+    window: { since: since.toISOString(), until: until.toISOString(), days },
+    totals: {
+      count: filtered.length,
+      by_source: bySource,
+      distinct_user_agents: userAgents.size,
+      distinct_ip_hashes: ipHashes.size,
+    },
+    latency: { avg_ms: avgMs, p50_ms: p50Ms, p95_ms: p95Ms, max_ms: maxMs },
+    top_caller_hints: topCallerHints,
+    top_user_agents: topUserAgents,
+    top_questions: topQuestions,
+    top_models: topModels,
+    trend,
+    ...(truncated && { truncated: true }),
+  }
+}
+
+// ── Text formatter (matches thought_stats style) ────────────
+
+export function formatEnvelopeToText(envelope: SummarizeEnvelope): string {
+  const lines: string[] = [
+    `Query Traffic Summary (${envelope.window.days} days)`,
+    '',
+    `Total queries: ${envelope.totals.count}`,
+    `  by source: MCP: ${envelope.totals.by_source.mcp}, HTTP: ${envelope.totals.by_source.http}`,
+    `  distinct user-agents: ${envelope.totals.distinct_user_agents}`,
+    `  distinct IPs: ${envelope.totals.distinct_ip_hashes}`,
+  ]
+
+  if (envelope.latency.avg_ms > 0) {
+    lines.push('', 'Latency:')
+    lines.push(`  avg: ${envelope.latency.avg_ms}ms, p50: ${envelope.latency.p50_ms}ms, p95: ${envelope.latency.p95_ms}ms, max: ${envelope.latency.max_ms}ms`)
+  }
+
+  if (envelope.top_caller_hints.length) {
+    lines.push('', 'Top caller hints:')
+    for (const { caller_hint, count } of envelope.top_caller_hints.slice(0, 5)) {
+      lines.push(`  ${caller_hint ?? '(none)'}: ${count}`)
+    }
+  }
+
+  if (envelope.top_user_agents.length) {
+    lines.push('', 'Top user-agents:')
+    for (const { user_agent, count } of envelope.top_user_agents.slice(0, 5)) {
+      lines.push(`  ${user_agent?.slice(0, 60) ?? '(none)'}: ${count}`)
+    }
+  }
+
+  if (envelope.top_questions.length) {
+    lines.push('', 'Top questions:')
+    for (const { question, count } of envelope.top_questions.slice(0, 5)) {
+      lines.push(`  ${question.slice(0, 80)}: ${count}`)
+    }
+  }
+
+  if (envelope.top_models.length) {
+    lines.push('', 'Top models:')
+    for (const { model, count } of envelope.top_models.slice(0, 5)) {
+      lines.push(`  ${model ?? '(none)'}: ${count}`)
+    }
+  }
+
+  if (envelope.trend.length) {
+    lines.push('', 'Trend:')
+    for (const { bucket_start, count } of envelope.trend.slice(0, 7)) {
+      lines.push(`  ${bucket_start}: ${count}`)
+    }
+  }
+
+  if (envelope.truncated) {
+    lines.push('', '(window capped at 10k rows)')
+  }
+
+  return lines.join('\n')
+}
+
+// ── MCP tool handler ────────────────────────────────────────
+
+export async function summarizeObservedQueries(input: SummarizeInput): Promise<{ content: [{ type: 'text'; text: string }]; isError?: boolean }> {
+  try {
+    // Parse and validate input
+    const parsed = SummarizeInputSchema.parse(input)
+
+    // Fetch rows from observed_queries (service_role access)
+    const { data: rows, error } = await supabase
+      .from('observed_queries')
+      .select('source, question, caller_hint, user_agent, ip_hash, model, latency_ms, created_at')
+      .order('created_at', { ascending: false })
+      .limit(10000)
+
+    if (error) {
+      return { content: [{ type: 'text', text: `Failed to fetch observed_queries: ${error.message}` }], isError: true }
+    }
+
+    if (!rows || rows.length === 0) {
+      return { content: [{ type: 'text', text: 'No queries in this window.' }] }
+    }
+
+    // Aggregate
+    const envelope = aggregateObservedQueries(rows as ObservedQuery[], parsed)
+
+    // Return in requested format
+    if (parsed.format === 'json') {
+      return { content: [{ type: 'text', text: JSON.stringify(envelope, null, 2) }] }
+    }
+
+    // Default: text format
+    const text = formatEnvelopeToText(envelope)
+    return { content: [{ type: 'text', text }] }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return { content: [{ type: 'text', text: `Error: ${message}` }], isError: true }
+  }
+}

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -10,6 +10,7 @@ import { openrouter } from '../lib/ai.js'
 import { supabase } from '../lib/supabase.js'
 import { parseJSON } from '../lib/parse-json.js'
 import { scoreMatch } from '../lib/score-match.js'
+import { summarizeObservedQueries } from '../lib/summarize-observed-queries.js'
 import { corsHeaders, checkOrigin } from '../lib/mcp-common.js'
 import type { Project } from '../types.js'
 
@@ -218,6 +219,30 @@ function buildServer(): McpServer {
       } catch (err: unknown) {
         return { content: [{ type: 'text' as const, text: `Error: ${(err as Error).message}` }], isError: true }
       }
+    }
+  )
+
+  server.registerTool(
+    'summarize_observed_queries',
+    {
+      title: 'Summarize Public Query Traffic',
+      description:
+        'Get a summary of public query traffic hitting the /public-mcp and /query endpoints. ' +
+        'Returns aggregated stats: total queries, split by source (MCP vs HTTP), top caller hints, ' +
+        'top user-agents, top questions, top models, latency percentiles, and a time-bucketed trend. ' +
+        'Useful for understanding how external AI clients are discovering and querying the candidate.',
+      inputSchema: {
+        since: z.string().datetime().optional().describe('ISO timestamp lower bound. Defaults to 7 days ago.'),
+        until: z.string().datetime().optional().describe('ISO timestamp upper bound. Defaults to now.'),
+        source: z.enum(['mcp', 'http']).optional().describe('Filter to one surface. Omit for both.'),
+        caller_hint: z.string().optional().describe('Filter by caller_hint prefix (e.g. "ATS", "recruiter").'),
+        bucket: z.enum(['hour', 'day', 'week']).optional().default('day').describe('Time bucket for the trend series.'),
+        top_n: z.number().int().min(1).max(50).optional().default(10).describe('How many rows to include in top-N lists.'),
+        format: z.enum(['text', 'json']).optional().default('text').describe('"text" returns a human summary; "json" returns the raw envelope.'),
+      },
+    },
+    async (input) => {
+      return summarizeObservedQueries(input)
     }
   )
 

--- a/tests/summarize-observed-queries.test.ts
+++ b/tests/summarize-observed-queries.test.ts
@@ -1,0 +1,440 @@
+/**
+ * Unit tests for summarize_observed_queries aggregation logic
+ *
+ * Tests the handler's aggregation math and output formatting without
+ * requiring a live Supabase instance. Uses mocked data.
+ *
+ * Run:
+ *   npm run test:unit
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+// Import the aggregation logic we'll implement
+// For now, these tests describe the expected behavior
+interface ObservedQuery {
+  source: 'mcp' | 'http'
+  question: string
+  caller_hint: string | null
+  user_agent: string | null
+  ip_hash: string | null
+  model: string | null
+  latency_ms: number | null
+  created_at: string
+}
+
+interface SummarizeInput {
+  since?: string
+  until?: string
+  source?: 'mcp' | 'http'
+  caller_hint?: string
+  bucket?: 'hour' | 'day' | 'week'
+  top_n?: number
+  format?: 'text' | 'json'
+}
+
+interface SummarizeEnvelope {
+  window: { since: string; until: string; days: number }
+  totals: {
+    count: number
+    by_source: { mcp: number; http: number }
+    distinct_user_agents: number
+    distinct_ip_hashes: number
+  }
+  latency: {
+    avg_ms: number
+    p50_ms: number
+    p95_ms: number
+    max_ms: number
+  }
+  top_caller_hints: { caller_hint: string | null; count: number }[]
+  top_user_agents: { user_agent: string | null; count: number }[]
+  top_questions: { question: string; count: number }[]
+  top_models: { model: string | null; count: number }[]
+  trend: { bucket_start: string; count: number }[]
+  truncated?: boolean
+}
+
+// Aggregation function to implement
+function aggregateObservedQueries(rows: ObservedQuery[], input: SummarizeInput): SummarizeEnvelope {
+  // Default params
+  const top_n = input.top_n ?? 10
+  const bucket = input.bucket ?? 'day'
+  const format = input.format ?? 'text'
+
+  // Time bounds
+  const until = input.until ? new Date(input.until) : new Date()
+  const since = input.since ? new Date(input.since) : new Date(until.getTime() - 7 * 24 * 60 * 60 * 1000)
+
+  // Filter rows
+  let filtered = rows.filter(r => {
+    const created = new Date(r.created_at)
+    if (created < since || created > until) return false
+    if (input.source && r.source !== input.source) return false
+    if (input.caller_hint && !(r.caller_hint?.startsWith(input.caller_hint))) return false
+    return true
+  })
+
+  // Hard cap at 10k rows
+  let truncated = false
+  if (filtered.length > 10000) {
+    filtered = filtered.slice(0, 10000)
+    truncated = true
+  }
+
+  // Count by source
+  const bySource = { mcp: 0, http: 0 }
+  for (const r of filtered) {
+    if (r.source === 'mcp') bySource.mcp++
+    else bySource.http++
+  }
+
+  // Distinct user_agents and ip_hashes
+  const userAgents = new Set(filtered.map(r => r.user_agent).filter(Boolean))
+  const ipHashes = new Set(filtered.map(r => r.ip_hash).filter(Boolean))
+
+  // Latency stats
+  const latencies = filtered.map(r => r.latency_ms).filter((l): l is number => l !== null)
+  const sortedLatencies = [...latencies].sort((a, b) => a - b)
+  const avgMs = latencies.length ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length) : 0
+  const p50Ms = sortedLatencies[Math.floor(sortedLatencies.length * 0.5)] ?? 0
+  const p95Ms = sortedLatencies[Math.floor(sortedLatencies.length * 0.95)] ?? 0
+  const maxMs = sortedLatencies[sortedLatencies.length - 1] ?? 0
+
+  // Top caller_hints
+  const callerHintCounts = new Map<string | null, number>()
+  for (const r of filtered) {
+    const key = r.caller_hint
+    callerHintCounts.set(key, (callerHintCounts.get(key) ?? 0) + 1)
+  }
+  const topCallerHints = [...callerHintCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, top_n)
+    .map(([caller_hint, count]) => ({ caller_hint, count }))
+
+  // Top user_agents
+  const userAgentCounts = new Map<string | null, number>()
+  for (const r of filtered) {
+    const key = r.user_agent
+    userAgentCounts.set(key, (userAgentCounts.get(key) ?? 0) + 1)
+  }
+  const topUserAgents = [...userAgentCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, top_n)
+    .map(([user_agent, count]) => ({ user_agent, count }))
+
+  // Top questions (exact string match)
+  // First pass: normalize (lowercase + trim + strip trailing punctuation)
+  const stripPunctuation = (s: string) => s.replace(/[.!?,:;]+$/, '')
+  const questionCounts = new Map<string, { normalized: string; original: string; count: number }>()
+  for (const r of filtered) {
+    const normalized = stripPunctuation(r.question.toLowerCase().trim())
+    const existing = questionCounts.get(normalized)
+    if (existing) {
+      existing.count++
+    } else {
+      questionCounts.set(normalized, { normalized, original: r.question, count: 1 })
+    }
+  }
+  const topQuestions = [...questionCounts.values()]
+    .sort((a, b) => b.count - a.count)
+    .slice(0, top_n)
+    .map(({ original, count }) => ({ question: original, count }))
+
+  // Top models
+  const modelCounts = new Map<string | null, number>()
+  for (const r of filtered) {
+    const key = r.model
+    modelCounts.set(key, (modelCounts.get(key) ?? 0) + 1)
+  }
+  const topModels = [...modelCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, top_n)
+    .map(([model, count]) => ({ model, count }))
+
+  // Trend (time bucketing)
+  const bucketMs = bucket === 'hour' ? 60 * 60 * 1000 : bucket === 'week' ? 7 * 24 * 60 * 60 * 1000 : 24 * 60 * 60 * 1000
+  const trendMap = new Map<string, number>()
+  for (const r of filtered) {
+    const created = new Date(r.created_at)
+    const bucketTime = Math.floor(created.getTime() / bucketMs) * bucketMs
+    // Format: ISO date for day/week, ISO datetime for hour
+    const bucketStart = bucket === 'day' 
+      ? new Date(bucketTime).toISOString().slice(0, 10)
+      : bucket === 'week'
+        ? new Date(bucketTime).toISOString().slice(0, 10)
+        : new Date(bucketTime).toISOString()
+    trendMap.set(bucketStart, (trendMap.get(bucketStart) ?? 0) + 1)
+  }
+  const trend = [...trendMap.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([bucket_start, count]) => ({ bucket_start, count }))
+
+  const days = Math.round((until.getTime() - since.getTime()) / (24 * 60 * 60 * 1000))
+
+  return {
+    window: { since: since.toISOString(), until: until.toISOString(), days },
+    totals: {
+      count: filtered.length,
+      by_source: bySource,
+      distinct_user_agents: userAgents.size,
+      distinct_ip_hashes: ipHashes.size,
+    },
+    latency: { avg_ms: avgMs, p50_ms: p50Ms, p95_ms: p95Ms, max_ms: maxMs },
+    top_caller_hints: topCallerHints,
+    top_user_agents: topUserAgents,
+    top_questions: topQuestions,
+    top_models: topModels,
+    trend,
+    ...(truncated && { truncated: true }),
+  }
+}
+
+// Format to text (mimics thought_stats style)
+function formatEnvelopeToText(envelope: SummarizeEnvelope): string {
+  const lines: string[] = [
+    `Query Traffic Summary (${envelope.window.days} days)`,
+    '',
+    `Total queries: ${envelope.totals.count}`,
+    `  by source: MCP: ${envelope.totals.by_source.mcp}, HTTP: ${envelope.totals.by_source.http}`,
+    `  distinct user-agents: ${envelope.totals.distinct_user_agents}`,
+    `  distinct IPs: ${envelope.totals.distinct_ip_hashes}`,
+  ]
+
+  if (envelope.latency.avg_ms > 0) {
+    lines.push('', 'Latency:')
+    lines.push(`  avg: ${envelope.latency.avg_ms}ms, p50: ${envelope.latency.p50_ms}ms, p95: ${envelope.latency.p95_ms}ms, max: ${envelope.latency.max_ms}ms`)
+  }
+
+  if (envelope.top_caller_hints.length) {
+    lines.push('', 'Top caller hints:')
+    for (const { caller_hint, count } of envelope.top_caller_hints.slice(0, 5)) {
+      lines.push(`  ${caller_hint ?? '(none)'}: ${count}`)
+    }
+  }
+
+  if (envelope.top_user_agents.length) {
+    lines.push('', 'Top user-agents:')
+    for (const { user_agent, count } of envelope.top_user_agents.slice(0, 5)) {
+      lines.push(`  ${user_agent?.slice(0, 60) ?? '(none)'}: ${count}`)
+    }
+  }
+
+  if (envelope.top_questions.length) {
+    lines.push('', 'Top questions:')
+    for (const { question, count } of envelope.top_questions.slice(0, 5)) {
+      lines.push(`  ${question.slice(0, 80)}: ${count}`)
+    }
+  }
+
+  if (envelope.top_models.length) {
+    lines.push('', 'Top models:')
+    for (const { model, count } of envelope.top_models.slice(0, 5)) {
+      lines.push(`  ${model ?? '(none)'}: ${count}`)
+    }
+  }
+
+  if (envelope.trend.length) {
+    lines.push('', 'Trend:')
+    for (const { bucket_start, count } of envelope.trend.slice(0, 7)) {
+      lines.push(`  ${bucket_start.slice(0, 10)}: ${count}`)
+    }
+  }
+
+  if (envelope.truncated) {
+    lines.push('', '(window capped at 10k rows)')
+  }
+
+  return lines.join('\n')
+}
+
+// ── Test fixtures ───────────────────────────────────────────
+
+const SAMPLE_ROWS: ObservedQuery[] = [
+  { source: 'mcp', question: 'What are your skills?', caller_hint: 'ATS', user_agent: 'Mozilla/5.0', ip_hash: 'abc123', model: 'gpt-4o', latency_ms: 1200, created_at: '2026-04-25T10:00:00Z' },
+  { source: 'mcp', question: 'Tell me about yourself', caller_hint: 'ATS', user_agent: 'Mozilla/5.0', ip_hash: 'abc123', model: 'gpt-4o', latency_ms: 1100, created_at: '2026-04-25T11:00:00Z' },
+  { source: 'http', question: 'What is your experience?', caller_hint: 'recruiter', user_agent: 'curl/7.68', ip_hash: 'def456', model: 'gpt-4o-mini', latency_ms: 800, created_at: '2026-04-26T09:00:00Z' },
+  { source: 'http', question: 'What is your experience?', caller_hint: 'recruiter', user_agent: 'curl/7.68', ip_hash: 'def456', model: 'gpt-4o-mini', latency_ms: 850, created_at: '2026-04-26T10:00:00Z' },
+  { source: 'mcp', question: 'What projects have you built?', caller_hint: 'ai-agent', user_agent: 'Claude/1.0', ip_hash: 'ghi789', model: 'gpt-4o', latency_ms: 1500, created_at: '2026-04-27T14:00:00Z' },
+  { source: 'mcp', question: 'What is your availability?', caller_hint: null, user_agent: 'Mozilla/5.0', ip_hash: 'abc123', model: 'gpt-4o', latency_ms: 900, created_at: '2026-04-28T16:00:00Z' },
+]
+
+// ── AC-1: Empty window returns friendly message ────────────
+
+describe('AC-1: empty window returns friendly message', () => {
+  it('returns "No queries in this window" when no rows match', () => {
+    const result = aggregateObservedQueries(SAMPLE_ROWS, {
+      since: '2026-01-01T00:00:00Z',
+      until: '2026-01-02T00:00:00Z',
+    })
+    assert.equal(result.totals.count, 0, 'Should have zero queries')
+  })
+})
+
+// ── AC-2: since > until rejects with validation error ───────
+
+describe('AC-2: since > until validation', () => {
+  it('should reject when since is after until', () => {
+    const input = {
+      since: '2026-05-01T00:00:00Z',
+      until: '2026-04-01T00:00:00Z',
+    }
+    // The function doesn't validate this — caller should handle it
+    // For now, we test that it produces a result (negative days indicates inverted)
+    const result = aggregateObservedQueries(SAMPLE_ROWS, input)
+    // Negative days is acceptable - caller should validate before calling
+    assert.ok(typeof result.window.days === 'number', 'Should return a number for days')
+  })
+})
+
+// ── AC-3: Window > 10k rows triggers truncated flag ───────
+
+describe('AC-3: truncated flag on large window', () => {
+  it('sets truncated:true when rows exceed 10k cap', () => {
+    // Generate 10,001 rows
+    const bigDataset = Array.from({ length: 10001 }, (_, i) => ({
+      source: 'mcp' as const,
+      question: `Question ${i}`,
+      caller_hint: 'test',
+      user_agent: 'test',
+      ip_hash: 'x',
+      model: 'gpt-4o',
+      latency_ms: 100,
+      created_at: '2026-04-28T10:00:00Z',
+    }))
+    const result = aggregateObservedQueries(bigDataset, {})
+    assert.equal(result.truncated, true, 'Should flag as truncated')
+    assert.equal(result.totals.count, 10000, 'Should cap at 10k')
+  })
+})
+
+// ── AC-4: Source filter works ───────────────────────────────
+
+describe('AC-4: source filter', () => {
+  it('filters to mcp only when specified', () => {
+    const result = aggregateObservedQueries(SAMPLE_ROWS, { source: 'mcp' })
+    assert.equal(result.totals.count, 4, 'Should have 4 mcp queries')
+    assert.equal(result.totals.by_source.mcp, 4)
+    assert.equal(result.totals.by_source.http, 0)
+  })
+
+  it('filters to http only when specified', () => {
+    const result = aggregateObservedQueries(SAMPLE_ROWS, { source: 'http' })
+    assert.equal(result.totals.count, 2, 'Should have 2 http queries')
+  })
+})
+
+// ── AC-5: caller_hint filter works ─────────────────────────
+
+describe('AC-5: caller_hint prefix filter', () => {
+  it('filters by caller_hint prefix', () => {
+    const result = aggregateObservedQueries(SAMPLE_ROWS, { caller_hint: 'ATS' })
+    assert.equal(result.totals.count, 2, 'Should have 2 ATS queries')
+    assert.equal(result.top_caller_hints[0]?.caller_hint, 'ATS')
+  })
+})
+
+// ── AC-6: bucket parameter works ───────────────────────────
+
+describe('AC-6: time bucket parameter', () => {
+  it('groups by hour correctly', () => {
+    const result = aggregateObservedQueries(SAMPLE_ROWS, { bucket: 'hour' })
+    assert.ok(result.trend.length > 0, 'Should have trend buckets')
+    // Check that we have hour-level granularity
+    const firstBucket = result.trend[0]
+    assert.ok(firstBucket.bucket_start.includes(':'), 'Hour buckets include time')
+  })
+
+  it('groups by day correctly', () => {
+    const result = aggregateObservedQueries(SAMPLE_ROWS, { bucket: 'day' })
+    assert.ok(result.trend.length > 0, 'Should have trend buckets')
+    // Day buckets should only have date (no time)
+    assert.ok(!result.trend[0]?.bucket_start.includes(':'), 'Day buckets should not include time')
+  })
+
+  it('groups by week correctly', () => {
+    const result = aggregateObservedQueries(SAMPLE_ROWS, { bucket: 'week' })
+    assert.ok(result.trend.length > 0, 'Should have trend buckets')
+  })
+})
+
+// ── AC-7: top_n parameter works ────────────────────────────
+
+describe('AC-7: top_n parameter limits lists', () => {
+  it('respects top_n for caller_hints', () => {
+    const result = aggregateObservedQueries(SAMPLE_ROWS, { top_n: 2 })
+    assert.equal(result.top_caller_hints.length, 2, 'Should return only top 2')
+  })
+
+  it('respects top_n for questions', () => {
+    const result = aggregateObservedQueries(SAMPLE_ROWS, { top_n: 1 })
+    // "What is your experience?" appears twice
+    const topQ = result.top_questions[0]
+    assert.ok(topQ, 'Should have at least one question')
+    if (topQ) {
+      assert.equal(topQ.count, 2, 'The duplicated question should have count 2')
+    }
+  })
+})
+
+// ── AC-8: JSON format returns full envelope ───────────────
+
+describe('AC-8: JSON format returns envelope', () => {
+  it('includes all envelope fields', () => {
+    const result = aggregateObservedQueries(SAMPLE_ROWS, { format: 'json' })
+    assert.ok(result.window, 'Should have window')
+    assert.ok(result.totals, 'Should have totals')
+    assert.ok(result.latency, 'Should have latency')
+    assert.ok(result.top_caller_hints, 'Should have top_caller_hints')
+    assert.ok(result.top_user_agents, 'Should have top_user_agents')
+    assert.ok(result.top_questions, 'Should have top_questions')
+    assert.ok(result.top_models, 'Should have top_models')
+    assert.ok(result.trend, 'Should have trend')
+  })
+})
+
+// ── AC-9: Text format is human-readable ────────────────────
+
+describe('AC-9: text format is human-readable', () => {
+  it('renders expected sections', () => {
+    const envelope = aggregateObservedQueries(SAMPLE_ROWS, {})
+    const text = formatEnvelopeToText(envelope)
+    assert.match(text, /Query Traffic Summary/, 'Should have header')
+    assert.match(text, /Total queries:/, 'Should show total')
+    assert.match(text, /by source:/, 'Should show source breakdown')
+    assert.match(text, /Latency:/, 'Should show latency when present')
+  })
+})
+
+// ── AC-10: Latency stats computed correctly ───────────────
+
+describe('AC-10: latency statistics', () => {
+  it('calculates avg, p50, p95, max correctly', () => {
+    const result = aggregateObservedQueries(SAMPLE_ROWS, {})
+    // latencies: 1200, 1100, 800, 850, 1500, 900
+    // avg = 1058
+    // sorted: 800, 850, 900, 1100, 1200, 1500
+    // p50 = index floor(6*0.5)=3 -> 1100, p95 = index floor(6*0.95)=5 -> 1500, max = 1500
+    assert.equal(result.latency.avg_ms, 1058, 'Avg should be 1058')
+    assert.equal(result.latency.p50_ms, 1100, 'p50 should be 1100 (index 3 of 6)')
+    assert.equal(result.latency.p95_ms, 1500, 'p95 should be 1500')
+    assert.equal(result.latency.max_ms, 1500, 'max should be 1500')
+  })
+})
+
+// ── AC-11: Question normalization (case + trim) ───────────
+
+describe('AC-11: question normalization groups by exact string', () => {
+  it('groups "Tell me about yourself" and "tell me about yourself!" together', () => {
+    const mixedRows: ObservedQuery[] = [
+      { source: 'mcp', question: 'Tell me about yourself', caller_hint: null, user_agent: 'x', ip_hash: 'x', model: 'x', latency_ms: 100, created_at: '2026-04-28T10:00:00Z' },
+      { source: 'mcp', question: 'tell me about yourself!', caller_hint: null, user_agent: 'x', ip_hash: 'x', model: 'x', latency_ms: 100, created_at: '2026-04-28T11:00:00Z' },
+    ]
+    const result = aggregateObservedQueries(mixedRows, {})
+    // Both should group under the second one's normalized key
+    // The current impl keeps original casing from first match
+    assert.equal(result.top_questions.length, 1, 'Should be one group')
+    assert.equal(result.top_questions[0].count, 2, 'Should have count of 2')
+  })
+})

--- a/tests/summarize-observed-queries.test.ts
+++ b/tests/summarize-observed-queries.test.ts
@@ -11,243 +11,8 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 
-// Import the aggregation logic we'll implement
-// For now, these tests describe the expected behavior
-interface ObservedQuery {
-  source: 'mcp' | 'http'
-  question: string
-  caller_hint: string | null
-  user_agent: string | null
-  ip_hash: string | null
-  model: string | null
-  latency_ms: number | null
-  created_at: string
-}
-
-interface SummarizeInput {
-  since?: string
-  until?: string
-  source?: 'mcp' | 'http'
-  caller_hint?: string
-  bucket?: 'hour' | 'day' | 'week'
-  top_n?: number
-  format?: 'text' | 'json'
-}
-
-interface SummarizeEnvelope {
-  window: { since: string; until: string; days: number }
-  totals: {
-    count: number
-    by_source: { mcp: number; http: number }
-    distinct_user_agents: number
-    distinct_ip_hashes: number
-  }
-  latency: {
-    avg_ms: number
-    p50_ms: number
-    p95_ms: number
-    max_ms: number
-  }
-  top_caller_hints: { caller_hint: string | null; count: number }[]
-  top_user_agents: { user_agent: string | null; count: number }[]
-  top_questions: { question: string; count: number }[]
-  top_models: { model: string | null; count: number }[]
-  trend: { bucket_start: string; count: number }[]
-  truncated?: boolean
-}
-
-// Aggregation function to implement
-function aggregateObservedQueries(rows: ObservedQuery[], input: SummarizeInput): SummarizeEnvelope {
-  // Default params
-  const top_n = input.top_n ?? 10
-  const bucket = input.bucket ?? 'day'
-  const format = input.format ?? 'text'
-
-  // Time bounds
-  const until = input.until ? new Date(input.until) : new Date()
-  const since = input.since ? new Date(input.since) : new Date(until.getTime() - 7 * 24 * 60 * 60 * 1000)
-
-  // Filter rows
-  let filtered = rows.filter(r => {
-    const created = new Date(r.created_at)
-    if (created < since || created > until) return false
-    if (input.source && r.source !== input.source) return false
-    if (input.caller_hint && !(r.caller_hint?.startsWith(input.caller_hint))) return false
-    return true
-  })
-
-  // Hard cap at 10k rows
-  let truncated = false
-  if (filtered.length > 10000) {
-    filtered = filtered.slice(0, 10000)
-    truncated = true
-  }
-
-  // Count by source
-  const bySource = { mcp: 0, http: 0 }
-  for (const r of filtered) {
-    if (r.source === 'mcp') bySource.mcp++
-    else bySource.http++
-  }
-
-  // Distinct user_agents and ip_hashes
-  const userAgents = new Set(filtered.map(r => r.user_agent).filter(Boolean))
-  const ipHashes = new Set(filtered.map(r => r.ip_hash).filter(Boolean))
-
-  // Latency stats
-  const latencies = filtered.map(r => r.latency_ms).filter((l): l is number => l !== null)
-  const sortedLatencies = [...latencies].sort((a, b) => a - b)
-  const avgMs = latencies.length ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length) : 0
-  const p50Ms = sortedLatencies[Math.floor(sortedLatencies.length * 0.5)] ?? 0
-  const p95Ms = sortedLatencies[Math.floor(sortedLatencies.length * 0.95)] ?? 0
-  const maxMs = sortedLatencies[sortedLatencies.length - 1] ?? 0
-
-  // Top caller_hints
-  const callerHintCounts = new Map<string | null, number>()
-  for (const r of filtered) {
-    const key = r.caller_hint
-    callerHintCounts.set(key, (callerHintCounts.get(key) ?? 0) + 1)
-  }
-  const topCallerHints = [...callerHintCounts.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, top_n)
-    .map(([caller_hint, count]) => ({ caller_hint, count }))
-
-  // Top user_agents
-  const userAgentCounts = new Map<string | null, number>()
-  for (const r of filtered) {
-    const key = r.user_agent
-    userAgentCounts.set(key, (userAgentCounts.get(key) ?? 0) + 1)
-  }
-  const topUserAgents = [...userAgentCounts.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, top_n)
-    .map(([user_agent, count]) => ({ user_agent, count }))
-
-  // Top questions (exact string match)
-  // First pass: normalize (lowercase + trim + strip trailing punctuation)
-  const stripPunctuation = (s: string) => s.replace(/[.!?,:;]+$/, '')
-  const questionCounts = new Map<string, { normalized: string; original: string; count: number }>()
-  for (const r of filtered) {
-    const normalized = stripPunctuation(r.question.toLowerCase().trim())
-    const existing = questionCounts.get(normalized)
-    if (existing) {
-      existing.count++
-    } else {
-      questionCounts.set(normalized, { normalized, original: r.question, count: 1 })
-    }
-  }
-  const topQuestions = [...questionCounts.values()]
-    .sort((a, b) => b.count - a.count)
-    .slice(0, top_n)
-    .map(({ original, count }) => ({ question: original, count }))
-
-  // Top models
-  const modelCounts = new Map<string | null, number>()
-  for (const r of filtered) {
-    const key = r.model
-    modelCounts.set(key, (modelCounts.get(key) ?? 0) + 1)
-  }
-  const topModels = [...modelCounts.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, top_n)
-    .map(([model, count]) => ({ model, count }))
-
-  // Trend (time bucketing)
-  const bucketMs = bucket === 'hour' ? 60 * 60 * 1000 : bucket === 'week' ? 7 * 24 * 60 * 60 * 1000 : 24 * 60 * 60 * 1000
-  const trendMap = new Map<string, number>()
-  for (const r of filtered) {
-    const created = new Date(r.created_at)
-    const bucketTime = Math.floor(created.getTime() / bucketMs) * bucketMs
-    // Format: ISO date for day/week, ISO datetime for hour
-    const bucketStart = bucket === 'day' 
-      ? new Date(bucketTime).toISOString().slice(0, 10)
-      : bucket === 'week'
-        ? new Date(bucketTime).toISOString().slice(0, 10)
-        : new Date(bucketTime).toISOString()
-    trendMap.set(bucketStart, (trendMap.get(bucketStart) ?? 0) + 1)
-  }
-  const trend = [...trendMap.entries()]
-    .sort((a, b) => a[0].localeCompare(b[0]))
-    .map(([bucket_start, count]) => ({ bucket_start, count }))
-
-  const days = Math.round((until.getTime() - since.getTime()) / (24 * 60 * 60 * 1000))
-
-  return {
-    window: { since: since.toISOString(), until: until.toISOString(), days },
-    totals: {
-      count: filtered.length,
-      by_source: bySource,
-      distinct_user_agents: userAgents.size,
-      distinct_ip_hashes: ipHashes.size,
-    },
-    latency: { avg_ms: avgMs, p50_ms: p50Ms, p95_ms: p95Ms, max_ms: maxMs },
-    top_caller_hints: topCallerHints,
-    top_user_agents: topUserAgents,
-    top_questions: topQuestions,
-    top_models: topModels,
-    trend,
-    ...(truncated && { truncated: true }),
-  }
-}
-
-// Format to text (mimics thought_stats style)
-function formatEnvelopeToText(envelope: SummarizeEnvelope): string {
-  const lines: string[] = [
-    `Query Traffic Summary (${envelope.window.days} days)`,
-    '',
-    `Total queries: ${envelope.totals.count}`,
-    `  by source: MCP: ${envelope.totals.by_source.mcp}, HTTP: ${envelope.totals.by_source.http}`,
-    `  distinct user-agents: ${envelope.totals.distinct_user_agents}`,
-    `  distinct IPs: ${envelope.totals.distinct_ip_hashes}`,
-  ]
-
-  if (envelope.latency.avg_ms > 0) {
-    lines.push('', 'Latency:')
-    lines.push(`  avg: ${envelope.latency.avg_ms}ms, p50: ${envelope.latency.p50_ms}ms, p95: ${envelope.latency.p95_ms}ms, max: ${envelope.latency.max_ms}ms`)
-  }
-
-  if (envelope.top_caller_hints.length) {
-    lines.push('', 'Top caller hints:')
-    for (const { caller_hint, count } of envelope.top_caller_hints.slice(0, 5)) {
-      lines.push(`  ${caller_hint ?? '(none)'}: ${count}`)
-    }
-  }
-
-  if (envelope.top_user_agents.length) {
-    lines.push('', 'Top user-agents:')
-    for (const { user_agent, count } of envelope.top_user_agents.slice(0, 5)) {
-      lines.push(`  ${user_agent?.slice(0, 60) ?? '(none)'}: ${count}`)
-    }
-  }
-
-  if (envelope.top_questions.length) {
-    lines.push('', 'Top questions:')
-    for (const { question, count } of envelope.top_questions.slice(0, 5)) {
-      lines.push(`  ${question.slice(0, 80)}: ${count}`)
-    }
-  }
-
-  if (envelope.top_models.length) {
-    lines.push('', 'Top models:')
-    for (const { model, count } of envelope.top_models.slice(0, 5)) {
-      lines.push(`  ${model ?? '(none)'}: ${count}`)
-    }
-  }
-
-  if (envelope.trend.length) {
-    lines.push('', 'Trend:')
-    for (const { bucket_start, count } of envelope.trend.slice(0, 7)) {
-      lines.push(`  ${bucket_start.slice(0, 10)}: ${count}`)
-    }
-  }
-
-  if (envelope.truncated) {
-    lines.push('', '(window capped at 10k rows)')
-  }
-
-  return lines.join('\n')
-}
+// Import from production module
+import { aggregateObservedQueries, formatEnvelopeToText, type ObservedQuery, type SummarizeInput } from '../src/lib/summarize-observed-queries.js'
 
 // ── Test fixtures ───────────────────────────────────────────
 
@@ -272,19 +37,19 @@ describe('AC-1: empty window returns friendly message', () => {
   })
 })
 
-// ── AC-2: since > until rejects with validation error ───────
+// ── AC-2: since > until throws validation error ───────
 
 describe('AC-2: since > until validation', () => {
-  it('should reject when since is after until', () => {
+  it('throws error when since is after until', () => {
     const input = {
       since: '2026-05-01T00:00:00Z',
       until: '2026-04-01T00:00:00Z',
     }
-    // The function doesn't validate this — caller should handle it
-    // For now, we test that it produces a result (negative days indicates inverted)
-    const result = aggregateObservedQueries(SAMPLE_ROWS, input)
-    // Negative days is acceptable - caller should validate before calling
-    assert.ok(typeof result.window.days === 'number', 'Should return a number for days')
+    assert.throws(
+      () => aggregateObservedQueries(SAMPLE_ROWS, input),
+      /Invalid window/,
+      'Should throw when since is after until'
+    )
   })
 })
 


### PR DESCRIPTION
## Summary

Add summarize_observed_queries tool to private MCP endpoint for observing public query traffic.

## Changes

- src/lib/summarize-observed-queries.ts — Aggregation logic + MCP handler
- src/routes/mcp.ts — Added tool to private MCP server
- 	ests/summarize-observed-queries.test.ts — 11 unit tests (all passing)
- README.md — Documented in available MCP tools section
- docs/plans/private-mcp-summarize-observed-queries.md — Updated status to shipped
- CHANGELOG.md + version bump

## Test plan

- [x] Unit tests pass: 
pm run test:unit
- [x] TypeScript compiles: 
px tsc --noEmit
- [ ] Verify tool appears in MCP tools/list
- [ ] Test tool returns expected aggregated data