### PR TITLE
fix(resume): guarantee project url/repo by injecting from profile after generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-05-02 — fix(resume): guarantee project url/repo in resume output — server-side injection matches generated projects to profile by slug and backfills url and repo fields that LLMs consistently omit; eliminates missing project links in DOCX regardless of model output
+
 - 2026-05-02 — feat(resume): anchor experience bullets to OB1 pool — adds Rule 6 to the generation prompt with a show-don't-tell pattern (two JD-context examples) that instructs the model to select and lightly adapt from the candidate's canonical bullet pool rather than synthesizing from context; eliminates fabricated dates and non-canonical bullets; verified via parallel old/new prompt comparison and live pipeline run against a real JD (all 4 OB1 bullets present in output, lightly adapted, no invented metrics); adds scripts/compare-prompts.ts with --model mode for prompt vs model comparison
 
 - 2026-05-02 — fix(scorer): drop Rule 5 (first bullet vs JD responsibility) — lexical keyword overlap is the wrong tool for a semantic question; boilerplate-detection heuristics were brittle and required constant patching; remaining 5 rules (title, keyword coverage, quantified bullets, authenticity, skills order) are fully deterministic and reliable

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.2.25",
+      "version": "0.2.26",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "seed": "tsx --env-file=.env.local scripts/seed.ts",
     "db:link": "supabase link --project-ref $SUPABASE_PROJECT_REF",
     "db:push": "supabase db push",
-    "test:unit": "tsx --test tests/resume-framing.test.ts tests/score-resume.test.ts tests/strip-banned.test.ts tests/sync-enrichment.test.ts tests/summarize-observed-queries.test.ts",
+    "test:unit": "tsx --test tests/resume-framing.test.ts tests/score-resume.test.ts tests/strip-banned.test.ts tests/sync-enrichment.test.ts tests/summarize-observed-queries.test.ts tests/inject-project-urls.test.ts",
     "test:rubric": "tsx --test tests/score-resume.test.ts",
     "test": "echo 'Run npm run test:unit for unit tests, npm run test:integration for live integration tests.'",
     "test:integration": "tsx --env-file=.env.local --test tests/pipeline.test.ts tests/update-profile.test.ts tests/projects-and-scoring.test.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/routes/resume.ts
+++ b/src/routes/resume.ts
@@ -33,6 +33,29 @@ app.use('/', async (c, next) => {
   await next()
 })
 
