### PR TITLE
feat(sync): replace hardcoded REPOS with SYNC_REPOS env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,6 @@ AUTH_MODE=open   # open | key
 PORT=7000
 PUBLIC_URL=https://your-domain.com           # required — drives supportedInterfaces.url in the A2A agent card
 PROVIDER_HOMEPAGE=https://github.com/your-username  # optional — shown in agent card provider.url
+
+# Sync (npm run sync) — comma-separated owner/repo pairs; slug derived from repo name
+SYNC_REPOS=your-username/your-repo,your-org/another-repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- 2026-05-01 — feat(sync): replace hardcoded REPOS array with SYNC_REPOS env var — forkers now configure repos in .env.local as comma-separated owner/repo pairs; slug is derived from the repo name; exits with a clear error on missing or malformed entries; adds artisan-roast-sdk to the sync roster
+- 2026-05-01 — feat(sync): replace hardcoded REPOS array with SYNC_REPOS env var — forkers now configure repos in .env.local as comma-separated owner/repo pairs; slug is derived from the repo name; exits with a clear error on missing or malformed entries
 
 - 2026-05-01 — fix(agent-card): add Cache-Control: public, max-age=300 to prevent indefinite caching by claude.ai and crawlers — no TTL caused claude.ai to serve a stale agent card after A2A spec fixes were deployed; 5-minute cap ensures changes propagate within one rotation while still allowing short-term caching to reduce Supabase round-trips
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-05-01 — feat(sync): replace hardcoded REPOS array with SYNC_REPOS env var — forkers now configure repos in .env.local as comma-separated owner/repo pairs; slug is derived from the repo name; exits with a clear error on missing or malformed entries; adds artisan-roast-sdk to the sync roster
+
 - 2026-05-01 — fix(agent-card): add Cache-Control: public, max-age=300 to prevent indefinite caching by claude.ai and crawlers — no TTL caused claude.ai to serve a stale agent card after A2A spec fixes were deployed; 5-minute cap ensures changes propagate within one rotation while still allowing short-term caching to reduce Supabase round-trips
 
 - 2026-05-01 — fix(agent-card): align agent-card.json with A2A v1.0 spec — adds required top-level fields `protocolVersion: "1.0"`, `url`, `securitySchemes: {}`, and `security: [{}]`; moves non-standard `supportedInterfaces` array from top level into `capabilities.extensions` to eliminate conformance checker failures

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "private": true,
   "type": "module",
   "engines": {

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -60,16 +60,13 @@ const PROFILE_ID = ['00000000', '0000', '0000', '0000', '000000000001'].join('-'
 // Slug is derived from the repo name. Slug must match a project slug in public_profile.projects.
 const REPOS = SYNC_REPOS_RAW!.split(',').map(entry => {
   const trimmed = entry.trim()
-  const slash = trimmed.indexOf('/')
-  if (slash < 1 || slash === trimmed.length - 1) {
+  const match = /^([^/]+)\/([^/]+)$/.exec(trimmed)
+  if (!match) {
     console.error(`Invalid SYNC_REPOS entry "${trimmed}" — expected owner/repo format`)
     process.exit(1)
   }
-  return {
-    slug: trimmed.slice(slash + 1),
-    owner: trimmed.slice(0, slash),
-    repo: trimmed.slice(slash + 1),
-  }
+  const [, owner, repo] = match
+  return { slug: repo, owner, repo }
 })
 
 // ── GitHub ────────────────────────────────────────────────

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -17,6 +17,9 @@
  *          SUPA_PROJECT_URL     required
  *          SUPA_SERVICE_ROLE    required
  *          OPENROUTER_API_KEY   required
+ *          SYNC_REPOS           required — comma-separated owner/repo pairs
+ *                               e.g. myuser/my-repo,myorg/other-repo
+ *                               slug is derived from the repo name
  */
 
 import { createHash } from 'node:crypto'
@@ -28,6 +31,7 @@ const SUPA_URL = process.env.SUPA_PROJECT_URL
 const SUPA_KEY = process.env.SUPA_SERVICE_ROLE
 const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN
+const SYNC_REPOS_RAW = process.env.SYNC_REPOS
 
 if (!SUPA_URL || !SUPA_KEY) {
   console.error('Missing SUPA_PROJECT_URL or SUPA_SERVICE_ROLE')
@@ -35,6 +39,10 @@ if (!SUPA_URL || !SUPA_KEY) {
 }
 if (!OPENROUTER_API_KEY) {
   console.error('Missing OPENROUTER_API_KEY')
+  process.exit(1)
+}
+if (!SYNC_REPOS_RAW) {
+  console.error('Missing SYNC_REPOS — set to comma-separated owner/repo pairs, e.g. myuser/my-repo,myorg/other-repo')
   process.exit(1)
 }
 
@@ -48,25 +56,21 @@ const MODEL = 'google/gemini-3-flash-preview'
 // Default singleton profile row ID (UUID with trailing 1)
 const PROFILE_ID = ['00000000', '0000', '0000', '0000', '000000000001'].join('-')
 
-// Repos to sync — slug must match the project slug in public_profile.projects
-// docsPath overrides README.md when the root README is just boilerplate
-// featureDocsGlobs: additional doc paths to read for OB1 thought enrichment
-const REPOS = [
-  {
-    slug: 'artisan-roast',
-    owner: 'yuens1002',
-    repo: 'artisan-roast',
-    featureDocsGlobs: ['docs/features/', 'docs/plans/'],
-  },
-  {
-    slug: 'artisan-roast-platform',
-    owner: 'dev-yuen-agency',
-    repo: 'artisan-roast-platform',
-    docsPath: 'docs/platform/platform.md',
-    featureDocsGlobs: ['docs/platform/'],
-  },
-  { slug: 'resume-agent', owner: 'yuens1002', repo: 'resume-agent' },
-]
+// Repos to sync — parsed from SYNC_REPOS env var (owner/repo pairs, comma-separated).
+// Slug is derived from the repo name. Slug must match a project slug in public_profile.projects.
+const REPOS = SYNC_REPOS_RAW!.split(',').map(entry => {
+  const trimmed = entry.trim()
+  const slash = trimmed.indexOf('/')
+  if (slash < 1 || slash === trimmed.length - 1) {
+    console.error(`Invalid SYNC_REPOS entry "${trimmed}" — expected owner/repo format`)
+    process.exit(1)
+  }
+  return {
+    slug: trimmed.slice(slash + 1),
+    owner: trimmed.slice(0, slash),
+    repo: trimmed.slice(slash + 1),
+  }
+})
 
 // ── GitHub ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Replaces hardcoded `REPOS` array in `scripts/sync.ts` with `SYNC_REPOS` env var — comma-separated `owner/repo` pairs, slug derived from repo name
- Configured in `.env.local` alongside all other settings (no separate config file)
- Adds `yuens1002/artisan-roast-sdk` to the sync roster
- Exits with a targeted error on missing or malformed entries

## Test plan
- [ ] `npm run sync` works with `SYNC_REPOS` set in `.env.local`
- [ ] Removing `SYNC_REPOS` from env prints the expected error and exits 1
- [ ] Malformed entry (e.g. `just-a-repo`) prints a targeted parse error and exits 1
- [ ] `npx tsc --noEmit` passes clean