### PR TITLE
fix(mcp): address post-merge review comments

### DIFF
--- a/docs/plans/private-mcp-summarize-observed-queries.md
+++ b/docs/plans/private-mcp-summarize-observed-queries.md
@@ -186,7 +186,7 @@ No new migrations, so no migration test pass needed.
 ### Unit tests — `tests/summarize-observed-queries.test.ts`
 
 - **AC-1:** Empty window returns friendly message "No queries in this window."
-- **AC-2:** `since > until` — returns valid envelope (caller should validate)
+- **AC-2:** `since > until` — throws a clear "Invalid window" error
 - **AC-3:** Window > 10k rows sets `truncated: true` flag
 - **AC-4:** Source filter (`mcp` or `http`) works correctly
 - **AC-5:** `caller_hint` prefix filter works correctly

--- a/src/lib/summarize-observed-queries.ts
+++ b/src/lib/summarize-observed-queries.ts
@@ -58,7 +58,7 @@ export function aggregateObservedQueries(rows: ObservedQuery[], input: Summarize
   const since = input.since ? new Date(input.since) : new Date(until.getTime() - 7 * 24 * 60 * 60 * 1000)
 
   // Validate: since must not be after until
-  if (input.since && input.until && new Date(input.since) > new Date(input.until)) {
+  if (since > until) {
     throw new Error('Invalid window: "since" must not be after "until"')
   }
 
@@ -248,20 +248,28 @@ export async function summarizeObservedQueries(input: SummarizeInput): Promise<{
     // Parse and validate input
     const parsed = SummarizeInputSchema.parse(input)
 
+    // Compute effective window bounds (for validation and SQL filtering)
+    const effectiveUntil = parsed.until ?? new Date().toISOString()
+    const effectiveSince =
+      parsed.since ??
+      new Date(new Date(effectiveUntil).getTime() - 7 * 24 * 60 * 60 * 1000).toISOString()
+
+    // Validate: since must not be after until (using computed values)
+    if (effectiveSince > effectiveUntil) {
+      return { content: [{ type: 'text', text: 'Invalid window: "since" must not be after "until"' }], isError: true }
+    }
+
     // Fetch rows from observed_queries (service_role access)
+    // Fetch 10001 to detect truncation; slice to 10000 after checking
     let query = supabase
       .from('observed_queries')
       .select('source, question, caller_hint, user_agent, ip_hash, model, latency_ms, created_at')
+      .gte('created_at', effectiveSince)
+      .lte('created_at', effectiveUntil)
       .order('created_at', { ascending: false })
-      .limit(10000)
+      .limit(10001)
 
-    // Apply filters in SQL for efficiency
-    if (parsed.since) {
-      query = query.gte('created_at', parsed.since)
-    }
-    if (parsed.until) {
-      query = query.lte('created_at', parsed.until)
-    }
+    // Apply additional filters in SQL for efficiency
     if (parsed.source) {
       query = query.eq('source', parsed.source)
     }

--- a/tests/summarize-observed-queries.test.ts
+++ b/tests/summarize-observed-queries.test.ts
@@ -190,7 +190,7 @@ describe('AC-10: latency statistics', () => {
 
 // ── AC-11: Question normalization (case + trim) ───────────
 
-describe('AC-11: question normalization groups by exact string', () => {
+describe('AC-11: question normalization groups normalized variants together', () => {
   it('groups "Tell me about yourself" and "tell me about yourself!" together', () => {
     const mixedRows: ObservedQuery[] = [
       { source: 'mcp', question: 'Tell me about yourself', caller_hint: null, user_agent: 'x', ip_hash: 'x', model: 'x', latency_ms: 100, created_at: '2026-04-28T10:00:00Z' },


### PR DESCRIPTION
Address 5 comments from Copilot review on PR #71

1. Plan doc AC-2 - Update to reflect error behavior instead of caller should validate
2. Test AC-11 - Fix describe text to say normalized variants instead of exact string  
3. Validation - Use computed since/until for validation, not raw inputs (fixes edge case with only since provided)
4. Truncation - Fetch 10001 rows to properly detect truncation
5. Default window - Apply default 7-day window in SQL, not just in aggregation

Tests pass: npm run test:unit