### PR TITLE
feat(routes): add /openapi.json for Custom GPT Actions and /qr for QR code PNG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-05-29 — feat(routes): add GET /openapi.json (Custom GPT Actions schema) and GET /qr (QR code PNG targeting QR_TARGET_URL)
+
 - 2026-05-29 — feat(data): add Brew Guide project to portfolio
 
 - 2026-05-29 — feat(routes): GET / serves agent card directly; add GET /health → {status: ok}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.22",
+      "version": "0.4.23",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",
@@ -17,11 +17,13 @@
         "dotenv": "^17.3.1",
         "hono": "^4.7.5",
         "jose": "^5.9.6",
+        "qrcode": "^1.5.4",
         "zod": "^3.24.2"
       },
       "devDependencies": {
         "@hono/node-server": "^1.13.7",
         "@types/node": "^22.13.13",
+        "@types/qrcode": "^1.5.6",
         "supabase": "^2.84.0",
         "tsx": "^4.19.3",
         "typescript": "^5.8.2"
@@ -762,6 +764,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -853,6 +865,30 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/bin-links": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-6.0.0.tgz",
@@ -932,6 +968,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -954,6 +999,17 @@
         "node": ">=18"
       }
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
     "node_modules/cmd-shim": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
@@ -963,6 +1019,24 @@
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
@@ -1062,6 +1136,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1085,6 +1168,12 @@
       "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
       "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "17.3.1",
@@ -1116,6 +1205,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -1363,6 +1458,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -1416,6 +1524,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1596,6 +1713,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -1650,6 +1776,18 @@
       },
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/math-intrinsics": {
@@ -1855,6 +1993,42 @@
         "wrappy": "1"
       }
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1862,6 +2036,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-key": {
@@ -1892,6 +2075,15 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/proc-log": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
@@ -1913,6 +2105,23 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/qs": {
@@ -1974,6 +2183,15 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -1982,6 +2200,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -2065,6 +2289,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -2185,6 +2415,32 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supabase": {
@@ -2370,6 +2626,26 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -2410,6 +2686,12 @@
         }
       }
     },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
