### PR TITLE
feat(routes): serve agent card at GET / and add GET /health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-05-29 — feat(routes): GET / serves agent card directly; add GET /health → {status: ok}
+
 - 2026-05-29 — fix(routes): serve /.well-known/agent-card as 200 JSON instead of 301 redirect — eliminates Google Safe Browsing false positive
 
 - 2026-05-14 — feat(mcp): add `update_thought` + `delete_thought` to the private MCP — closes the CRUD loop on captured thoughts; previously the private MCP could capture, search, list, and aggregate, but had no way to edit a typo or remove a thought without dropping into SQL

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.20",
+      "version": "0.4.21",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,8 +45,8 @@ const getClientIp = (c: Context): string => {
 }
 
 app.use('*', async (c, next) => {
-  // Skip OPTIONS preflights — don't count them toward the rate limit
-  if (c.req.method === 'OPTIONS') return next()
+  // Skip OPTIONS preflights and health checks — don't count toward the rate limit
+  if (c.req.method === 'OPTIONS' || c.req.path === '/health') return next()
 
   // Owner bypass — valid API_KEY skips rate limiting entirely
   const authHeader = c.req.header('Authorization') ?? ''
@@ -108,7 +108,10 @@ app.route('/mcp', mcpRoute)
 app.route('/public-mcp', publicMcpRoute)
 app.route('/', oauthRoute)
 
-app.get('/health', (c) => c.json({ status: 'ok' }))
+app.get('/health', (c) => {
+  c.header('Cache-Control', 'no-store')
+  return c.json({ status: 'ok' })
+})
 app.route('/', agentCardRoute)
 
 const port = parseInt(process.env.PORT ?? '3000')
@@ -116,7 +119,7 @@ const port = parseInt(process.env.PORT ?? '3000')
 serve({ fetch: app.fetch, port }, () => {
   const authMode = process.env.AUTH_MODE ?? 'open'
   console.log(`resume-agent running on http://localhost:${port}`)
-  console.log('[routes] GET /, /info, /availability, /projects, /projects/:slug, /try, /.well-known/agent-card.json, /.well-known/agent-card (agent.json → 301)')
+  console.log('[routes] GET /, /health, /info, /availability, /projects, /projects/:slug, /try, /.well-known/agent-card.json, /.well-known/agent-card (agent.json → 301)')
   console.log(`[routes] POST /query, /match | POST /resume (auth: ${authMode}) | PATCH /profile (auth: key)`)
-  console.log('[middleware] rate-limit: 30 req/min per IP (excludes OPTIONS)')
+  console.log('[middleware] rate-limit: 30 req/min per IP (excludes OPTIONS, /health)')
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,8 @@ app.route('/mcp', mcpRoute)
 app.route('/public-mcp', publicMcpRoute)
 app.route('/', oauthRoute)
 
-app.get('/', (c) => c.json({ status: 'ok', agent: 'resume-agent' }))
+app.get('/health', (c) => c.json({ status: 'ok' }))
+app.route('/', agentCardRoute)
 
 const port = parseInt(process.env.PORT ?? '3000')
 

--- a/tests/agent-card-routing.test.ts
+++ b/tests/agent-card-routing.test.ts
@@ -20,6 +20,10 @@ stubHandler.get('/', (c) => c.json({ stub: true }))
 
 function buildApp() {
   const app = new Hono()
+  app.get('/health', (c) => {
+    c.header('Cache-Control', 'no-store')
+    return c.json({ status: 'ok' })
+  })
   app.route('/', stubHandler)
   app.route('/.well-known/agent-card.json', stubHandler)
   app.route('/.well-known/agent-card', stubHandler)
@@ -43,25 +47,33 @@ describe('/.well-known/agent-card routing', () => {
 
   after(() => server.close())
 
-  it('AC-0: GET / → 200 JSON (root alias for agent card)', async () => {
+  it('AC-0: GET /health → 200 { status: ok }, Cache-Control: no-store', async () => {
+    const res = await fetch(`${baseUrl}/health`)
+    assert.equal(res.status, 200)
+    assert.equal(res.headers.get('cache-control'), 'no-store')
+    const body = await res.json() as Record<string, unknown>
+    assert.equal(body.status, 'ok')
+  })
+
+  it('AC-2: GET / → 200 JSON (root alias for agent card)', async () => {
     const res = await fetch(`${baseUrl}/`, { redirect: 'manual' })
     assert.equal(res.status, 200, 'root must not redirect')
     assert.match(res.headers.get('content-type') ?? '', /application\/json/)
   })
 
-  it('AC-1: /.well-known/agent-card.json → 200', async () => {
+  it('AC-3: /.well-known/agent-card.json → 200', async () => {
     const res = await fetch(`${baseUrl}/.well-known/agent-card.json`)
     assert.equal(res.status, 200)
     assert.match(res.headers.get('content-type') ?? '', /application\/json/)
   })
 
-  it('AC-2: /.well-known/agent-card → 200 (not a redirect)', async () => {
+  it('AC-4: /.well-known/agent-card → 200 (not a redirect)', async () => {
     const res = await fetch(`${baseUrl}/.well-known/agent-card`, { redirect: 'manual' })
     assert.equal(res.status, 200, 'extensionless URL must not redirect')
     assert.match(res.headers.get('content-type') ?? '', /application\/json/)
   })
 
-  it('AC-3: /.well-known/agent.json → 301 to /.well-known/agent-card.json', async () => {
+  it('AC-5: /.well-known/agent.json → 301 to /.well-known/agent-card.json', async () => {
     const res = await fetch(`${baseUrl}/.well-known/agent.json`, { redirect: 'manual' })
     assert.equal(res.status, 301)
     assert.ok(

--- a/tests/agent-card-routing.test.ts
+++ b/tests/agent-card-routing.test.ts
@@ -20,6 +20,7 @@ stubHandler.get('/', (c) => c.json({ stub: true }))
 
 function buildApp() {
   const app = new Hono()
+  app.route('/', stubHandler)
   app.route('/.well-known/agent-card.json', stubHandler)
   app.route('/.well-known/agent-card', stubHandler)
   app.get('/.well-known/agent.json', (c) => c.redirect('/.well-known/agent-card.json', 301))
@@ -41,6 +42,12 @@ describe('/.well-known/agent-card routing', () => {
   })
 
   after(() => server.close())
+
+  it('AC-0: GET / → 200 JSON (root alias for agent card)', async () => {
+    const res = await fetch(`${baseUrl}/`, { redirect: 'manual' })
+    assert.equal(res.status, 200, 'root must not redirect')
+    assert.match(res.headers.get('content-type') ?? '', /application\/json/)
+  })
 
   it('AC-1: /.well-known/agent-card.json → 200', async () => {
     const res = await fetch(`${baseUrl}/.well-known/agent-card.json`)


### PR DESCRIPTION
**Version:** 0.4.20 → 0.4.21

## Summary
- `GET /` now serves the agent card JSON directly (200 OK) — `agent.yuens.me` is a short alias for `agent.yuens.me/.well-known/agent-card.json`; no redirect, consistent with the Safe Browsing fix in #105
- `GET /health` returns `{ "status": "ok" }` — replaces the former root status ping at its conventional path
- Routing test gains AC-0 covering the root alias

## Test plan
- [ ] `GET /` returns 200 with agent card JSON (same body as `/.well-known/agent-card.json`)
- [ ] `GET /health` returns 200 `{ "status": "ok" }`
- [ ] `GET /.well-known/agent-card.json` still returns 200
- [ ] All 4 ACs in `tests/agent-card-routing.test.ts` pass (`npm run test:unit`)