### PR TITLE
feat(data): add Brew Guide project to portfolio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-05-29 — feat(data): add Brew Guide project to portfolio
+
 - 2026-05-29 — feat(routes): GET / serves agent card directly; add GET /health → {status: ok}
 
 - 2026-05-29 — fix(routes): serve /.well-known/agent-card as 200 JSON instead of 301 redirect — eliminates Google Safe Browsing false positive

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.21",
+      "version": "0.4.22",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "private": true,
   "type": "module",
   "engines": {

--- a/scripts/seed-profile.json
+++ b/scripts/seed-profile.json
@@ -180,6 +180,25 @@
       "status": "in-progress",
       "started": "2026-03",
       "repo": "https://github.com/yuens1002/resume-agent"
+    },
+    {
+      "name": "Brew Guide",
+      "slug": "brew-guide",
+      "description": "Community-powered MCP server that answers 'how should I brew this coffee?' — synthesizes consensus brew parameters from logged experiments with zero LLM dependency.",
+      "problem": "Brew parameter guides are anecdotal and inconsistent — different sources recommend wildly different temperatures, ratios, and grind sizes with no basis in collective data.",
+      "role": "Sole developer — designed and built the MCP server, recommendation engine, database schema, and all tooling end-to-end.",
+      "tech": ["TypeScript", "Hono", "Neon PostgreSQL", "Prisma", "MCP (@modelcontextprotocol/sdk)", "Vitest", "Railway", "Node.js"],
+      "highlights": [
+        "Built a deterministic recommendation engine — no LLM in the hot path; confidence tiers (high/medium/low) reflect actual community brew data volume, not model confidence",
+        "Implemented 5 MCP tools over a public Streamable HTTP endpoint (recommend, log_brew, search_brews, compare_brew, get_brewing_methods) — compatible with Claude Desktop, Claude.ai, Cursor, and any MCP client",
+        "56 Vitest tests with zero TypeScript errors; auto-deploys to Railway from main"
+      ],
+      "architecture": "Hono 4 HTTP server on Node.js 24 with MCP Streamable HTTP transport. Neon Postgres + Prisma for brew log persistence. Recommendation engine aggregates logged experiments into weighted consensus parameters per origin/roast/method — no AI in the hot path.",
+      "impact": "Public MCP endpoint at brew-guide-production.up.railway.app/mcp — usable by any MCP-capable tool. Submitted as an entry to the Hermes Agent Challenge 2026.",
+      "status": "active",
+      "started": "2026-05",
+      "url": "https://brew-guide-production.up.railway.app",
+      "repo": "https://github.com/yuens1002/brew-guide"
     }
   ],
   "availability": {


### PR DESCRIPTION
**Version:** 0.4.21 → 0.4.22

## Summary
- Adds Brew Guide to `scripts/seed-profile.json` and seeds it to Supabase (4 projects total)
- Community-powered MCP server (Hono + Neon Postgres + Prisma, Railway), Hermes Agent Challenge 2026 entry
- Fields: slug `brew-guide`, status `active`, started `2026-05`, 3 highlights, architecture, impact, live URL + repo

## Test plan
- [ ] `GET /projects` returns 4 projects including `brew-guide`
- [ ] `GET /projects/brew-guide` returns full detail with all fields
- [ ] Seed script confirms: `Projects: 4`