@@ -2418,6 +2700,41 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "private": true,
   "type": "module",
   "engines": {
@@ -13,7 +13,7 @@
     "seed": "tsx --env-file=.env.local scripts/seed.ts",
     "db:link": "supabase link --project-ref $SUPABASE_PROJECT_REF",
     "db:push": "supabase db push",
-    "test:unit": "tsx --test tests/resume-framing.test.ts tests/score-resume.test.ts tests/strip-banned.test.ts tests/sync-enrichment.test.ts tests/summarize-observed-queries.test.ts tests/inject-project-urls.test.ts tests/oep-domain.test.ts tests/thoughts-grounded-query.test.ts tests/thought-metadata.test.ts tests/query-prompt.test.ts tests/eval-query-answer.test.ts tests/agent-card-routing.test.ts",
+    "test:unit": "tsx --test tests/resume-framing.test.ts tests/score-resume.test.ts tests/strip-banned.test.ts tests/sync-enrichment.test.ts tests/summarize-observed-queries.test.ts tests/inject-project-urls.test.ts tests/oep-domain.test.ts tests/thoughts-grounded-query.test.ts tests/thought-metadata.test.ts tests/query-prompt.test.ts tests/eval-query-answer.test.ts tests/agent-card-routing.test.ts tests/qr-openapi.test.ts",
     "test:rubric": "tsx --test tests/score-resume.test.ts",
     "test": "echo 'Run npm run test:unit for unit tests, npm run test:integration for live integration tests.'",
     "test:integration": "tsx --env-file=.env.local --test tests/pipeline.test.ts tests/update-profile.test.ts tests/projects-and-scoring.test.ts",
@@ -35,11 +35,13 @@
     "dotenv": "^17.3.1",
     "hono": "^4.7.5",
     "jose": "^5.9.6",
+    "qrcode": "^1.5.4",
     "zod": "^3.24.2"
   },
   "devDependencies": {
     "@hono/node-server": "^1.13.7",
     "@types/node": "^22.13.13",
+    "@types/qrcode": "^1.5.6",
     "supabase": "^2.84.0",
     "tsx": "^4.19.3",
     "typescript": "^5.8.2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import queryRoute from './routes/query.js'
 import matchRoute from './routes/match.js'
 import resumeRoute from './routes/resume.js'
 import agentCardRoute from './routes/agent-card.js'
+import openApiRoute from './routes/openapi.js'
+import qrRoute from './routes/qr.js'
 import profileRoute from './routes/profile.js'
 import projectsRoute from './routes/projects.js'
 import mcpRoute from './routes/mcp.js'
@@ -112,6 +114,8 @@ app.get('/health', (c) => {
   c.header('Cache-Control', 'no-store')
   return c.json({ status: 'ok' })
 })
+app.route('/openapi.json', openApiRoute)
+app.route('/qr', qrRoute)
 app.route('/', agentCardRoute)
 
 const port = parseInt(process.env.PORT ?? '3000')
@@ -119,7 +123,7 @@ const port = parseInt(process.env.PORT ?? '3000')
 serve({ fetch: app.fetch, port }, () => {
   const authMode = process.env.AUTH_MODE ?? 'open'
   console.log(`resume-agent running on http://localhost:${port}`)
-  console.log('[routes] GET /, /health, /info, /availability, /projects, /projects/:slug, /try, /.well-known/agent-card.json, /.well-known/agent-card (agent.json → 301)')
+  console.log('[routes] GET /, /health, /openapi.json, /qr, /info, /availability, /projects, /projects/:slug, /try, /.well-known/agent-card.json, /.well-known/agent-card (agent.json → 301)')
   console.log(`[routes] POST /query, /match | POST /resume (auth: ${authMode}) | PATCH /profile (auth: key)`)
   console.log('[middleware] rate-limit: 30 req/min per IP (excludes OPTIONS, /health)')
 })

--- a/src/routes/openapi.ts
+++ b/src/routes/openapi.ts
@@ -1,0 +1,195 @@
+import { Hono } from 'hono'
+
+const app = new Hono()
+
+app.get('/', (c) => {
+  const baseUrl = (process.env.PUBLIC_URL ?? new URL(c.req.url).origin).replace(/\/$/, '')
+
+  c.header('Cache-Control', 'public, max-age=3600')
+  return c.json({
+    openapi: '3.1.0',
+    info: {
+      title: 'Resume Agent API',
+      description: 'Query a candidate\'s professional profile. Use queryProfile for natural language questions, matchJob to score against a job description, and the GET endpoints for structured profile data.',
+      version: '1.0.0',
+    },
+    servers: [{ url: baseUrl }],
+    paths: {
+      '/query': {
+        post: {
+          operationId: 'queryProfile',
+          summary: 'Ask a question about the candidate',
+          description: 'Ask any natural language question about the candidate\'s skills, experience, projects, background, or behavioral tendencies. Use this for conversational questions like "What is your TypeScript experience?" or "How do you approach testing?"',
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['question'],
+                  properties: {
+                    question: {
+                      type: 'string',
+                      description: 'The question to ask about the candidate',
+                    },
+                    context: {
+                      type: 'string',
+                      description: 'Optional extra context (e.g. role being hired for)',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            '200': {
+              description: 'Answer grounded in the candidate\'s profile data',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      answer: { type: 'string' },
+                      confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+                      sources: { type: 'array', items: { type: 'string' } },
+                      follow_up_suggestions: { type: 'array', items: { type: 'string' } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      '/match': {
+        post: {
+          operationId: 'matchJob',
+          summary: 'Score the candidate against a job description',
+          description: 'Paste a job description to get a structured fit score. Returns a percentage score, matched skills, gaps, and a hiring recommendation. Use this when the user shares a role they\'re considering.',
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['job_description'],
+                  properties: {
+                    job_description: {
+                      type: 'string',
+                      description: 'The full job description text',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            '200': {
+              description: 'Fit score and breakdown',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      fit_score: { type: 'number', description: 'Overall fit percentage 0–100' },
+                      matched: { type: 'array', items: { type: 'string' }, description: 'Skills and experience that match' },
+                      gaps: { type: 'array', items: { type: 'string' }, description: 'Missing or weak areas' },
+                      verdict: { type: 'string' },
+                      recommended_action: { type: 'string', enum: ['apply', 'apply-with-tailoring', 'pass'] },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      '/info': {
+        get: {
+          operationId: 'getProfile',
+          summary: 'Get the full candidate profile',
+          description: 'Returns the complete structured profile including contact info, summary, all skills, full employment history, education, and all portfolio projects. Use when you need comprehensive profile data.',
+          responses: {
+            '200': {
+              description: 'Full public profile',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      contact: { type: 'object' },
+                      summary: { type: 'string' },
+                      skills: { type: 'array' },
+                      employment: { type: 'array' },
+                      education: { type: 'array' },
+                      projects: { type: 'array' },
+                      availability: { type: 'object' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      '/availability': {
+        get: {
+          operationId: 'getAvailability',
+          summary: 'Get current availability and preferred roles',
+          description: 'Returns whether the candidate is currently seeking work, their availability status, and preferred roles and locations. Use when asked "Are you open to work?" or "What roles are you looking for?"',
+          responses: {
+            '200': {
+              description: 'Availability status',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      seeking: { type: 'boolean' },
+                      status: { type: 'string', enum: ['open', 'actively-looking', 'not-looking'] },
+                      preferred_roles: { type: 'array', items: { type: 'string' } },
+                      remote: { type: 'boolean' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      '/projects': {
+        get: {
+          operationId: 'listProjects',
+          summary: 'List portfolio projects',
+          description: 'Returns a summary list of all portfolio projects with name, description, tech stack, and status. Use when asked about projects or portfolio work.',
+          responses: {
+            '200': {
+              description: 'Project list',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        name: { type: 'string' },
+                        slug: { type: 'string' },
+                        description: { type: 'string' },
+                        tech: { type: 'array', items: { type: 'string' } },
+                        status: { type: 'string' },
+                        url: { type: 'string' },
+                        repo: { type: 'string' },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+})
+
+export default app

--- a/src/routes/qr.ts
+++ b/src/routes/qr.ts
@@ -1,0 +1,25 @@
+import { Hono } from 'hono'
+import QRCode from 'qrcode'
+
+// QR_TARGET_URL — set to your Custom GPT URL (e.g. https://chatgpt.com/g/g-XXXXX) after creating the GPT.
+// Falls back to PUBLIC_URL then https://agent.yuens.me if unset.
+
+const app = new Hono()
+
+app.get('/', async (c) => {
+  const target = process.env.QR_TARGET_URL
+    ?? process.env.PUBLIC_URL
+    ?? 'https://agent.yuens.me'
+
+  const png = await QRCode.toBuffer(target, {
+    errorCorrectionLevel: 'M',
+    width: 300,
+    margin: 2,
+  })
+
+  c.header('Content-Type', 'image/png')
+  c.header('Cache-Control', 'public, max-age=3600')
+  return c.body(png)
+})
+
+export default app

--- a/src/routes/qr.ts
+++ b/src/routes/qr.ts
@@ -9,7 +9,7 @@ const app = new Hono()
 app.get('/', async (c) => {
   const target = process.env.QR_TARGET_URL
     ?? process.env.PUBLIC_URL
-    ?? 'https://agent.yuens.me'
+    ?? new URL(c.req.url).origin
 
   const png = await QRCode.toBuffer(target, {
     errorCorrectionLevel: 'M',

--- a/tests/qr-openapi.test.ts
+++ b/tests/qr-openapi.test.ts
@@ -4,7 +4,7 @@
  * Run: npm run test:unit
  */
 
-import { describe, it, before, after, beforeEach, afterEach } from 'node:test'
+import { describe, it, before, after } from 'node:test'
 import assert from 'node:assert/strict'
 import { serve } from '@hono/node-server'
 import { Hono } from 'hono'
@@ -86,14 +86,17 @@ describe('/openapi.json and /qr routes', () => {
       assert.equal(buf[3], 0x47) // G
     })
 
-    it('AC-6: uses QR_TARGET_URL env var when set', async () => {
+    it('AC-6: uses QR_TARGET_URL env var when set — PNG differs from fallback', async () => {
       const saved = process.env.QR_TARGET_URL
+      delete process.env.QR_TARGET_URL
+      const baseline = Buffer.from(await (await fetch(`${baseUrl}/qr`)).arrayBuffer())
+
       process.env.QR_TARGET_URL = 'https://chatgpt.com/g/g-TEST'
       try {
         const res = await fetch(`${baseUrl}/qr`)
         assert.equal(res.status, 200)
-        // We can't decode the QR in a unit test, but a 200 PNG response
-        // confirms the target URL was accepted and encoded without error
+        const withTarget = Buffer.from(await res.arrayBuffer())
+        assert.notDeepEqual(withTarget, baseline, 'QR PNG should differ when QR_TARGET_URL changes')
       } finally {
         if (saved === undefined) delete process.env.QR_TARGET_URL
         else process.env.QR_TARGET_URL = saved

--- a/tests/qr-openapi.test.ts
+++ b/tests/qr-openapi.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Routing contract tests — /openapi.json and /qr endpoints.
+ *
+ * Run: npm run test:unit
+ */
+
+import { describe, it, before, after, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { serve } from '@hono/node-server'
+import { Hono } from 'hono'
+import openApiRoute from '../src/routes/openapi.js'
+import qrRoute from '../src/routes/qr.js'
+
+function buildApp() {
+  const app = new Hono()
+  app.route('/openapi.json', openApiRoute)
+  app.route('/qr', qrRoute)
+  return app
+}
+
+describe('/openapi.json and /qr routes', () => {
+  let baseUrl: string
+  let server: ReturnType<typeof serve>
+
+  before(async () => {
+    const app = buildApp()
+    await new Promise<void>((resolve) => {
+      server = serve({ fetch: app.fetch, port: 0 }, (info) => {
+        baseUrl = `http://localhost:${info.port}`
+        resolve()
+      })
+    })
+  })
+
+  after(() => server.close())
+
+  describe('GET /openapi.json', () => {
+    it('AC-1: returns 200 with application/json', async () => {
+      const res = await fetch(`${baseUrl}/openapi.json`)
+      assert.equal(res.status, 200)
+      assert.match(res.headers.get('content-type') ?? '', /application\/json/)
+    })
+
+    it('AC-2: body has openapi 3.1.0 and exactly 5 paths', async () => {
+      const res = await fetch(`${baseUrl}/openapi.json`)
+      const body = await res.json() as Record<string, unknown>
+      assert.equal(body.openapi, '3.1.0')
+      const paths = Object.keys(body.paths as object)
+      assert.equal(paths.length, 5, `expected 5 paths, got ${paths.length}: ${paths.join(', ')}`)
+      assert.ok(paths.includes('/query'))
+      assert.ok(paths.includes('/match'))
+      assert.ok(paths.includes('/info'))
+      assert.ok(paths.includes('/availability'))
+      assert.ok(paths.includes('/projects'))
+    })
+
+    it('AC-3: servers[0].url uses PUBLIC_URL env var when set', async () => {
+      const saved = process.env.PUBLIC_URL
+      process.env.PUBLIC_URL = 'https://agent.example.com'
+      try {
+        const res = await fetch(`${baseUrl}/openapi.json`)
+        const body = await res.json() as { servers: Array<{ url: string }> }
+        assert.equal(body.servers[0].url, 'https://agent.example.com')
+      } finally {
+        if (saved === undefined) delete process.env.PUBLIC_URL
+        else process.env.PUBLIC_URL = saved
+      }
+    })
+  })
+
+  describe('GET /qr', () => {
+    it('AC-4: returns 200 with image/png', async () => {
+      const res = await fetch(`${baseUrl}/qr`)
+      assert.equal(res.status, 200)
+      assert.match(res.headers.get('content-type') ?? '', /image\/png/)
+    })
+
+    it('AC-5: response body is a non-empty PNG buffer', async () => {
+      const res = await fetch(`${baseUrl}/qr`)
+      const buf = Buffer.from(await res.arrayBuffer())
+      assert.ok(buf.length > 0, 'PNG buffer should not be empty')
+      // PNG magic bytes: 89 50 4E 47
+      assert.equal(buf[0], 0x89)
+      assert.equal(buf[1], 0x50) // P
+      assert.equal(buf[2], 0x4e) // N
+      assert.equal(buf[3], 0x47) // G
+    })
+
+    it('AC-6: uses QR_TARGET_URL env var when set', async () => {
+      const saved = process.env.QR_TARGET_URL
+      process.env.QR_TARGET_URL = 'https://chatgpt.com/g/g-TEST'
+      try {
+        const res = await fetch(`${baseUrl}/qr`)
+        assert.equal(res.status, 200)
+        // We can't decode the QR in a unit test, but a 200 PNG response
+        // confirms the target URL was accepted and encoded without error
+      } finally {
+        if (saved === undefined) delete process.env.QR_TARGET_URL
+        else process.env.QR_TARGET_URL = saved
+      }
+    })
+
+    it('AC-7: falls back gracefully when QR_TARGET_URL is unset', async () => {
+      const savedTarget = process.env.QR_TARGET_URL
+      const savedPublic = process.env.PUBLIC_URL
+      delete process.env.QR_TARGET_URL
+      delete process.env.PUBLIC_URL
+      try {
+        const res = await fetch(`${baseUrl}/qr`)
+        assert.equal(res.status, 200)
+        assert.match(res.headers.get('content-type') ?? '', /image\/png/)
+      } finally {
+        if (savedTarget !== undefined) process.env.QR_TARGET_URL = savedTarget
+        if (savedPublic !== undefined) process.env.PUBLIC_URL = savedPublic
+      }
+    })
+  })
+})


### PR DESCRIPTION
**Version:** 0.4.22 → 0.4.23

## Summary
- `GET /openapi.json` — serves an OpenAPI 3.1.0 schema describing the 5 public endpoints (`/query`, `/match`, `/info`, `/availability`, `/projects`). ChatGPT's GPT builder can import this URL directly to wire up Actions. `servers[0].url` is derived from `PUBLIC_URL` env var (fork-friendly — no hardcoded domain).
- `GET /qr` — returns a 300px QR code PNG. Target URL is `QR_TARGET_URL` env var (set to your Custom GPT URL after creating it), falling back to `PUBLIC_URL` then `https://agent.yuens.me`. Resume website can embed as a plain `<img>` tag.
- Adds `qrcode` runtime dependency
- 7 new unit tests (AC-1 through AC-7) in `tests/qr-openapi.test.ts`

## Setup (post-deploy)
1. Create the Custom GPT at chatgpt.com → Actions → import from `https://agent.yuens.me/openapi.json`
2. Publish GPT → get URL `https://chatgpt.com/g/g-XXXXX`
3. Set `QR_TARGET_URL=https://chatgpt.com/g/g-XXXXX` in deployment env
4. `GET /qr` now returns a QR pointing directly to the GPT

## Test plan
- [ ] `npm run test:unit` — all 7 ACs in `qr-openapi.test.ts` pass
- [ ] `GET /openapi.json` — paste URL into ChatGPT GPT builder → 5 operations imported cleanly
- [ ] `GET /qr` — returns a scannable PNG in browser / `<img>` tag
- [ ] With `QR_TARGET_URL` unset → QR falls back gracefully (200, valid PNG)