### PR TITLE
feat(sync): derive repos from profile.projects and add HIDE_FROM_PROJECTS filter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,5 +25,9 @@ PORT=7000
 PUBLIC_URL=https://your-domain.com           # required — drives supportedInterfaces.url in the A2A agent card
 PROVIDER_HOMEPAGE=https://github.com/your-username  # optional — shown in agent card provider.url
 
-# Sync (npm run sync) — comma-separated owner/repo pairs; slug derived from repo name
-SYNC_REPOS=your-username/your-repo,your-org/another-repo
+# Sync (npm run sync) — automatically syncs all projects in public_profile.projects that have a GitHub repo URL
+# No configuration needed; add a project to the profile and the next sync picks it up.
+
+# Resume generation — comma-separated project slugs to exclude from the Projects section
+# while still keeping their OB1 thoughts in play for employment context injection.
+# HIDE_FROM_PROJECTS=slug-one,slug-two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-05-02 — feat(sync): derive repos from profile.projects and add HIDE_FROM_PROJECTS filter — eliminates SYNC_REPOS env var (breaking); sync script now reads GitHub owner/repo from each project's repo URL so adding a project to the profile automatically includes it in the next sync; HIDE_FROM_PROJECTS env var (comma-separated slugs) filters projects from the resume output at generation time while keeping OB1 thoughts in play for employment context injection; documents both in a new "Project sync" README section
+
 - 2026-05-02 — fix(resume): guarantee project url/repo in resume output — server-side injection matches generated projects to profile by slug and backfills url and repo fields that LLMs consistently omit; eliminates missing project links in DOCX regardless of model output
 
 - 2026-05-02 — feat(resume): anchor experience bullets to OB1 pool — adds Rule 6 to the generation prompt with a show-don't-tell pattern (two JD-context examples) that instructs the model to select and lightly adapt from the candidate's canonical bullet pool rather than synthesizing from context; eliminates fabricated dates and non-canonical bullets; verified via parallel old/new prompt comparison and live pipeline run against a real JD (all 4 OB1 bullets present in output, lightly adapted, no invented metrics); adds scripts/compare-prompts.ts with --model mode for prompt vs model comparison

--- a/README.md
+++ b/README.md
@@ -363,6 +363,28 @@ See [`docs/workflow.md`](docs/workflow.md) for a walkthrough of how employer AI 
 
 ---
 
