### PR TITLE
fix(agent-card): add Cache-Control: public, max-age=300 to prevent indefinite caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-05-01 — fix(agent-card): add Cache-Control: public, max-age=300 to prevent indefinite caching by claude.ai and crawlers — no TTL caused claude.ai to serve a stale agent card after A2A spec fixes were deployed; 5-minute cap ensures changes propagate within one rotation while still allowing short-term caching to reduce Supabase round-trips
+
 - 2026-05-01 — fix(agent-card): align agent-card.json with A2A v1.0 spec — adds required top-level fields `protocolVersion: "1.0"`, `url`, `securitySchemes: {}`, and `security: [{}]`; moves non-standard `supportedInterfaces` array from top level into `capabilities.extensions` to eliminate conformance checker failures
 
 - 2026-05-01 — test(oauth): add e2e script proving token expiry, refresh, and rotation live — runs against a server with ACCESS_TOKEN_TTL=60; verifies access token is accepted then rejected after 65s (401 on /mcp + jwtVerify), refresh token exchanges for new access+refresh (rotation confirmed), new access token works immediately, old refresh token dead; all 8 steps passing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/routes/agent-card.ts
+++ b/src/routes/agent-card.ts
@@ -13,6 +13,7 @@ app.get('/', async (c) => {
 
   const baseUrl = (process.env.PUBLIC_URL ?? new URL(c.req.url).origin).replace(/\/$/, '')
 
+  c.header('Cache-Control', 'public, max-age=300')
   return c.json({
     protocolVersion: '1.0',
     url: baseUrl,

--- a/tests/public-mcp-tool.test.ts
+++ b/tests/public-mcp-tool.test.ts
@@ -330,6 +330,21 @@ describe('AC-18: MCP interface listed first in agent card', () => {
   })
 })
 
+// ── AC-19: agent card sets Cache-Control header ──
+
+describe('AC-19: agent card sets Cache-Control header', () => {
+  it('response includes Cache-Control: public, max-age=300', async () => {
+    const res = await fetch(AGENT_CARD_URL)
+    assert.ok(res.ok, `Agent card must be reachable, got ${res.status}`)
+    const cc = res.headers.get('cache-control')
+    assert.ok(cc, 'Cache-Control header must be present')
+    assert.ok(
+      cc!.includes('public') && cc!.includes('max-age=300'),
+      `Cache-Control must include 'public, max-age=300', got '${cc}'`,
+    )
+  })
+})
+
 // ── AC-20: migration applied cleanly (implicit — table is reachable) ──
 
 describe('AC-20: observed_queries migration applied cleanly', () => {


### PR DESCRIPTION
## Summary
- Adds `Cache-Control: public, max-age=300` to the agent card endpoint response
- Prevents claude.ai and crawlers from caching the agent card indefinitely after A2A spec fixes were deployed
- 5-minute TTL ensures changes propagate within one rotation while still allowing short-term caching to reduce Supabase round-trips

## Root Cause
No `Cache-Control` header meant downstream clients (claude.ai, CDNs) could cache the response indefinitely. After the A2A spec alignment fixes in the previous PR were deployed, claude.ai mobile was still serving the stale pre-fix agent card.

## Test Plan
- [ ] Remove and re-add the claude.ai connector on mobile — should fetch a fresh card immediately
- [ ] Verify `curl -I https://agent.yuens.me/.well-known/agent-card.json` returns `cache-control: public, max-age=300`
- [ ] Confirm the three A2A required fields (`protocolVersion`, `securitySchemes`, `security`) are present in the live response