### PR TITLE
docs: align README, ROADMAP, and plan docs with shipped public MCP stance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-05-11 — docs: align README, ROADMAP, and plan docs with the shipped public MCP stance — README now states three access tiers (public HTTP, public MCP, private MCP) instead of two; ROADMAP moves the `/public-mcp` + `ask_candidate` work from "In progress" to "Shipped" (v0.3.0, PR #66) and parks "In progress" with no active work pending live traffic observations; docs/README promotes the public-MCP plan to Shipped (reference) with a note that the plan stays as historical record; the plan doc itself is re-headered "Shipped" and points readers to the live behavior in workflow.md and the README connector section
+
 - 2026-05-02 — fix(resume): make injectProjectUrls reliable with slug requirement + name-normalized fallback — system prompt now explicitly requires `slug` verbatim from profile in project entries; `injectProjectUrls` falls back to normalized-name match when slug is absent, eliminating the no-op injection that caused missing project links
 
 - 2026-05-02 — feat(ci): add nightly GitHub Actions sync workflow — replaces OS-specific task schedulers with a cross-platform cron that runs npm run sync on a configurable schedule (default 2am UTC daily); supports on-demand runs via workflow_dispatch from the GitHub UI or gh workflow run; GITHUB_TOKEN is automatic, only three secrets required (SUPA_PROJECT_URL, SUPA_SERVICE_ROLE, OPENROUTER_API_KEY); documents setup steps and cron examples in README

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## [Unreleased]
 
-- 2026-05-11 — docs: align README, ROADMAP, and plan docs with the shipped public MCP stance — README now states three access tiers (public HTTP, public MCP, private MCP) instead of two; ROADMAP moves the `/public-mcp` + `ask_candidate` work from "In progress" to "Shipped" (v0.3.0, PR #66) and parks "In progress" with no active work pending live traffic observations; docs/README promotes the public-MCP plan to Shipped (reference) with a note that the plan stays as historical record; the plan doc itself is re-headered "Shipped" and points readers to the live behavior in workflow.md and the README connector section
+- 2026-05-11 — docs: align repo docs with the shipped public MCP stance
+  - README — three access tiers (public HTTP, public MCP, private MCP) instead of two
+  - ROADMAP — moves `/public-mcp` + `ask_candidate` from "In progress" to "Shipped" (v0.3.0, PR #66); "In progress" parked pending live traffic observations
+  - docs/README — promotes the public-MCP plan to Shipped (reference); the plan stays in `plans/` as historical record per CONTRIBUTING convention
+  - docs/plans/public-mcp-query-only.md — re-headered "Shipped" with pointers to live behavior in `workflow.md` and the README connector section
 
 - 2026-05-02 — fix(resume): make injectProjectUrls reliable with slug requirement + name-normalized fallback — system prompt now explicitly requires `slug` verbatim from profile in project entries; `injectProjectUrls` falls back to normalized-name match when slug is absent, eliminating the no-op injection that caused missing project links
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > Scan to load the live agent card — then paste it into any AI and start asking questions, or [open it directly](https://agent.yuens.me/.well-known/agent-card.json).
 
-A machine-queryable AI agent that represents a professional profile. No UI. Two access tiers: a public HTTP API for employer AI systems, and a private MCP server for personal interaction.
+A machine-queryable AI agent that represents a professional profile. No UI. Three access tiers: a public HTTP API for employer AI systems, a public MCP server (`ask_candidate` tool) that any MCP-aware AI client can add as a custom connector, and a private MCP server for personal interaction.
 
 Built on top of [OB1 (Open Brain)](https://github.com/NateBJones-Projects/OB1) by Nate B. Jones — OB1 handles the knowledge capture and storage layer; this project handles the public-facing agentic interface and job match methodology.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,7 +13,7 @@ A running log of what's shipped and what's in flight. See the [README](README.md
 | v0.2.14 | Stateless MCP transport — session map removed, mid-conversation drops eliminated | [#62](https://github.com/yuens1002/resume-agent/pull/62) |
 | v0.2.15 | System prompt refactor — drop length + employment-trim rules | [#63](https://github.com/yuens1002/resume-agent/pull/63) |
 | v0.2.16 | Retire Supabase Edge Function artifacts, clarify Railway as runtime tier | [#65](https://github.com/yuens1002/resume-agent/pull/65) |
-| v0.3.0  | Public MCP endpoint with `ask_candidate` tool — single unauthenticated MCP tool wrapping `/query`, advertised first in agent card `supportedInterfaces`, every call logged to `observed_queries` | [#66](https://github.com/yuens1002/resume-agent/pull/66) |
+| v0.3.0 | Public MCP endpoint with `ask_candidate` tool — single unauthenticated MCP tool wrapping `/query`, advertised first in agent card `supportedInterfaces`, every call logged to `observed_queries` | [#66](https://github.com/yuens1002/resume-agent/pull/66) |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,16 +13,13 @@ A running log of what's shipped and what's in flight. See the [README](README.md
 | v0.2.14 | Stateless MCP transport — session map removed, mid-conversation drops eliminated | [#62](https://github.com/yuens1002/resume-agent/pull/62) |
 | v0.2.15 | System prompt refactor — drop length + employment-trim rules | [#63](https://github.com/yuens1002/resume-agent/pull/63) |
 | v0.2.16 | Retire Supabase Edge Function artifacts, clarify Railway as runtime tier | [#65](https://github.com/yuens1002/resume-agent/pull/65) |
+| v0.3.0  | Public MCP endpoint with `ask_candidate` tool — single unauthenticated MCP tool wrapping `/query`, advertised first in agent card `supportedInterfaces`, every call logged to `observed_queries` | [#66](https://github.com/yuens1002/resume-agent/pull/66) |
 
 ---
 
 ## In progress
 
-### Public MCP endpoint with `ask_candidate` tool
-
-**Branch:** `feat/public-mcp-query` · **Plan:** [docs/plans/public-mcp-query-only.md](docs/plans/public-mcp-query-only.md)
-
-Adds `/public-mcp` route exposing a single MCP tool — `ask_candidate` — wrapping the existing `/query` handler. Advertised in the agent card's `supportedInterfaces` for A2A-aware client discovery. Unauthenticated, rate-limited per IP, and logs every call (plus HTTP `/query` traffic) to a new `observed_queries` table.
+_None right now — public MCP shipped; awaiting live traffic before the next step._
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,9 +16,9 @@ See [ROADMAP.md](../ROADMAP.md) for what's shipped and what's in progress.
 - [mcp-architecture.md](mcp-architecture.md) — MCP transport architecture (stateless Streamable HTTP, auth, Railway runtime)
 - [resume-pipeline-v2.md](resume-pipeline-v2.md) — `/resume` endpoint's dual-gen + rubric scorer pipeline
 - [workflow.md](workflow.md) — how employer AI, recruiters, and the candidate each interact with the agent
+- [plans/public-mcp-query-only.md](plans/public-mcp-query-only.md) — public `/public-mcp` endpoint with `ask_candidate` tool (shipped — historical record of the design decision)
 - [plans/private-mcp-summarize-observed-queries.md](plans/private-mcp-summarize-observed-queries.md) — private MCP `summarize_observed_queries` tool for public query traffic analytics
 
-### In progress (plans)
+### Exploring (plans)
 
-- [plans/public-mcp-query-only.md](plans/public-mcp-query-only.md) — public `/public-mcp` endpoint with `ask_candidate` tool
-- [plans/a2a-trust-layer.md](plans/a2a-trust-layer.md) — exploring: signed agent cards, invocation receipts, `/verify` endpoint
+- [plans/a2a-trust-layer.md](plans/a2a-trust-layer.md) — signed agent cards, invocation receipts, `/verify` endpoint

--- a/docs/plans/public-mcp-query-only.md
+++ b/docs/plans/public-mcp-query-only.md
@@ -1,7 +1,7 @@
 # Plan: Public MCP — `ask_candidate` Tool
 
-**Branch:** `feat/public-mcp-query`
-**Status:** Planning complete — ready to implement
+**Branch:** `feat/public-mcp-query` (merged)
+**Status:** Shipped in [PR #66](https://github.com/yuens1002/resume-agent/pull/66) — this doc remains as the historical record of the design. Live behavior is documented in [`docs/workflow.md`](../workflow.md) and the [README](../../README.md#add-as-a-custom-connector-in-claude).
 **Scope:** Public MCP endpoint exposing a single tool, `ask_candidate`, for AI clients to ask natural-language questions about the candidate's profile. Includes streaming support and persistent call logging.
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.0",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.0",
+      "version": "0.4.2",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- README: \"Two access tiers\" → \"Three access tiers\" so the public MCP server (`ask_candidate`) is on equal footing with the public HTTP API and private MCP.
- ROADMAP: move the `/public-mcp` + `ask_candidate` work from \"In progress\" to \"Shipped\" (v0.3.0, PR #66) and park the in-progress section pending live traffic observations.
- docs/README: promote `plans/public-mcp-query-only.md` to the Shipped (reference) list, leaving the plan in `plans/` per the historical-record convention; remaining plans now sit under an \"Exploring\" header.
- docs/plans/public-mcp-query-only.md: re-header from \"Planning complete\" to \"Shipped (PR #66)\" with pointers to the live behavior in `workflow.md` and the README connector section.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Grep for \"Two access tiers\", \"in progress\" claims about public MCP — no remaining stale references
- [ ] Visual scan of rendered README + ROADMAP on the PR