### PR TITLE
feat(resume): anchor experience bullets to OB1 pool via show-don't-tell prompt pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-05-02 — feat(resume): anchor experience bullets to OB1 pool — adds Rule 6 to the generation prompt with a show-don't-tell pattern (two JD-context examples) that instructs the model to select and lightly adapt from the candidate's canonical bullet pool rather than synthesizing from context; eliminates fabricated dates and non-canonical bullets; verified via parallel old/new prompt comparison and live pipeline run against a real JD (all 4 OB1 bullets present in output, lightly adapted, no invented metrics); adds scripts/compare-prompts.ts with --model mode for prompt vs model comparison
+
 - 2026-05-02 — fix(scorer): drop Rule 5 (first bullet vs JD responsibility) — lexical keyword overlap is the wrong tool for a semantic question; boilerplate-detection heuristics were brittle and required constant patching; remaining 5 rules (title, keyword coverage, quantified bullets, authenticity, skills order) are fully deterministic and reliable
 
 - 2026-05-01 — feat(resume): SSE keepalive streaming eliminates Railway 503 on long dual-model generations — POST /resume now returns a text/event-stream immediately, sends `: keepalive\n\n` every 10s, and emits the final resume JSON as a single `data:` event; bumps maxTokens to 8192 for Gemini 2.5 Flash thinking-token budget; strips banned phrases before scoring so Rule 4 reflects post-processed output; fixes Rule 1 adjective extraction ("talented Application Engineer" → "Application Engineer"); fixes Rule 5 to skip keyword overlap when JD opening is company boilerplate rather than stated duties

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.2.19",
+  "version": "0.2.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.2.19",
+      "version": "0.2.25",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "private": true,
   "type": "module",
   "engines": {
@@ -20,7 +20,9 @@
     "test:transport": "tsx --env-file=.env.local --test tests/mcp-transport.test.ts",
     "test:oauth": "tsx --env-file=.env.local --test tests/oauth.test.ts",
     "test:public-mcp": "tsx --env-file=.env.local --test tests/public-mcp-transport.test.ts tests/public-mcp-tool.test.ts",
-    "sync": "tsx --env-file=.env.local scripts/sync.ts"
+    "sync": "tsx --env-file=.env.local scripts/sync.ts",
+    "compare:prompts": "tsx --env-file=.env.local scripts/compare-prompts.ts",
+    "compare:models": "tsx --env-file=.env.local scripts/compare-prompts.ts --model"
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.3.19",

--- a/scripts/compare-prompts.ts
+++ b/scripts/compare-prompts.ts
@@ -1,0 +1,226 @@
+/**
+ * compare-prompts.ts
+ *
+ * Runs the old and new resume generation system prompts in parallel against
+ * the same profile + JD, then prints the employment sections side-by-side
+ * so you can see the delta before committing.
+ *
+ * Usage:
+ *   npm run compare:prompts
+ *   npm run compare:prompts -- "paste a JD here as a single arg"
+ */
+
+import { generateText } from 'ai'
+import { supabase } from '../src/lib/supabase.js'
+import { getModel } from '../src/lib/ai.js'
+import { parseJSON } from '../src/lib/parse-json.js'
+import type { ResumeResponse, Employment } from '../src/types.js'
+
+const MODEL_A = process.env.RESUME_MODEL ?? 'openai/gpt-4o-mini'
+const MODEL_B = process.env.RESUME_MODEL_B ?? MODEL_A
+// 'prompt' = old vs new with MODEL_A | 'model' = MODEL_A vs MODEL_B with new prompt
+const MODE = process.argv.includes('--model') ? 'model' : 'prompt'
+
+const SAMPLE_JD = `
+Senior AI Product Engineer
+
+We're looking for a product-minded engineer to lead development of AI-powered features
+in our SaaS platform. You'll own the full cycle — from spec through production — and
+work closely with LLMs, build reliable agentic workflows, and keep quality high as we scale.
+
+Requirements:
+- 4+ years building production software end-to-end
+- Experience integrating LLMs / AI APIs into real products
+- Strong TypeScript and backend fundamentals
+- Familiarity with CI/CD, observability, and multi-tenant architecture
+- Ability to work autonomously across design, implementation, and operations
+`.trim()
+
+// ── Old prompt (pre-fix) ─────────────────────────────────────────────────────
+
+const OLD_SYSTEM_PROMPT = `You are a professional resume writer optimizing for ATS (Applicant Tracking Systems) and human recruiter review. Generate a tailored resume for the candidate based on their profile and the target job description.
+
+Rules:
+
+1. SUMMARY — JD TITLE FIRST: Your opening words in the summary MUST use the exact job title from the job description, not the candidate's default self-description. Follow with years of experience and 3-5 high-priority skills from the JD woven naturally.
+   Example: If JD says "Sr UX Engineer", open with "Senior UX Engineer with 6+ years..." — never "Full-stack engineer".
+
+2. KEYWORD COVERAGE: Achieve at least 25% coverage of the JD's key technical terms, targeting 40%+ for strong matches. Place the highest-priority keywords in: summary first sentence, skills section, and first bullet of each employment entry. Include both long-form and abbreviations where applicable (e.g., "Continuous Integration / CI/CD").
+
+3. IMPACT BULLETS: Every bullet must use "action verb + specific achievement + quantified result". Include real project names, real technologies, and real metrics from the candidate's profile. Never genericize specific accomplishments into vague descriptions.
+   Bad: "Optimized front-end performance"
+   Good: "Reduced page load time by 40% through code splitting and lazy loading across 25+ React components" (use the candidate's actual project name, technology, and metric)
+
+4. AUTHENTICITY: Vary sentence structure and verb choices across bullets. Never use: "results-driven", "proven track record", "leveraging", "dynamic team player", "synergies", "spearheaded". Every bullet must contain at least one detail specific to THIS candidate's actual experience — a project name, a technology choice, a metric, or a specific outcome.
+
+5. PER-ROLE BULLET PRIORITIZATION: For each employment entry, lead with bullets that demonstrate skills matching the JD's core requirements. The first bullet of the most recent role MUST directly address the JD's primary responsibility. Deprioritize or omit bullets about skills the JD doesn't mention.
+
+6. SKILLS ORDERING: List 10-15 skills ordered by relevance to the target role. Skills mentioned in the JD come first. Include both the JD's exact terminology and the candidate's equivalent terms.
+
+7. SELF-EMPLOYMENT FRAMING: For self-employed or solo entrepreneur roles, frame the work as if it were a job matching the JD title. Describe the JD-relevant work performed — not just the technical architecture. If the JD emphasizes design, describe design work; if it emphasizes backend, describe backend work. Technical architecture details belong in the Projects section, not Employment bullets.
+
+8. PROJECTS SECTION: Projects should highlight what makes the work impressive at a glance — key features, scale, and standout achievements. Keep it concise with a brief description and 3-4 bullet highlights. Technical architecture depth is welcome here. This is the "nice-to-have" that demonstrates breadth and initiative.
+
+Additional rules:
+- Never fabricate credentials, titles, dates, or skills
+- Do NOT include a "contact" key in your JSON — it will be injected server-side
+- Each project in the profile represents a distinct goal and outcome — never merge or combine them regardless of shared tech stack. Treat each as its own entry. As the portfolio grows, include only the projects most relevant to the target JD.
+
+Respond with structured JSON:
+{
+  "summary": "...",
+  "skills": [...],
+  "employment": [...],
+  "education": [...],
+  "projects": [...]
+}`
+
+// ── New prompt (with Rule 6 pattern) ─────────────────────────────────────────
+
+const NEW_SYSTEM_PROMPT = `You are a professional resume writer optimizing for ATS (Applicant Tracking Systems) and human recruiter review. Generate a tailored resume for the candidate based on their profile and the target job description.
+
+Rules:
+
+1. SUMMARY — JD TITLE FIRST: Your opening words in the summary MUST use the exact job title from the job description, not the candidate's default self-description. Follow with years of experience and 3-5 high-priority skills from the JD woven naturally.
+   Example: If JD says "Sr UX Engineer", open with "Senior UX Engineer with 6+ years..." — never "Full-stack engineer".
+
+2. KEYWORD COVERAGE: Achieve at least 25% coverage of the JD's key technical terms, targeting 40%+ for strong matches. Place the highest-priority keywords in: summary first sentence, skills section, and first bullet of each employment entry. Include both long-form and abbreviations where applicable (e.g., "Continuous Integration / CI/CD").
+
+3. IMPACT BULLETS: Every bullet must use "action verb + specific achievement + quantified result". Include real project names, real technologies, and real metrics from the candidate's profile. Never genericize specific accomplishments into vague descriptions.
+   Bad: "Optimized front-end performance"
+   Good: "Reduced page load time by 40% through code splitting and lazy loading across 25+ React components" (use the candidate's actual project name, technology, and metric)
+
+4. AUTHENTICITY: Vary sentence structure and verb choices across bullets. Never use: "results-driven", "proven track record", "leveraging", "dynamic team player", "synergies", "spearheaded". Every bullet must contain at least one detail specific to THIS candidate's actual experience — a project name, a technology choice, a metric, or a specific outcome.
+
+5. PER-ROLE BULLET PRIORITIZATION: For each employment entry, lead with bullets that demonstrate skills matching the JD's core requirements. The first bullet of the most recent role MUST directly address the JD's primary responsibility. Deprioritize or omit bullets about skills the JD doesn't mention.
+
+6. EXPERIENCE SECTION — the \`bullets\` array on each employment entry is your pool. Select from it and lightly adapt — do not invent new bullets. Follow this pattern:
+
+  Profile entry:
+  {
+    "company": "Acme Corp",
+    "start_date": "2024-03",
+    "end_date": null,
+    "bullets": [
+      "Led end-to-end delivery across the full product lifecycle, from specification through production",
+      "Automated deployment pipeline, reducing release cycle from days to minutes",
+      "Integrated LLM-based features into production, cutting manual review time by 60%"
+    ]
+  }
+
+  Output for a DevOps-focused JD:
+  {
+    "company": "Acme Corp",
+    "start_date": "2024-03",
+    "end_date": null,
+    "bullets": [
+      "Automated CI/CD pipeline, reducing release cycle from days to minutes",
+      "Led end-to-end delivery across the full product lifecycle, from specification through production"
+    ]
+  }
+
+  Output for an AI/ML-focused JD:
+  {
+    "company": "Acme Corp",
+    "start_date": "2024-03",
+    "end_date": null,
+    "bullets": [
+      "Integrated LLM-based features into production, cutting manual review time by 60%",
+      "Led end-to-end delivery across the full product lifecycle, from specification through production"
+    ]
+  }
+
+7. SKILLS ORDERING: List 10-15 skills ordered by relevance to the target role. Skills mentioned in the JD come first. Include both the JD's exact terminology and the candidate's equivalent terms.
+
+8. SELF-EMPLOYMENT FRAMING: For self-employed or solo entrepreneur roles, frame the work as if it were a job matching the JD title. Describe the JD-relevant work performed — not just the technical architecture. If the JD emphasizes design, describe design work; if it emphasizes backend, describe backend work. Technical architecture details belong in the Projects section, not Employment bullets.
+
+9. PROJECTS SECTION: Projects should highlight what makes the work impressive at a glance — key features, scale, and standout achievements. Keep it concise with a brief description and 3-4 bullet highlights. Technical architecture depth is welcome here. This is the "nice-to-have" that demonstrates breadth and initiative.
+
+Additional rules:
+- Never fabricate credentials, titles, dates, or skills
+- Do NOT include a "contact" key in your JSON — it will be injected server-side
+- Each project in the profile represents a distinct goal and outcome — never merge or combine them regardless of shared tech stack. Treat each as its own entry. As the portfolio grows, include only the projects most relevant to the target JD.
+
+Respond with structured JSON:
+{
+  "summary": "...",
+  "skills": [...],
+  "employment": [...],
+  "education": [...],
+  "projects": [...]
+}`
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function printEmployment(label: string, entries: Employment[]) {
+  console.log(`\n${'─'.repeat(60)}`)
+  console.log(`  ${label}`)
+  console.log('─'.repeat(60))
+  for (const e of entries) {
+    console.log(`\n  ${e.company} — ${e.title}`)
+    console.log(`  ${e.start_date} → ${e.end_date ?? 'present'}`)
+    for (const b of e.bullets) {
+      console.log(`    • ${b}`)
+    }
+  }
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+const jd = process.argv.find((a, i) => i >= 2 && !a.startsWith('--')) ?? SAMPLE_JD
+
+const { data: profile, error } = await supabase
+  .from('public_profile')
+  .select('*')
+  .eq('id', '00000000-0000-0000-0000-000000000001')
+  .single()
+
+if (error || !profile) {
+  console.error('Profile not found:', error?.message)
+  process.exit(1)
+}
+
+const userMessage = `Candidate profile:\n${JSON.stringify(profile, null, 2)}\n\nTarget job description:\n${jd}`
+
+console.log(`\nMode: ${MODE}`)
+console.log(`Model A: ${MODEL_A}`)
+if (MODE === 'model') console.log(`Model B: ${MODEL_B}`)
+console.log(`JD preview: ${jd.slice(0, 80).replace(/\n/g, ' ')}…`)
+console.log(`\nRunning in parallel…`)
+
+async function generate(systemPrompt: string, modelId: string): Promise<ResumeResponse | null> {
+  try {
+    const { text } = await generateText({
+      model: getModel(modelId),
+      maxTokens: 8192,
+      system: systemPrompt,
+      prompt: userMessage,
+    })
+    return parseJSON<ResumeResponse>(text)
+  } catch (err) {
+    console.error(`Generation failed (${modelId}):`, err instanceof Error ? err.message : err)
+    return null
+  }
+}
+
+if (MODE === 'model') {
+  const [resultA, resultB] = await Promise.all([
+    generate(NEW_SYSTEM_PROMPT, MODEL_A),
+    generate(NEW_SYSTEM_PROMPT, MODEL_B),
+  ])
+  if (!resultA) { console.error(`${MODEL_A} generation failed`); process.exit(1) }
+  if (!resultB) { console.error(`${MODEL_B} generation failed`); process.exit(1) }
+  printEmployment(MODEL_A, resultA.employment)
+  printEmployment(MODEL_B, resultB.employment)
+} else {
+  const [oldResult, newResult] = await Promise.all([
+    generate(OLD_SYSTEM_PROMPT, MODEL_A),
+    generate(NEW_SYSTEM_PROMPT, MODEL_A),
+  ])
+  if (!oldResult) { console.error('OLD prompt generation failed'); process.exit(1) }
+  if (!newResult) { console.error('NEW prompt generation failed'); process.exit(1) }
+  printEmployment('OLD PROMPT', oldResult.employment)
+  printEmployment('NEW PROMPT', newResult.employment)
+}
+
+console.log('\n')

--- a/scripts/compare-prompts.ts
+++ b/scripts/compare-prompts.ts
@@ -99,6 +99,7 @@ Rules:
   Profile entry:
   {
     "company": "Acme Corp",
+    "title": "Senior Engineer",
     "start_date": "2024-03",
     "end_date": null,
     "bullets": [
@@ -111,6 +112,7 @@ Rules:
   Output for a DevOps-focused JD:
   {
     "company": "Acme Corp",
+    "title": "Senior Engineer",
     "start_date": "2024-03",
     "end_date": null,
     "bullets": [
@@ -122,6 +124,7 @@ Rules:
   Output for an AI/ML-focused JD:
   {
     "company": "Acme Corp",
+    "title": "Senior Engineer",
     "start_date": "2024-03",
     "end_date": null,
     "bullets": [
@@ -152,14 +155,19 @@ Respond with structured JSON:
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-function printEmployment(label: string, entries: Employment[]) {
+function printEmployment(label: string, result: ResumeResponse) {
   console.log(`\n${'─'.repeat(60)}`)
   console.log(`  ${label}`)
   console.log('─'.repeat(60))
-  for (const e of entries) {
+  if (!Array.isArray(result.employment)) {
+    console.log(`  [no employment array — raw output: ${JSON.stringify(result).slice(0, 200)}]`)
+    return
+  }
+  for (const e of result.employment) {
     console.log(`\n  ${e.company} — ${e.title}`)
     console.log(`  ${e.start_date} → ${e.end_date ?? 'present'}`)
-    for (const b of e.bullets) {
+    const bullets = Array.isArray(e.bullets) ? e.bullets : []
+    for (const b of bullets) {
       console.log(`    • ${b}`)
     }
   }
@@ -167,7 +175,7 @@ function printEmployment(label: string, entries: Employment[]) {
 
 // ── Main ─────────────────────────────────────────────────────────────────────
 
-const jd = process.argv.find((a, i) => i >= 2 && !a.startsWith('--')) ?? SAMPLE_JD
+const jd = process.argv.find((a, i) => i >= 2 && !a.startsWith('--') && !a.endsWith('.ts') && !a.endsWith('.js')) ?? SAMPLE_JD
 
 const { data: profile, error } = await supabase
   .from('public_profile')
@@ -210,8 +218,8 @@ if (MODE === 'model') {
   ])
   if (!resultA) { console.error(`${MODEL_A} generation failed`); process.exit(1) }
   if (!resultB) { console.error(`${MODEL_B} generation failed`); process.exit(1) }
-  printEmployment(MODEL_A, resultA.employment)
-  printEmployment(MODEL_B, resultB.employment)
+  printEmployment(MODEL_A, resultA)
+  printEmployment(MODEL_B, resultB)
 } else {
   const [oldResult, newResult] = await Promise.all([
     generate(OLD_SYSTEM_PROMPT, MODEL_A),
@@ -219,8 +227,8 @@ if (MODE === 'model') {
   ])
   if (!oldResult) { console.error('OLD prompt generation failed'); process.exit(1) }
   if (!newResult) { console.error('NEW prompt generation failed'); process.exit(1) }
-  printEmployment('OLD PROMPT', oldResult.employment)
-  printEmployment('NEW PROMPT', newResult.employment)
+  printEmployment('OLD PROMPT', oldResult)
+  printEmployment('NEW PROMPT', newResult)
 }
 
 console.log('\n')

--- a/src/lib/score-resume.ts
+++ b/src/lib/score-resume.ts
@@ -221,7 +221,7 @@ function scoreRule4(resume: ResumeResponse): RuleResult {
 }
 
 
-/** Rule 6: Top skills in the skills list match JD requirements. */
+/** Rule 7: Top skills in the skills list match JD requirements. */
 function scoreRule6(resume: ResumeResponse, jd: string): RuleResult {
   const skills = (resume.skills ?? []) as unknown[]
   const flatSkills = skills.flatMap((s: unknown) =>
@@ -229,7 +229,7 @@ function scoreRule6(resume: ResumeResponse, jd: string): RuleResult {
   )
 
   if (flatSkills.length === 0) {
-    return { rule: 6, name: 'Skills ordered by JD relevance', pass: false, score: 0, detail: 'No skills found' }
+    return { rule: 7, name: 'Skills ordered by JD relevance', pass: false, score: 0, detail: 'No skills found' }
   }
 
   const jdLower = jd.toLowerCase()
@@ -246,7 +246,7 @@ function scoreRule6(resume: ResumeResponse, jd: string): RuleResult {
 
   const ratio = top5.length > 0 ? top5InJD.length / top5.length : 0
   return {
-    rule: 6,
+    rule: 7,
     name: 'Skills ordered by JD relevance',
     pass: ratio >= 0.4,
     score: ratio,

--- a/src/routes/resume.ts
+++ b/src/routes/resume.ts
@@ -63,11 +63,50 @@ Rules:
 
 5. PER-ROLE BULLET PRIORITIZATION: For each employment entry, lead with bullets that demonstrate skills matching the JD's core requirements. The first bullet of the most recent role MUST directly address the JD's primary responsibility. Deprioritize or omit bullets about skills the JD doesn't mention.
 
-6. SKILLS ORDERING: List 10-15 skills ordered by relevance to the target role. Skills mentioned in the JD come first. Include both the JD's exact terminology and the candidate's equivalent terms.
+6. EXPERIENCE SECTION — the "bullets" array on each employment entry is your pool. Select from it and lightly adapt — do not invent new bullets. Follow this pattern:
 
-7. SELF-EMPLOYMENT FRAMING: For self-employed or solo entrepreneur roles, frame the work as if it were a job matching the JD title. Describe the JD-relevant work performed — not just the technical architecture. If the JD emphasizes design, describe design work; if it emphasizes backend, describe backend work. Technical architecture details belong in the Projects section, not Employment bullets.
+  Profile entry:
+  {
+    "company": "Acme Corp",
+    "title": "Senior Engineer",
+    "start_date": "2024-03",
+    "end_date": null,
+    "bullets": [
+      "Led end-to-end delivery across the full product lifecycle, from specification through production",
+      "Automated deployment pipeline, reducing release cycle from days to minutes",
+      "Integrated LLM-based features into production, cutting manual review time by 60%"
+    ]
+  }
 
-8. PROJECTS SECTION: Projects should highlight what makes the work impressive at a glance — key features, scale, and standout achievements. Keep it concise with a brief description and 3-4 bullet highlights. Technical architecture depth is welcome here. This is the "nice-to-have" that demonstrates breadth and initiative.
+  Output for a DevOps-focused JD:
+  {
+    "company": "Acme Corp",
+    "title": "Senior Engineer",
+    "start_date": "2024-03",
+    "end_date": null,
+    "bullets": [
+      "Automated CI/CD pipeline, reducing release cycle from days to minutes",
+      "Led end-to-end delivery across the full product lifecycle, from specification through production"
+    ]
+  }
+
+  Output for an AI/ML-focused JD:
+  {
+    "company": "Acme Corp",
+    "title": "Senior Engineer",
+    "start_date": "2024-03",
+    "end_date": null,
+    "bullets": [
+      "Integrated LLM-based features into production, cutting manual review time by 60%",
+      "Led end-to-end delivery across the full product lifecycle, from specification through production"
+    ]
+  }
+
+7. SKILLS ORDERING: List 10-15 skills ordered by relevance to the target role. Skills mentioned in the JD come first. Include both the JD's exact terminology and the candidate's equivalent terms.
+
+8. SELF-EMPLOYMENT FRAMING: For self-employed or solo entrepreneur roles, frame the work as if it were a job matching the JD title. Describe the JD-relevant work performed — not just the technical architecture. If the JD emphasizes design, describe design work; if it emphasizes backend, describe backend work. Technical architecture details belong in the Projects section, not Employment bullets.
+
+9. PROJECTS SECTION: Projects should highlight what makes the work impressive at a glance — key features, scale, and standout achievements. Keep it concise with a brief description and 3-4 bullet highlights. Technical architecture depth is welcome here. This is the "nice-to-have" that demonstrates breadth and initiative.
 
 Additional rules:
 - Never fabricate credentials, titles, dates, or skills


### PR DESCRIPTION
## Summary

- Adds Rule 6 to the generation system prompt: instructs the model to treat each employment entry's \`bullets\` array as an authoritative pool — select from it, lightly adapt for JD relevance, do not invent
- Uses a show-don't-tell pattern (two concrete JD-context examples — DevOps and AI/ML) rather than a prescriptive rule, so the model learns by example what selection and light adaptation look like
- Fixes fabricated dates and non-canonical bullets that were being synthesized from broader profile context (projects, thoughts) instead of the stored employment data
- Adds `scripts/compare-prompts.ts` with `--model` flag for prompt-vs-prompt and model-vs-model comparisons; `npm run compare:prompts` and `npm run compare:models` scripts wired up

## Test plan

- [x] Ran `npm run compare:prompts` (old vs new) — new prompt produces verbatim/lightly-adapted OB1 bullets; old prompt fabricates metrics and project-context details
- [x] Ran `npm run compare:models` (deepseek-v3.2 vs grok-4.20) — grok follows the pool instruction faithfully; deepseek still synthesizes (expected: grok wins rubric)
- [x] Ran live pipeline: `POST /match` → `POST /resume` against DoorDash Full Stack Engineer JD — rubric passed (4.06), all 4 OB1 Self-Employed bullets present and lightly adapted, dates correct (2025-11 → present), winner model grok-4.20
- [x] Typecheck clean (`npx tsc --noEmit`)