### PR TITLE
fix(data): rename artisan-roast project to Artisan Roast Store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-05-29 — fix(data): rename artisan-roast project to "Artisan Roast Store" and trim description
+
 - 2026-05-29 — feat(profile): add optional cover image URL to Project schema; populate 3 project covers from Supabase Storage
 
 - 2026-05-29 — fix(qr): cast Buffer to Uint8Array for BodyInit compatibility — fixes Railway build failure

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.25",
+  "version": "0.4.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.25",
+      "version": "0.4.27",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.25",
+  "version": "0.4.27",
   "private": true,
   "type": "module",
   "engines": {

--- a/scripts/seed-profile.json
+++ b/scripts/seed-profile.json
@@ -121,9 +121,9 @@
   ],
   "projects": [
     {
-      "name": "Artisan Roast Platform",
+      "name": "Artisan Roast Store",
       "slug": "artisan-roast",
-      "description": "Open-source e-commerce platform for specialty coffee retailers, built with an AI-native development workflow and a SaaS layer for managed hosting, billing, and AI-powered back office.",
+      "description": "Open-source e-commerce store for specialty coffee retailers, built with an AI-native development workflow.",
       "problem": "Independent coffee shop owners lack affordable, purpose-built e-commerce tooling. Generic platforms are expensive and not tailored to specialty coffee workflows. Non-technical owners have no viable self-hosted option.",
       "role": "Sole developer and architect — designed and built the open-source store, the SaaS platform, and the AI-native development workflow end-to-end.",
       "tech": ["Next.js", "TypeScript", "Prisma", "Neon PostgreSQL", "Stripe", "NextAuth.js v5", "Tailwind CSS", "shadcn/ui", "Jest", "Playwright", "Claude Agent SDK", "Google Gemini", "Zod", "GitHub Actions", "Vercel"],


### PR DESCRIPTION
**Version:** 0.4.25 → 0.4.27

## Summary
- Renames `artisan-roast` project from "Artisan Roast Platform" → "Artisan Roast Store" and trims description to remove SaaS layer reference (that belongs to the separate `artisan-roast-platform` entry)
- Updates `scripts/seed-profile.json` to keep it in sync as source of truth; data already live in Supabase

## Test plan
- [ ] `GET /projects` — entry with slug `artisan-roast` shows `name: "Artisan Roast Store"`
- [ ] `GET /projects/artisan-roast` — full detail reflects updated name and description