### PR TITLE
fix(qr): cast Buffer to Uint8Array for BodyInit compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-05-29 — fix(qr): cast Buffer to Uint8Array for BodyInit compatibility — fixes Railway build failure
+
 - 2026-05-29 — feat(routes): add GET /openapi.json (Custom GPT Actions schema) and GET /qr (QR code PNG targeting QR_TARGET_URL)
 
 - 2026-05-29 — feat(data): add Brew Guide project to portfolio

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.23",
+      "version": "0.4.24",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/routes/qr.ts
+++ b/src/routes/qr.ts
@@ -17,9 +17,12 @@ app.get('/', async (c) => {
     margin: 2,
   })
 
-  c.header('Content-Type', 'image/png')
-  c.header('Cache-Control', 'public, max-age=3600')
-  return c.body(png)
+  return new Response(new Uint8Array(png), {
+    headers: {
+      'Content-Type': 'image/png',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  })
 })
 
 export default app


### PR DESCRIPTION
**Version:** 0.4.23 → 0.4.24

## Summary
- Fixes Railway build failure: `Buffer<ArrayBufferLike>` is not assignable to `BodyInit` in TypeScript's lib
- `new Uint8Array(png)` wraps the buffer as a `BufferSource`, which is a valid `BodyInit` — no data copy, same bytes

## Test plan
- [ ] `tsc --noEmit` passes with no errors
- [ ] All 7 ACs in `tests/qr-openapi.test.ts` pass
- [ ] Railway deploy succeeds