### PR TITLE
feat(ci): add nightly GitHub Actions sync workflow with workflow_dispatch

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,27 @@
+name: Nightly project sync
+
+on:
+  schedule:
+    - cron: '0 2 * * *'  # 2am UTC daily — edit to change cadence
+  workflow_dispatch:       # manual run from GitHub UI or `gh workflow run sync.yml`
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Sync projects to OB1
+        env:
+          SUPA_PROJECT_URL: ${{ secrets.SUPA_PROJECT_URL }}
+          SUPA_SERVICE_ROLE: ${{ secrets.SUPA_SERVICE_ROLE }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run sync

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -5,9 +5,15 @@ on:
     - cron: '0 2 * * *'  # 2am UTC daily — edit to change cadence
   workflow_dispatch:       # manual run from GitHub UI or `gh workflow run sync.yml`
 
+concurrency:
+  group: sync
+  cancel-in-progress: true
+
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -24,4 +30,4 @@ jobs:
           SUPA_SERVICE_ROLE: ${{ secrets.SUPA_SERVICE_ROLE }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm run sync
+        run: npx tsx scripts/sync.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-05-02 — feat(ci): add nightly GitHub Actions sync workflow — replaces OS-specific task schedulers with a cross-platform cron that runs npm run sync on a configurable schedule (default 2am UTC daily); supports on-demand runs via workflow_dispatch from the GitHub UI or gh workflow run; GITHUB_TOKEN is automatic, only three secrets required (SUPA_PROJECT_URL, SUPA_SERVICE_ROLE, OPENROUTER_API_KEY); documents setup steps and cron examples in README
+
 - 2026-05-02 — feat(sync): derive repos from profile.projects and add HIDE_FROM_PROJECTS filter — eliminates SYNC_REPOS env var (breaking); sync script now reads GitHub owner/repo from each project's repo URL so adding a project to the profile automatically includes it in the next sync; HIDE_FROM_PROJECTS env var (comma-separated slugs) filters projects from the resume output at generation time while keeping OB1 thoughts in play for employment context injection; documents both in a new "Project sync" README section
 
 - 2026-05-02 — fix(resume): guarantee project url/repo in resume output — server-side injection matches generated projects to profile by slug and backfills url and repo fields that LLMs consistently omit; eliminates missing project links in DOCX regardless of model output

--- a/README.md
+++ b/README.md
@@ -383,6 +383,33 @@ The filter runs server-side before the LLM prompt is built. OB1 thoughts from hi
 
 > **Breaking change (v0.3.0):** `SYNC_REPOS` has been removed. The sync script now derives repos directly from `profile.projects[].repo`. Remove `SYNC_REPOS` from your `.env.local` and Railway env vars — it is no longer read.
 
+### Automated sync via GitHub Actions
+
+The included `.github/workflows/sync.yml` runs `npm run sync` on a nightly schedule so your profile stays current without any manual intervention. It also supports on-demand runs from the GitHub UI or CLI — no local setup or OS-specific scheduler needed.
+
+**To enable:**
+
+1. Add these secrets to your GitHub repository (**Settings → Secrets and variables → Actions**):
+
+   | Secret | Value |
+   |---|---|
+   | `SUPA_PROJECT_URL` | Your Supabase project URL |
+   | `SUPA_SERVICE_ROLE` | Your Supabase service role key |
+   | `OPENROUTER_API_KEY` | Your OpenRouter API key |
+
+   > `GITHUB_TOKEN` is provided automatically by GitHub Actions — no setup needed.
+
+2. The workflow runs at **2am UTC daily**. To change the cadence, edit the `cron` expression in `.github/workflows/sync.yml`:
+
+   ```yaml
+   - cron: '0 2 * * *'   # daily at 2am UTC
+   - cron: '0 2 * * 1'   # weekly on Monday
+   - cron: '0 */6 * * *' # every 6 hours
+   ```
+
+3. To trigger an immediate sync from anywhere: **GitHub → Actions → Nightly project sync → Run workflow**.
+   From the CLI: `gh workflow run sync.yml`
+
 ---
 
 ## Setup

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/sync.yml` — runs `npm run sync` on a nightly cron (2am UTC, configurable) and on `workflow_dispatch` for immediate on-demand runs
- Replaces OS-specific schedulers (Windows Task Scheduler, launchd, cron) with a cross-platform trigger that works for any contributor from the GitHub UI or CLI
- `GITHUB_TOKEN` is provided automatically; only three secrets required: `SUPA_PROJECT_URL`, `SUPA_SERVICE_ROLE`, `OPENROUTER_API_KEY`
- Documents setup steps and cron examples in a new README subsection under "Project sync"

## Test plan
- [ ] Workflow appears under Actions tab
- [ ] `gh workflow run sync.yml` triggers a successful run
- [ ] Nightly schedule fires at 2am UTC
- [ ] Missing secrets cause the run to fail with a clear error (not a silent no-op)