### PR TITLE
fix(routes): serve /.well-known/agent-card as 200 JSON instead of 301 redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-05-29 — fix(routes): serve /.well-known/agent-card as 200 JSON instead of 301 redirect — eliminates Google Safe Browsing false positive
+
 - 2026-05-14 — feat(mcp): add `update_thought` + `delete_thought` to the private MCP — closes the CRUD loop on captured thoughts; previously the private MCP could capture, search, list, and aggregate, but had no way to edit a typo or remove a thought without dropping into SQL
   - `update_thought` takes an `id` plus optional `content` and/or `private`. When `content` changes, the embedding and metadata are regenerated so semantic search stays consistent with the new text. `source` and `private` are preserved from the existing row unless `private` is explicitly overridden — `undefined` means "leave unchanged", not "make public"
   - `delete_thought` takes an `id` and removes the row permanently (no soft-delete)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.19",
+      "version": "0.4.20",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "seed": "tsx --env-file=.env.local scripts/seed.ts",
     "db:link": "supabase link --project-ref $SUPABASE_PROJECT_REF",
     "db:push": "supabase db push",
-    "test:unit": "tsx --test tests/resume-framing.test.ts tests/score-resume.test.ts tests/strip-banned.test.ts tests/sync-enrichment.test.ts tests/summarize-observed-queries.test.ts tests/inject-project-urls.test.ts tests/oep-domain.test.ts tests/thoughts-grounded-query.test.ts tests/thought-metadata.test.ts tests/query-prompt.test.ts tests/eval-query-answer.test.ts",
+    "test:unit": "tsx --test tests/resume-framing.test.ts tests/score-resume.test.ts tests/strip-banned.test.ts tests/sync-enrichment.test.ts tests/summarize-observed-queries.test.ts tests/inject-project-urls.test.ts tests/oep-domain.test.ts tests/thoughts-grounded-query.test.ts tests/thought-metadata.test.ts tests/query-prompt.test.ts tests/eval-query-answer.test.ts tests/agent-card-routing.test.ts",
     "test:rubric": "tsx --test tests/score-resume.test.ts",
     "test": "echo 'Run npm run test:unit for unit tests, npm run test:integration for live integration tests.'",
     "test:integration": "tsx --env-file=.env.local --test tests/pipeline.test.ts tests/update-profile.test.ts tests/projects-and-scoring.test.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,8 +77,8 @@ app.route('/query', queryRoute)
 app.route('/match', matchRoute)
 app.route('/resume', resumeRoute)
 app.route('/.well-known/agent-card.json', agentCardRoute)
+app.route('/.well-known/agent-card', agentCardRoute)
 app.get('/.well-known/agent.json', (c) => c.redirect('/.well-known/agent-card.json', 301))
-app.get('/.well-known/agent-card', (c) => c.redirect('/.well-known/agent-card.json', 301))
 app.route('/.well-known/oep-public-key.json', oepRoute)
 app.get('/try', (c) => c.redirect('/query?question=Tell+me+about+yourself&stream=true', 302))
 
@@ -115,7 +115,7 @@ const port = parseInt(process.env.PORT ?? '3000')
 serve({ fetch: app.fetch, port }, () => {
   const authMode = process.env.AUTH_MODE ?? 'open'
   console.log(`resume-agent running on http://localhost:${port}`)
-  console.log('[routes] GET /, /info, /availability, /projects, /projects/:slug, /try, /.well-known/agent-card.json (agent.json → 301)')
+  console.log('[routes] GET /, /info, /availability, /projects, /projects/:slug, /try, /.well-known/agent-card.json, /.well-known/agent-card (agent.json → 301)')
   console.log(`[routes] POST /query, /match | POST /resume (auth: ${authMode}) | PATCH /profile (auth: key)`)
   console.log('[middleware] rate-limit: 30 req/min per IP (excludes OPTIONS)')
 })

--- a/tests/agent-card-routing.test.ts
+++ b/tests/agent-card-routing.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Routing contract tests — /.well-known/agent-card paths.
+ *
+ * Verifies that the extensionless URL returns 200 JSON (not a redirect),
+ * preventing regression back to the 301 pattern that triggered Google Safe
+ * Browsing's social-engineering classifier (issue #104).
+ *
+ * Run: npm run test:unit
+ */
+
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { serve } from '@hono/node-server'
+import { Hono } from 'hono'
+
+// Minimal stub handler that returns the same shape the real agentCardRoute would.
+// We test routing behaviour (status + redirect-or-not), not content.
+const stubHandler = new Hono()
+stubHandler.get('/', (c) => c.json({ stub: true }))
+
+function buildApp() {
+  const app = new Hono()
+  app.route('/.well-known/agent-card.json', stubHandler)
+  app.route('/.well-known/agent-card', stubHandler)
+  app.get('/.well-known/agent.json', (c) => c.redirect('/.well-known/agent-card.json', 301))
+  return app
+}
+
+describe('/.well-known/agent-card routing', () => {
+  let baseUrl: string
+  let server: ReturnType<typeof serve>
+
+  before(async () => {
+    const app = buildApp()
+    await new Promise<void>((resolve) => {
+      server = serve({ fetch: app.fetch, port: 0 }, (info) => {
+        baseUrl = `http://localhost:${info.port}`
+        resolve()
+      })
+    })
+  })
+
+  after(() => server.close())
+
+  it('AC-1: /.well-known/agent-card.json → 200', async () => {
+    const res = await fetch(`${baseUrl}/.well-known/agent-card.json`)
+    assert.equal(res.status, 200)
+    assert.match(res.headers.get('content-type') ?? '', /application\/json/)
+  })
+
+  it('AC-2: /.well-known/agent-card → 200 (not a redirect)', async () => {
+    const res = await fetch(`${baseUrl}/.well-known/agent-card`, { redirect: 'manual' })
+    assert.equal(res.status, 200, 'extensionless URL must not redirect')
+    assert.match(res.headers.get('content-type') ?? '', /application\/json/)
+  })
+
+  it('AC-3: /.well-known/agent.json → 301 to /.well-known/agent-card.json', async () => {
+    const res = await fetch(`${baseUrl}/.well-known/agent.json`, { redirect: 'manual' })
+    assert.equal(res.status, 301)
+    assert.ok(
+      res.headers.get('location')?.endsWith('/.well-known/agent-card.json'),
+      'agent.json must redirect to agent-card.json',
+    )
+  })
+})


### PR DESCRIPTION
**Version:** 0.4.19 → 0.4.20

## Summary
- Replaces the `301` redirect from `/.well-known/agent-card` → `/.well-known/agent-card.json` with a direct `200 OK` JSON response using the same `agentCardRoute` handler
- Eliminates the Google Safe Browsing false positive (Deceptive page / social engineering) that was triggered by the redirect pattern
- Canonical discovery URL remains `/.well-known/agent-card.json`; the extensionless path now also works without redirecting
- `/.well-known/agent.json` alias redirect (`301`) is kept — that URL was never flagged

Closes #104

## Test plan
- [ ] `GET /.well-known/agent-card.json` returns 200 with agent card JSON
- [ ] `GET /.well-known/agent-card` returns 200 with agent card JSON (no redirect)
- [ ] `GET /.well-known/agent.json` returns 301 → `/.well-known/agent-card.json`
- [ ] After deploy: submit Google Safe Browsing review via Search Console → Security Issues → Request Review