### PR TITLE
fix(agent-card): align agent-card.json with A2A v1.0 spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-05-01 — fix(agent-card): align agent-card.json with A2A v1.0 spec — adds required top-level fields `protocolVersion: "1.0"`, `url`, `securitySchemes: {}`, and `security: [{}]`; moves non-standard `supportedInterfaces` array from top level into `capabilities.extensions` to eliminate conformance checker failures
+
 - 2026-05-01 — test(oauth): add e2e script proving token expiry, refresh, and rotation live — runs against a server with ACCESS_TOKEN_TTL=60; verifies access token is accepted then rejected after 65s (401 on /mcp + jwtVerify), refresh token exchanges for new access+refresh (rotation confirmed), new access token works immediately, old refresh token dead; all 8 steps passing
 
 - 2026-05-01 — feat(oauth): persist refresh tokens in Supabase with rotation and reuse detection — eliminates reconnection prompts caused by in-memory token store being wiped on Railway restarts/redeploys; tokens are now stored as SHA-256 hashes in a new `oauth_refresh_tokens` table; each redemption atomically deletes the old row and issues a new token (rotation); replaying an already-used token triggers full revocation of all tokens for that client (reuse detection); 8 integration tests covering the full lifecycle including AC-8 reuse detection scenario

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/routes/agent-card.ts
+++ b/src/routes/agent-card.ts
@@ -14,21 +14,13 @@ app.get('/', async (c) => {
   const baseUrl = process.env.PUBLIC_URL ?? new URL(c.req.url).origin
 
   return c.json({
+    protocolVersion: '1.0',
+    url: baseUrl,
     name: data?.contact?.name ?? 'Resume Agent',
     description: 'Self-sovereign AI agent representing this professional\'s canonical profile. Query skills, experience, and availability — responses are grounded in data the individual publishes and controls, not fabricated by the calling AI.',
     version: '1.1.0',
-    supportedInterfaces: [
-      {
-        url: `${baseUrl}/public-mcp`,
-        protocolBinding: 'MCP',
-        protocolVersion: '2025-03-26',
-      },
-      {
-        url: baseUrl,
-        protocolBinding: 'HTTP+JSON',
-        protocolVersion: '1.0',
-      },
-    ],
+    securitySchemes: {},
+    security: [{}],
     provider: {
       organization: data?.contact?.name ?? 'Resume Agent',
       url: process.env.PROVIDER_HOMEPAGE,
@@ -39,6 +31,25 @@ app.get('/', async (c) => {
       pushNotifications: false,
       stateTransitionHistory: false,
       extensions: [
+        {
+          uri: `${baseUrl}/.well-known/agent-card.json#supported-interfaces`,
+          description: 'Protocol bindings supported by this agent (MCP, HTTP+JSON).',
+          required: false,
+          params: {
+            supportedInterfaces: [
+              {
+                url: `${baseUrl}/public-mcp`,
+                protocolBinding: 'MCP',
+                protocolVersion: '2025-03-26',
+              },
+              {
+                url: baseUrl,
+                protocolBinding: 'HTTP+JSON',
+                protocolVersion: '1.0',
+              },
+            ],
+          },
+        },
         {
           uri: `${baseUrl}/.well-known/agent-card.json#api-docs`,
           description: 'Custom API documentation, rate limits, and contact metadata.',

--- a/src/routes/agent-card.ts
+++ b/src/routes/agent-card.ts
@@ -11,7 +11,7 @@ app.get('/', async (c) => {
     .eq('id', '00000000-0000-0000-0000-000000000001')
     .single()
 
-  const baseUrl = process.env.PUBLIC_URL ?? new URL(c.req.url).origin
+  const baseUrl = (process.env.PUBLIC_URL ?? new URL(c.req.url).origin).replace(/\/$/, '')
 
   return c.json({
     protocolVersion: '1.0',

--- a/tests/public-mcp-tool.test.ts
+++ b/tests/public-mcp-tool.test.ts
@@ -294,12 +294,12 @@ describe('AC-17: agent card advertises MCP interface', () => {
   it('supportedInterfaces contains an MCP entry with correct URL + version', async () => {
     const res = await fetch(AGENT_CARD_URL)
     assert.ok(res.ok, `Agent card must be reachable, got ${res.status}`)
-    const card = (await res.json()) as {
-      supportedInterfaces?: { url: string; protocolBinding: string; protocolVersion?: string }[]
-    }
-    const interfaces = card.supportedInterfaces ?? []
+    type Extension = { uri: string; params?: { supportedInterfaces?: { url: string; protocolBinding: string; protocolVersion?: string }[] } }
+    const card = (await res.json()) as { capabilities?: { extensions?: Extension[] } }
+    const ext = card.capabilities?.extensions?.find((e) => e.uri.endsWith('#supported-interfaces'))
+    const interfaces = ext?.params?.supportedInterfaces ?? []
     const mcp = interfaces.find((i) => i.protocolBinding === 'MCP')
-    assert.ok(mcp, 'MCP interface must be present in supportedInterfaces')
+    assert.ok(mcp, 'MCP interface must be present in capabilities.extensions[#supported-interfaces].params.supportedInterfaces')
     assert.ok(
       mcp!.url.endsWith('/public-mcp'),
       `MCP URL should end with /public-mcp, got ${mcp!.url}`,
@@ -317,10 +317,10 @@ describe('AC-17: agent card advertises MCP interface', () => {
 describe('AC-18: MCP interface listed first in agent card', () => {
   it('supportedInterfaces[0] has protocolBinding MCP', async () => {
     const res = await fetch(AGENT_CARD_URL)
-    const card = (await res.json()) as {
-      supportedInterfaces?: { protocolBinding: string }[]
-    }
-    const interfaces = card.supportedInterfaces ?? []
+    type Extension = { uri: string; params?: { supportedInterfaces?: { protocolBinding: string }[] } }
+    const card = (await res.json()) as { capabilities?: { extensions?: Extension[] } }
+    const ext = card.capabilities?.extensions?.find((e) => e.uri.endsWith('#supported-interfaces'))
+    const interfaces = ext?.params?.supportedInterfaces ?? []
     assert.ok(interfaces.length > 0, 'supportedInterfaces must be non-empty')
     assert.equal(
       interfaces[0].protocolBinding,


### PR DESCRIPTION
## Summary

- Adds required top-level `protocolVersion: "1.0"` field (was only present inside `supportedInterfaces`, not at root)
- Adds top-level `url` field pointing to the agent's primary endpoint
- Adds `securitySchemes: {}` and `security: [{}]` — required by spec even for open/unauthenticated agents
- Moves `supportedInterfaces` array from top level into `capabilities.extensions` — it was non-standard at root and caused conformance checker failures

## Test plan

- [ ] `GET /.well-known/agent-card.json` returns `protocolVersion`, `url`, `securitySchemes`, `security` at root
- [ ] `supportedInterfaces` no longer appears at top level — lives under `capabilities.extensions[0].params`
- [ ] MCP connector discovery still works (URL unchanged, just nested differently)
- [ ] Run against an A2A conformance checker