### PR TITLE
feat(sync): externalize hardcoded REPOS into sync.repos.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ supabase/.temp/
 # logs
 *.log
 npm-debug.log*
+
+# sync repo config (user-local; copy from sync.repos.example.json)
+scripts/sync.repos.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-05-01 — feat(sync): externalize hardcoded REPOS into sync.repos.json — replaces hardcoded GitHub owner/repo array with a gitignored sync.repos.json loaded at runtime; ships sync.repos.example.json as the template forkers copy and fill in; exits with a clear error message if the config file is missing; eliminates the requirement to modify source to configure the sync pipeline
+
 - 2026-05-01 — fix(agent-card): add Cache-Control: public, max-age=300 to prevent indefinite caching by claude.ai and crawlers — no TTL caused claude.ai to serve a stale agent card after A2A spec fixes were deployed; 5-minute cap ensures changes propagate within one rotation while still allowing short-term caching to reduce Supabase round-trips
 
 - 2026-05-01 — fix(agent-card): align agent-card.json with A2A v1.0 spec — adds required top-level fields `protocolVersion: "1.0"`, `url`, `securitySchemes: {}`, and `security: [{}]`; moves non-standard `supportedInterfaces` array from top level into `capabilities.extensions` to eliminate conformance checker failures

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "private": true,
   "type": "module",
   "engines": {

--- a/scripts/sync.repos.example.json
+++ b/scripts/sync.repos.example.json
@@ -1,0 +1,14 @@
+[
+  {
+    "slug": "my-project",
+    "owner": "your-github-username",
+    "repo": "your-repo-name"
+  },
+  {
+    "slug": "my-other-project",
+    "owner": "your-github-username",
+    "repo": "another-repo",
+    "docsPath": "docs/architecture.md",
+    "featureDocsGlobs": ["docs/features/", "docs/plans/"]
+  }
+]

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -20,6 +20,9 @@
  */
 
 import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { createClient } from '@supabase/supabase-js'
 import { createOpenAI } from '@ai-sdk/openai'
 import { embed, generateText } from 'ai'
@@ -48,25 +51,24 @@ const MODEL = 'google/gemini-3-flash-preview'
 // Default singleton profile row ID (UUID with trailing 1)
 const PROFILE_ID = ['00000000', '0000', '0000', '0000', '000000000001'].join('-')
 
-// Repos to sync — slug must match the project slug in public_profile.projects
-// docsPath overrides README.md when the root README is just boilerplate
-// featureDocsGlobs: additional doc paths to read for OB1 thought enrichment
-const REPOS = [
-  {
-    slug: 'artisan-roast',
-    owner: 'yuens1002',
-    repo: 'artisan-roast',
-    featureDocsGlobs: ['docs/features/', 'docs/plans/'],
-  },
-  {
-    slug: 'artisan-roast-platform',
-    owner: 'dev-yuen-agency',
-    repo: 'artisan-roast-platform',
-    docsPath: 'docs/platform/platform.md',
-    featureDocsGlobs: ['docs/platform/'],
-  },
-  { slug: 'resume-agent', owner: 'yuens1002', repo: 'resume-agent' },
-]
+// Repos to sync — loaded from scripts/sync.repos.json (gitignored, user-local).
+// Copy scripts/sync.repos.example.json to scripts/sync.repos.json and fill in your repos.
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPOS_PATH = resolve(__dirname, 'sync.repos.json')
+let REPOS: Array<{
+  slug: string
+  owner: string
+  repo: string
+  docsPath?: string
+  featureDocsGlobs?: string[]
+}>
+try {
+  REPOS = JSON.parse(readFileSync(REPOS_PATH, 'utf-8'))
+} catch {
+  console.error(`sync.repos.json not found at ${REPOS_PATH}`)
+  console.error('Copy scripts/sync.repos.example.json to scripts/sync.repos.json and fill in your repos.')
+  process.exit(1)
+}
 
 // ── GitHub ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Replaces hardcoded GitHub owner/repo array in `scripts/sync.ts` with a gitignored `sync.repos.json` loaded at runtime
- Ships `scripts/sync.repos.example.json` as the copy-and-fill template for forkers
- Exits with a clear error message if the config file is missing
- Eliminates the requirement to modify source code to configure the sync pipeline

## Test plan
- [ ] `npm run sync` still works with `scripts/sync.repos.json` present
- [ ] Deleting `sync.repos.json` and running `npm run sync` prints the expected error and exits 1
- [ ] `scripts/sync.repos.json` does not appear in `git status` (confirmed gitignored)
- [ ] `npx tsc --noEmit` passes clean