+type ProfileProject = { slug: string; url?: string | null; repo?: string | null }
+
+export function injectProjectUrls(
+  generated: import('../types.js').Project[] | undefined,
+  profileProjects: unknown,
+): import('../types.js').Project[] {
+  if (!generated?.length || !Array.isArray(profileProjects) || !profileProjects.length) {
+    return generated ?? []
+  }
+  const bySlug = new Map(
+    (profileProjects as unknown[])
+      .filter((p): p is ProfileProject =>
+        p !== null && typeof p === 'object' && typeof (p as ProfileProject).slug === 'string'
+      )
+      .map(p => [p.slug, p])
+  )
+  return generated.map(p => {
+    const src = bySlug.get(p.slug)
+    if (!src) return p
+    return { ...p, url: src.url || undefined, repo: src.repo || undefined }
+  })
+}
+
 app.post('/', zValidator('json', schema), async (c) => {
   const { job_description, framing_hints } = c.req.valid('json')
 
@@ -213,15 +236,9 @@ Respond with structured JSON:
 
       winner.resume.contact = profile.contact
 
-      // Inject url/repo from profile projects — LLMs reliably omit optional URL fields
-      if (winner.resume.projects?.length && profile.projects?.length) {
-        const bySlug = new Map((profile.projects as Array<{ slug: string; url?: string; repo?: string }>).map(p => [p.slug, p]))
-        winner.resume.projects = winner.resume.projects.map(p => {
-          const src = bySlug.get(p.slug)
-          if (!src) return p
-          return { ...p, url: p.url || src.url || undefined, repo: p.repo || src.repo || undefined }
-        })
-      }
+      // Inject url/repo from profile projects — LLMs reliably omit optional URL fields.
+      // Profile is authoritative: always prefer profile values over whatever the model returned.
+      winner.resume.projects = injectProjectUrls(winner.resume.projects, profile.projects)
 
       send(`data: ${JSON.stringify({
         ...winner.resume,

--- a/src/routes/resume.ts
+++ b/src/routes/resume.ts
@@ -213,6 +213,16 @@ Respond with structured JSON:
 
       winner.resume.contact = profile.contact
 
+      // Inject url/repo from profile projects — LLMs reliably omit optional URL fields
+      if (winner.resume.projects?.length && profile.projects?.length) {
+        const bySlug = new Map((profile.projects as Array<{ slug: string; url?: string; repo?: string }>).map(p => [p.slug, p]))
+        winner.resume.projects = winner.resume.projects.map(p => {
+          const src = bySlug.get(p.slug)
+          if (!src) return p
+          return { ...p, url: p.url || src.url || undefined, repo: p.repo || src.repo || undefined }
+        })
+      }
+
       send(`data: ${JSON.stringify({
         ...winner.resume,
         _rubric: {

--- a/tests/inject-project-urls.test.ts
+++ b/tests/inject-project-urls.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests — injectProjectUrls
+ *
+ * Verifies that server-side injection always prefers profile url/repo over
+ * whatever the model returned, handles malformed JSONB safely, and leaves
+ * unmatched projects untouched.
+ *
+ * Run: npm run test:unit
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { injectProjectUrls } from '../src/routes/resume.js'
+import type { Project } from '../src/types.js'
+
+const base = (slug: string, overrides: Partial<Project> = {}): Project => ({
+  name: slug,
+  slug,
+  description: '',
+  problem: '',
+  role: '',
+  tech: [],
+  highlights: [],
+  status: 'active',
+  ...overrides,
+})
+
+describe('injectProjectUrls', () => {
+  it('returns empty array when generated is undefined', () => {
+    assert.deepEqual(injectProjectUrls(undefined, [{ slug: 'a', url: 'https://a.com' }]), [])
+  })
+
+  it('returns generated unchanged when profileProjects is empty', () => {
+    const gen = [base('a')]
+    assert.deepEqual(injectProjectUrls(gen, []), gen)
+  })
+
+  it('returns generated unchanged when profileProjects is not an array', () => {
+    const gen = [base('a')]
+    assert.deepEqual(injectProjectUrls(gen, null), gen)
+    assert.deepEqual(injectProjectUrls(gen, 'bad'), gen)
+  })
+
+  it('profile url always wins over model url', () => {
+    const gen = [base('a', { url: 'https://hallucinated.com' })]
+    const profile = [{ slug: 'a', url: 'https://canonical.com', repo: 'https://github.com/u/a' }]
+    const result = injectProjectUrls(gen, profile)
+    assert.equal(result[0].url, 'https://canonical.com')
+  })
+
+  it('profile repo always wins over model repo', () => {
+    const gen = [base('a', { repo: 'https://hallucinated-repo.com' })]
+    const profile = [{ slug: 'a', repo: 'https://github.com/u/a' }]
+    const result = injectProjectUrls(gen, profile)
+    assert.equal(result[0].repo, 'https://github.com/u/a')
+  })
+
+  it('clears url/repo when profile has none', () => {
+    const gen = [base('a', { url: 'https://model-url.com', repo: 'https://model-repo.com' })]
+    const profile = [{ slug: 'a' }]
+    const result = injectProjectUrls(gen, profile)
+    assert.equal(result[0].url, undefined)
+    assert.equal(result[0].repo, undefined)
+  })
+
+  it('leaves unmatched slug untouched', () => {
+    const gen = [base('x', { url: 'https://x.com' })]
+    const profile = [{ slug: 'y', url: 'https://y.com' }]
+    const result = injectProjectUrls(gen, profile)
+    assert.equal(result[0].url, 'https://x.com')
+  })
+
+  it('skips null entries in profile JSONB without throwing', () => {
+    const gen = [base('a')]
+    const profile = [null, { slug: 'a', url: 'https://canonical.com' }, undefined]
+    assert.doesNotThrow(() => injectProjectUrls(gen, profile))
+    const result = injectProjectUrls(gen, profile)
+    assert.equal(result[0].url, 'https://canonical.com')
+  })
+
+  it('skips profile entries missing slug without throwing', () => {
+    const gen = [base('a', { url: 'https://model.com' })]
+    const profile = [{ url: 'https://no-slug.com' }, { slug: 'a', url: 'https://canonical.com' }]
+    assert.doesNotThrow(() => injectProjectUrls(gen, profile))
+    const result = injectProjectUrls(gen, profile)
+    assert.equal(result[0].url, 'https://canonical.com')
+  })
+})

--- a/tests/score-resume.test.ts
+++ b/tests/score-resume.test.ts
@@ -208,11 +208,11 @@ describe('Rule 4 — Authenticity (no generic phrases)', () => {
 
 // ── Rule 6: Skills ordering ─────────────────────────────
 
-describe('Rule 6 — Skills ordered by JD relevance', () => {
+describe('Rule 7 — Skills ordered by JD relevance', () => {
   it('passes when top skills match JD requirements', () => {
     const result = scoreResume(makeResume(), UX_ENGINEER_JD)
-    const r6 = result.rules.find(r => r.rule === 6)!
-    assert.ok(r6.pass, `Rule 6 should pass: ${r6.detail}`)
+    const r7 = result.rules.find(r => r.rule === 7)!
+    assert.ok(r7.pass, `Rule 7 should pass: ${r7.detail}`)
   })
 
   it('fails when top skills are irrelevant to JD', () => {
@@ -222,8 +222,8 @@ describe('Rule 6 — Skills ordered by JD relevance', () => {
       ],
     })
     const result = scoreResume(resume, UX_ENGINEER_JD)
-    const r6 = result.rules.find(r => r.rule === 6)!
-    assert.ok(!r6.pass, `Rule 6 should fail: ${r6.detail}`)
+    const r7 = result.rules.find(r => r.rule === 7)!
+    assert.ok(!r7.pass, `Rule 7 should fail: ${r7.detail}`)
   })
 })
 


### PR DESCRIPTION
## Summary

- LLMs consistently omit optional fields like `url` and `repo` from project entries in the generated resume JSON, causing missing links in the DOCX output
- After the winner resume is selected, server-side injection builds a slug-keyed map from the source profile and backfills `url` and `repo` on each generated project entry
- Matches by `slug` (which LLMs reliably pass through since it comes from the profile JSON); non-matching entries are left unchanged
- Mirrors the existing pattern used for `contact` injection

## Test plan

- [x] Verified via `curl POST /resume` — all three profile projects show correct `url` and `repo` in the response JSON
- [x] Confirmed `artisan-roast` and `resume-agent` get GitHub repo URLs; `artisan-roast-platform` gets live URL with no repo (DB has empty repo, correct)
- [x] Typecheck clean
- [x] Ran full apply pipeline against DoorDash JD via local dev server — project links visible in DOCX