### PR TITLE
docs(readme): fix stale content — QR badge, agent card version, missing routes, setup step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-05-29 — docs(readme): fix stale QR badge, agent card version, missing routes (/health, /openapi.json, /qr, GET /), and setup step 10
+
 - 2026-05-29 — feat(profile): add optional cover image URL to Project schema; populate 3 project covers from Supabase Storage
 
 - 2026-05-29 — fix(qr): cast Buffer to Uint8Array for BodyInit compatibility — fixes Railway build failure

--- a/README.md
+++ b/README.md
@@ -532,7 +532,7 @@ The included `.github/workflows/sync.yml` runs `npm run sync` on a nightly sched
 7. `npm run dev`
 8. Deploy to Railway (connect the repo — `railway.toml` handles build + start)
 9. Set env vars in Railway dashboard (see `.env.example` for the full list)
-10. Set `QR_TARGET_URL` in Railway to the URL you want the QR to point to (e.g. your resume website or a Custom GPT URL). `GET /your-domain/qr` generates the QR automatically — embed it anywhere as an `<img>` tag.
+10. Set `QR_TARGET_URL` in Railway to the URL you want the QR to point to (e.g. your resume website or a Custom GPT URL). `GET /qr` on your deployed domain generates the QR automatically — embed it anywhere as an `<img>` tag.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # resume-agent
 
-[![Agent QR Code](qr.png)](https://agent.yuens.me/.well-known/agent-card.json)
+[![Agent QR Code](https://agent.yuens.me/qr)](https://agent.yuens.me)
 
-> Scan to load the live agent card — then paste it into any AI and start asking questions, or [open it directly](https://agent.yuens.me/.well-known/agent-card.json).
+> Scan to open the agent — then paste it into any AI and start asking questions, or [open it directly](https://agent.yuens.me).
 
 A machine-queryable AI agent that represents a professional profile. No UI. Three access tiers: a public HTTP API for employer AI systems, a public MCP server (`ask_candidate` tool) that any MCP-aware AI client can add as a custom connector, and a private MCP server for personal interaction.
 
@@ -100,7 +100,7 @@ A2A v1.0-compliant agent card (canonical path per RFC 8615). `/.well-known/agent
 {
   "name": "<from Supabase public_profile.contact.name>",
   "description": "...",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "supportedInterfaces": [
     {
       "url": "<baseUrl>/public-mcp",
@@ -155,6 +155,21 @@ A2A v1.0-compliant agent card (canonical path per RFC 8615). `/.well-known/agent
 ```
 
 > **Note on `provider` field names:** The [official A2A proto spec](https://github.com/a2aproject/A2A/blob/main/specification/a2a.proto) uses `provider.name` and `provider.homepage`. The a2aregistry.org validator requires `provider.organization` and `provider.url` (both required). This card uses the registry's schema. See [Schema discrepancies](#schema-discrepancies) below.
+
+### `GET /`
+Serves the agent card JSON directly (alias for `/.well-known/agent-card.json`). `agent.yuens.me` is the short-form discovery URL.
+
+### `GET /health`
+Health check. Returns `{ "status": "ok" }` with `Cache-Control: no-store`. Exempt from rate limiting — safe to poll from uptime monitors.
+
+### `GET /openapi.json`
+OpenAPI 3.1.0 schema describing all five public endpoints (`/query`, `/match`, `/info`, `/availability`, `/projects`). Import this URL directly into ChatGPT's GPT builder (Actions → import from URL), Gemini Gems, or any platform that accepts OpenAPI for tool wiring. The `servers[0].url` is derived from the `PUBLIC_URL` env var — set it to your deployed domain.
+
+### `GET /qr`
+Returns a 300px QR code PNG. Target URL is controlled by the `QR_TARGET_URL` env var (e.g. a Custom GPT URL or your resume website). Falls back to `PUBLIC_URL` then the request origin if unset. Embed in any web page as a plain `<img>` tag:
+```html
+<img src="https://agent.yuens.me/qr" alt="Scan to chat" />
+```
 
 ### `GET /info`
 Full structured profile snapshot. Skills, experience, projects, education. No Claude call — raw data from `public_profile`. Fast, cacheable, suitable for ATS systems that want facts without NL processing.
@@ -517,7 +532,7 @@ The included `.github/workflows/sync.yml` runs `npm run sync` on a nightly sched
 7. `npm run dev`
 8. Deploy to Railway (connect the repo — `railway.toml` handles build + start)
 9. Set env vars in Railway dashboard (see `.env.example` for the full list)
-10. Generate a QR code pointing to `https://your-domain/.well-known/agent-card.json`
+10. Set `QR_TARGET_URL` in Railway to the URL you want the QR to point to (e.g. your resume website or a Custom GPT URL). `GET /your-domain/qr` generates the QR automatically — embed it anywhere as an `<img>` tag.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.25",
+      "version": "0.4.26",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
**Version:** 0.4.25 → 0.4.26

## Summary
Four accuracy fixes identified by README audit:

1. **QR badge** — was `qr.png` (static file); now `https://agent.yuens.me/qr` (dynamic endpoint). Badge link updated to `agent.yuens.me` since `GET /` now serves the agent card directly.
2. **Agent card version** — README sample showed `"version": "1.1.0"`; actual code is `1.3.0`.
3. **Missing routes** — added documentation for `GET /`, `GET /health`, `GET /openapi.json`, `GET /qr` to the Public API section.
4. **Setup step 10** — replaced manual QR generation instruction with reference to `GET /qr` and `QR_TARGET_URL` env var.

## Test plan
- [ ] README renders correctly on GitHub
- [ ] QR badge image loads from `https://agent.yuens.me/qr`
- [ ] All four new route entries are accurate against the deployed API