### PR TITLE
fix(resume): make injectProjectUrls reliable with slug requirement + name-normalized fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-05-02 — fix(resume): make injectProjectUrls reliable with slug requirement + name-normalized fallback — system prompt now explicitly requires `slug` verbatim from profile in project entries; `injectProjectUrls` falls back to normalized-name match when slug is absent, eliminating the no-op injection that caused missing project links
+
 - 2026-05-02 — feat(ci): add nightly GitHub Actions sync workflow — replaces OS-specific task schedulers with a cross-platform cron that runs npm run sync on a configurable schedule (default 2am UTC daily); supports on-demand runs via workflow_dispatch from the GitHub UI or gh workflow run; GITHUB_TOKEN is automatic, only three secrets required (SUPA_PROJECT_URL, SUPA_SERVICE_ROLE, OPENROUTER_API_KEY); documents setup steps and cron examples in README
 
 - 2026-05-02 — feat(sync): derive repos from profile.projects and add HIDE_FROM_PROJECTS filter — eliminates SYNC_REPOS env var (breaking); sync script now reads GitHub owner/repo from each project's repo URL so adding a project to the profile automatically includes it in the next sync; HIDE_FROM_PROJECTS env var (comma-separated slugs) filters projects from the resume output at generation time while keeping OB1 thoughts in play for employment context injection; documents both in a new "Project sync" README section

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/routes/resume.ts
+++ b/src/routes/resume.ts
@@ -63,10 +63,15 @@ export function injectProjectUrls(
       p !== null && typeof p === 'object' && typeof (p as ProfileProject).slug === 'string'
   )
   const bySlug = new Map(valid.map(p => [p.slug, p]))
-  const byName = new Map(valid.filter(p => p.name).map(p => [normalizeName(p.name!), p]))
+  const byName = new Map(
+    valid
+      .filter(p => typeof p.name === 'string' && p.name.trim().length > 0)
+      .map(p => [normalizeName(p.name!), p])
+  )
 
   return generated.map(p => {
-    const src = bySlug.get(p.slug) ?? byName.get(normalizeName(p.name ?? ''))
+    const nameKey = typeof p.name === 'string' && p.name.trim() ? normalizeName(p.name) : undefined
+    const src = bySlug.get(p.slug) ?? (nameKey ? byName.get(nameKey) : undefined)
     if (!src) return p
     return { ...p, url: src.url || undefined, repo: src.repo || undefined }
   })

--- a/src/routes/resume.ts
+++ b/src/routes/resume.ts
@@ -46,7 +46,10 @@ app.use('/', async (c, next) => {
   await next()
 })
 
-type ProfileProject = { slug: string; url?: string | null; repo?: string | null }
+type ProfileProject = { slug: string; name?: string; url?: string | null; repo?: string | null }
+
+const normalizeName = (s: string) =>
+  s.toLowerCase().replace(/[^\w\s]/g, ' ').replace(/\s+/g, ' ').trim()
 
 export function injectProjectUrls(
   generated: import('../types.js').Project[] | undefined,
@@ -55,15 +58,15 @@ export function injectProjectUrls(
   if (!generated?.length || !Array.isArray(profileProjects) || !profileProjects.length) {
     return generated ?? []
   }
-  const bySlug = new Map(
-    (profileProjects as unknown[])
-      .filter((p): p is ProfileProject =>
-        p !== null && typeof p === 'object' && typeof (p as ProfileProject).slug === 'string'
-      )
-      .map(p => [p.slug, p])
+  const valid = (profileProjects as unknown[]).filter(
+    (p): p is ProfileProject =>
+      p !== null && typeof p === 'object' && typeof (p as ProfileProject).slug === 'string'
   )
+  const bySlug = new Map(valid.map(p => [p.slug, p]))
+  const byName = new Map(valid.filter(p => p.name).map(p => [normalizeName(p.name!), p]))
+
   return generated.map(p => {
-    const src = bySlug.get(p.slug)
+    const src = bySlug.get(p.slug) ?? byName.get(normalizeName(p.name ?? ''))
     if (!src) return p
     return { ...p, url: src.url || undefined, repo: src.repo || undefined }
   })
@@ -155,7 +158,7 @@ Respond with structured JSON:
   "skills": [...],
   "employment": [...],
   "education": [...],
-  "projects": [...]
+  "projects": [{ "slug": "<from profile, verbatim>", "name": "...", "highlights": [...], ... }]
 }`
 
   // ── SSE stream — sends first bytes immediately so Railway's proxy never times out ──

--- a/tests/inject-project-urls.test.ts
+++ b/tests/inject-project-urls.test.ts
@@ -85,6 +85,29 @@ describe('injectProjectUrls', () => {
     const result = injectProjectUrls(gen, profile)
     assert.equal(result[0].url, 'https://canonical.com')
   })
+
+  it('falls back to name match when generated slug does not match profile', () => {
+    const gen = [base('wrong-slug', { name: 'Artisan Roast' })]
+    const profile = [{ slug: 'artisan-roast', name: 'Artisan Roast', url: 'https://artisanroast.com', repo: 'https://github.com/u/ar' }]
+    const result = injectProjectUrls(gen, profile)
+    assert.equal(result[0].url, 'https://artisanroast.com')
+    assert.equal(result[0].repo, 'https://github.com/u/ar')
+  })
+
+  it('name matching normalizes punctuation and whitespace', () => {
+    const gen = [base('wrong', { name: 'artisan-roast: the store' })]
+    const profile = [{ slug: 'artisan-roast', name: 'artisan roast  the store', url: 'https://artisanroast.com' }]
+    const result = injectProjectUrls(gen, profile)
+    assert.equal(result[0].url, 'https://artisanroast.com')
+  })
+
+  it('does not throw on non-string name in profile JSONB', () => {
+    const gen = [base('a')]
+    const profile = [{ slug: 'b', name: 123 }, { slug: 'a', url: 'https://canonical.com' }]
+    assert.doesNotThrow(() => injectProjectUrls(gen, profile))
+    const result = injectProjectUrls(gen, profile)
+    assert.equal(result[0].url, 'https://canonical.com')
+  })
 })
 
 describe('filterVisibleProjects', () => {


### PR DESCRIPTION
## Summary
- System prompt now explicitly requires `slug` verbatim from profile in the JSON spec for project entries: `"projects": [{ "slug": "<from profile, verbatim>", ... }]`
- `injectProjectUrls` adds a name-normalized fallback (`byName` map) — lowercases, strips punctuation, collapses whitespace — so URL injection succeeds when the LLM omits the slug field
- Eliminates the no-op injection that caused missing `url`/`repo` links in DOCX output

## Test plan
- [ ] Confirm existing `inject-project-urls` unit tests still pass (`npx tsx --test tests/inject-project-urls.test.ts`)
- [ ] Generate a resume against a real JD and verify project links appear in DOCX output
- [ ] Verify typecheck passes (`npx tsc --noEmit`)