+## Project sync
+
+`npm run sync` keeps every project in your `public_profile.projects` array up-to-date from GitHub — no configuration needed beyond what's already in the profile.
+
+**How it works:** For each project that has a `repo` field pointing to a GitHub URL, the sync script fetches the README and CHANGELOG, reconciles the `architecture` and `highlights` fields via LLM semantic diff, and extracts new OB1 thoughts for downstream context injection. Projects without a GitHub `repo` are skipped silently.
+
+**Controlling what appears on the resume:** Not every synced project belongs in the Projects section of a generated resume. Some projects are better represented as context for the employment section (e.g. a SaaS platform that's already covered by a self-employment entry). Use `HIDE_FROM_PROJECTS` to exclude specific slugs from the resume output at generation time — the project continues to sync and its OB1 thoughts continue to flow into employment bullet context.
+
+```bash
+# .env.local
+HIDE_FROM_PROJECTS=artisan-roast-platform
+
+# comma-separate to hide multiple
+HIDE_FROM_PROJECTS=artisan-roast-platform,internal-tool
+```
+
+The filter runs server-side before the LLM prompt is built. OB1 thoughts from hidden projects are unaffected and continue to be injected as employment context via semantic search.
+
+> **Breaking change (v0.3.0):** `SYNC_REPOS` has been removed. The sync script now derives repos directly from `profile.projects[].repo`. Remove `SYNC_REPOS` from your `.env.local` and Railway env vars — it is no longer read.
+
+---
+
 ## Setup
 
 1. Clone this repo

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ See [`docs/workflow.md`](docs/workflow.md) for a walkthrough of how employer AI 
 # .env.local
 HIDE_FROM_PROJECTS=artisan-roast-platform
 
-# comma-separate to hide multiple
+# comma-separated to hide multiple
 HIDE_FROM_PROJECTS=artisan-roast-platform,internal-tool
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.2.26",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.2.26",
+      "version": "0.3.0",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.2.26",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -12,14 +12,15 @@
  *
  * Also rebuilds the CANDIDATE_STACK thought from the updated profile.
  *
+ * Repos to sync are derived from profile.projects — any project with a GitHub
+ * repo URL is synced automatically. No env var needed; add a project to the
+ * profile and the next sync picks it up.
+ *
  * Usage:   npm run sync
  * Env:     GITHUB_TOKEN         optional but recommended (higher rate limit)
  *          SUPA_PROJECT_URL     required
  *          SUPA_SERVICE_ROLE    required
  *          OPENROUTER_API_KEY   required
- *          SYNC_REPOS           required — comma-separated owner/repo pairs
- *                               e.g. myuser/my-repo,myorg/other-repo
- *                               slug is derived from the repo name
  */
 
 import { createHash } from 'node:crypto'
@@ -31,18 +32,12 @@ const SUPA_URL = process.env.SUPA_PROJECT_URL
 const SUPA_KEY = process.env.SUPA_SERVICE_ROLE
 const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN
-const SYNC_REPOS_RAW = process.env.SYNC_REPOS
-
 if (!SUPA_URL || !SUPA_KEY) {
   console.error('Missing SUPA_PROJECT_URL or SUPA_SERVICE_ROLE')
   process.exit(1)
 }
 if (!OPENROUTER_API_KEY) {
   console.error('Missing OPENROUTER_API_KEY')
-  process.exit(1)
-}
-if (!SYNC_REPOS_RAW) {
-  console.error('Missing SYNC_REPOS — set to comma-separated owner/repo pairs, e.g. myuser/my-repo,myorg/other-repo')
   process.exit(1)
 }
 
@@ -56,18 +51,18 @@ const MODEL = 'google/gemini-3-flash-preview'
 // Default singleton profile row ID (UUID with trailing 1)
 const PROFILE_ID = ['00000000', '0000', '0000', '0000', '000000000001'].join('-')
 
-// Repos to sync — parsed from SYNC_REPOS env var (owner/repo pairs, comma-separated).
-// Slug is derived from the repo name. Slug must match a project slug in public_profile.projects.
-const REPOS = SYNC_REPOS_RAW!.split(',').map(entry => {
-  const trimmed = entry.trim()
-  const match = /^([^/]+)\/([^/]+)$/.exec(trimmed)
-  if (!match) {
-    console.error(`Invalid SYNC_REPOS entry "${trimmed}" — expected owner/repo format`)
-    process.exit(1)
+function reposFromProfile(projects: ProjectEntry[]): Array<{ slug: string; owner: string; repo: string }> {
+  const results = []
+  for (const p of projects) {
+    const repoUrl = typeof p.repo === 'string' ? p.repo : null
+    if (!repoUrl) continue
+    const match = /github\.com\/([^/]+)\/([^/]+?)(?:\.git)?$/.exec(repoUrl)
+    if (!match) continue
+    const [, owner, repo] = match
+    results.push({ slug: p.slug, owner, repo })
   }
-  const [, owner, repo] = match
-  return { slug: repo, owner, repo }
-})
+  return results
+}
 
 // ── GitHub ────────────────────────────────────────────────
 
@@ -680,6 +675,12 @@ async function sync(): Promise<void> {
 
   let projects = profile.projects
   const allNewThoughts: ExtractedFact[] = []
+  const REPOS = reposFromProfile(projects)
+
+  if (REPOS.length === 0) {
+    console.warn('No GitHub repos found in profile.projects — nothing to sync.')
+    return
+  }
 
   for (const r of REPOS) {
     console.log(`Syncing ${r.slug}...`)

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -51,7 +51,9 @@ const MODEL = 'google/gemini-3-flash-preview'
 // Default singleton profile row ID (UUID with trailing 1)
 const PROFILE_ID = ['00000000', '0000', '0000', '0000', '000000000001'].join('-')
 
-function reposFromProfile(projects: ProjectEntry[]): Array<{ slug: string; owner: string; repo: string }> {
+type RepoToSync = { slug: string; owner: string; repo: string }
+
+function reposFromProfile(projects: ProjectEntry[]): RepoToSync[] {
   const results = []
   for (const p of projects) {
     const repoUrl = typeof p.repo === 'string' ? p.repo : null
@@ -532,7 +534,7 @@ interface SyncResult {
 }
 
 async function syncProject(
-  r: typeof REPOS[number],
+  r: RepoToSync,
   projects: ProfileRow['projects'],
 ): Promise<SyncResult> {
   const allNewThoughts: ExtractedFact[] = []
@@ -678,8 +680,7 @@ async function sync(): Promise<void> {
   const REPOS = reposFromProfile(projects)
 
   if (REPOS.length === 0) {
-    console.warn('No GitHub repos found in profile.projects — nothing to sync.')
-    return
+    console.warn('No GitHub repos found in profile.projects — skipping per-repo sync.')
   }
 
   for (const r of REPOS) {

--- a/src/routes/resume.ts
+++ b/src/routes/resume.ts
@@ -16,6 +16,16 @@ const HIDE_FROM_PROJECTS = new Set(
   (process.env.HIDE_FROM_PROJECTS ?? '').split(',').map(s => s.trim()).filter(Boolean)
 )
 
+export function filterVisibleProjects(projects: unknown, hidden: Set<string>): unknown {
+  if (!Array.isArray(projects) || hidden.size === 0) return projects
+  return (projects as unknown[]).filter(
+    (p): p is import('../types.js').Project =>
+      p !== null && typeof p === 'object' &&
+      typeof (p as { slug?: unknown }).slug === 'string' &&
+      !hidden.has((p as { slug: string }).slug)
+  )
+}
+
 const app = new Hono()
 
 const schema = z.object({
@@ -173,9 +183,7 @@ Respond with structured JSON:
 
       const visibleProfile = {
         ...profile,
-        projects: Array.isArray(profile.projects) && HIDE_FROM_PROJECTS.size > 0
-          ? (profile.projects as import('../types.js').Project[]).filter(p => !HIDE_FROM_PROJECTS.has(p.slug))
-          : profile.projects,
+        projects: filterVisibleProjects(profile.projects, HIDE_FROM_PROJECTS),
       }
 
       let userMessage = `Candidate profile:\n${JSON.stringify(visibleProfile, null, 2)}`

--- a/src/routes/resume.ts
+++ b/src/routes/resume.ts
@@ -12,6 +12,9 @@ import type { ResumeResponse } from '../types.js'
 
 const RESUME_MODEL = process.env.RESUME_MODEL ?? 'openai/gpt-4o-mini'
 const RESUME_MODEL_B = process.env.RESUME_MODEL_B ?? RESUME_MODEL
+const HIDE_FROM_PROJECTS = new Set(
+  (process.env.HIDE_FROM_PROJECTS ?? '').split(',').map(s => s.trim()).filter(Boolean)
+)
 
 const app = new Hono()
 
@@ -168,7 +171,14 @@ Respond with structured JSON:
     try {
       const relevantThoughts = await queryRelevantThoughts(job_description)
 
-      let userMessage = `Candidate profile:\n${JSON.stringify(profile, null, 2)}`
+      const visibleProfile = {
+        ...profile,
+        projects: Array.isArray(profile.projects) && HIDE_FROM_PROJECTS.size > 0
+          ? (profile.projects as import('../types.js').Project[]).filter(p => !HIDE_FROM_PROJECTS.has(p.slug))
+          : profile.projects,
+      }
+
+      let userMessage = `Candidate profile:\n${JSON.stringify(visibleProfile, null, 2)}`
 
       if (relevantThoughts.length) {
         userMessage += `\n\nAdditional context from candidate's shipped work (each entry is attributed — use the project and date to place it correctly in the resume):\n${relevantThoughts.map((t, i) => `${i + 1}. ${t}`).join('\n')}`

--- a/tests/inject-project-urls.test.ts
+++ b/tests/inject-project-urls.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { injectProjectUrls } from '../src/routes/resume.js'
+import { injectProjectUrls, filterVisibleProjects } from '../src/routes/resume.js'
 import type { Project } from '../src/types.js'
 
 const base = (slug: string, overrides: Partial<Project> = {}): Project => ({
@@ -84,5 +84,45 @@ describe('injectProjectUrls', () => {
     assert.doesNotThrow(() => injectProjectUrls(gen, profile))
     const result = injectProjectUrls(gen, profile)
     assert.equal(result[0].url, 'https://canonical.com')
+  })
+})
+
+describe('filterVisibleProjects', () => {
+  it('returns input unchanged when hidden set is empty', () => {
+    const projects = [base('a'), base('b')]
+    assert.deepEqual(filterVisibleProjects(projects, new Set()), projects)
+  })
+
+  it('returns input unchanged when projects is not an array', () => {
+    assert.equal(filterVisibleProjects(null, new Set(['a'])), null)
+    assert.equal(filterVisibleProjects('bad', new Set(['a'])), 'bad')
+  })
+
+  it('removes projects whose slug is in the hidden set', () => {
+    const projects = [base('a'), base('b'), base('c')]
+    const result = filterVisibleProjects(projects, new Set(['b'])) as Project[]
+    assert.equal(result.length, 2)
+    assert.ok(result.every(p => p.slug !== 'b'))
+  })
+
+  it('keeps all projects when no slug matches hidden set', () => {
+    const projects = [base('a'), base('b')]
+    const result = filterVisibleProjects(projects, new Set(['z'])) as Project[]
+    assert.equal(result.length, 2)
+  })
+
+  it('skips null entries in JSONB without throwing', () => {
+    const projects = [null, base('a'), undefined, base('b')]
+    assert.doesNotThrow(() => filterVisibleProjects(projects, new Set(['a'])))
+    const result = filterVisibleProjects(projects, new Set(['a'])) as Project[]
+    assert.equal(result.length, 1)
+    assert.equal(result[0].slug, 'b')
+  })
+
+  it('removes multiple hidden slugs at once', () => {
+    const projects = [base('a'), base('b'), base('c')]
+    const result = filterVisibleProjects(projects, new Set(['a', 'c'])) as Project[]
+    assert.equal(result.length, 1)
+    assert.equal(result[0].slug, 'b')
   })
 })


### PR DESCRIPTION
## Summary
- **Breaking (v0.3.0):** removes `SYNC_REPOS` env var — sync now derives `owner/repo` from each project's `repo` URL in `profile.projects`; adding a project to the profile automatically includes it in the next sync
- Adds `HIDE_FROM_PROJECTS` env var (comma-separated slugs) to exclude specific projects from the resume Projects section at generation time without stopping their OB1 sync or thought injection
- Documents both in a new "Project sync" README section with usage examples and the breaking change callout

## Test plan
- [ ] `npm run sync` runs without `SYNC_REPOS` set and syncs all projects with a GitHub `repo` URL
- [ ] Project with no `repo` URL is skipped silently
- [ ] `HIDE_FROM_PROJECTS=artisan-roast-platform` — platform excluded from generated resume Projects section
- [ ] OB1 thoughts from hidden project still appear as employment context in resume generation
- [ ] `npx tsc --noEmit` passes