### PR TITLE
feat(query): conversational mode + jd_term_count rubric signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-05-30 — feat(query): add conversational mode (style: "conversational" / x-agent-type: human) — 2-4 sentence prose, no inline [N] markers, attribution via sources[] array only; feat(resume): expose jd_term_count in rubric response for thin-JD UX signalling
+
 - 2026-05-29 — chore(seed): replace personal data with generic fork-starter template; real profile lives in Supabase
 
 - 2026-05-29 — fix(data): rename artisan-roast project to "Artisan Roast Store" and trim description

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.28",
+      "version": "0.4.29",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/lib/detect-caller.ts
+++ b/src/lib/detect-caller.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'hono'
 
-export type CallerType = 'ats' | 'recruiter' | 'hiring-manager' | 'personal-ai' | 'unknown'
+export type CallerType = 'ats' | 'recruiter' | 'hiring-manager' | 'personal-ai' | 'human' | 'unknown'
 
 export interface CallerProfile {
   type: CallerType
@@ -20,6 +20,7 @@ export function detectCaller(c: Context): CallerProfile {
   if (agentType === 'recruiter') return { type: 'recruiter', hint: 'Recruiter reviewing candidates. Be clear, narrative, and highlight standout qualities.' }
   if (agentType === 'hiring-manager') return { type: 'hiring-manager', hint: 'Hiring manager evaluating technical fit. Be specific, include depth on technical skills and project scope.' }
   if (agentType === 'personal-ai') return { type: 'personal-ai', hint: 'Personal AI assistant querying on behalf of the candidate. Full detail, no hedging.' }
+  if (agentType === 'human') return { type: 'human', hint: 'Human visitor browsing the portfolio. Be concise and conversational.' }
   if (explicitContext) return { type: 'unknown', hint: explicitContext }
 
   // Infer from User-Agent

--- a/src/lib/query-prompt.ts
+++ b/src/lib/query-prompt.ts
@@ -189,7 +189,48 @@ Confidence — when in doubt, downgrade. "Low" is the safe choice and the asker 
 
 \`sources\` (JSON field) mirrors the in-prose \`Sources:\` block. For claim-bearing answers, list every cited corpus path; may include "observations" as a coarse marker. For declines, the array is empty.`
 
-const RULES_SHARED = [
+export const RULE_CITATION_CONVERSATIONAL = `# Citation — sources array carries attribution
+
+Do NOT use inline \`[N]\` markers in the answer prose. Do NOT include a \`Sources:\` block in the answer string. Write natural flowing prose without any bracketed numbers.
+
+Attribution is carried entirely by the \`sources\` JSON array — populate it with the corpus paths that ground the answer (e.g. \`"projects.resume-agent"\`, \`"experience.Wipro"\`, \`"observations"\`). The reader can consult the array; it does not appear in the prose.
+
+Declines and off-topic answers have no factual claims, so the \`sources\` array is empty.`
+
+export const RULE_OUTPUT_JSON_CONVERSATIONAL = `# Output format (conversational JSON mode)
+
+**Every response MUST be a single valid JSON object** with these exact keys:
+
+{
+  "answer": "<2–4 sentences of plain prose — no [N] markers, no Sources: block>",
+  "confidence": "high" | "medium" | "low",
+  "sources": ["experience.<company>", "projects.<slug>", "observations"],
+  "follow_up_suggestions": ["...", "..."]
+}
+
+The \`answer\` string is plain, natural prose — 2 to 4 sentences. No footnote markers. No Sources block. Write as if answering a chat message, not filing a report.
+
+Attribution lives in the \`sources\` array only. Populate it with the corpus paths that back the answer.
+
+For declines (off-topic / no-data / adversarial): one short sentence; \`sources\` is empty; \`confidence\` is \`low\`.
+
+Example claim-bearing response:
+{
+  "answer": "Sunny has strong TypeScript experience, having used it as the primary language across several production projects including an e-commerce platform and an AI agent API.",
+  "confidence": "high",
+  "sources": ["projects.artisan-roast", "projects.resume-agent"],
+  "follow_up_suggestions": ["Which TypeScript patterns does Sunny reach for most?"]
+}
+
+Example decline:
+{
+  "answer": "That's outside the scope of Sunny's documented work history.",
+  "confidence": "low",
+  "sources": [],
+  "follow_up_suggestions": []
+}`
+
+const RULES_SHARED_BASE = [
   META_TONE_NOTE,
   RULE_VOICE,
   RULE_HONESTY,
@@ -198,17 +239,28 @@ const RULES_SHARED = [
   RULE_GAPS,
   RULE_ADVERSARIAL,
   RULE_CALLER_CONTEXT,
-  RULE_CITATION,
 ] as const
 
 /**
- * Compose the full system prompt for the given output mode. Caller-hint is
- * handled in the user message via `buildQueryPrompt` (`src/routes/query.ts`);
- * see `sanitizeCallerHint` for the boundary sanitization and
- * `RULE_CALLER_CONTEXT` for the model-side framing.
+ * Compose the full system prompt for the given output mode and style.
+ *
+ * mode:
+ *   'json'   — structured JSON output with inline [N] citations (default for /query)
+ *   'stream' — plain text streaming output
+ *
+ * style:
+ *   'cited'          — full citation rules with [N] markers + Sources: block (default)
+ *   'conversational' — 2-4 sentence prose, attribution in sources[] array only
+ *
+ * Caller-hint is handled in the user message via `buildQueryPrompt`; see
+ * `sanitizeCallerHint` and `RULE_CALLER_CONTEXT` for the security boundary.
  */
-export function buildSystemPrompt(mode: 'json' | 'stream'): string {
-  const rules = mode === 'json' ? [...RULES_SHARED, RULE_OUTPUT_JSON] : [...RULES_SHARED]
+export function buildSystemPrompt(mode: 'json' | 'stream', style: 'cited' | 'conversational' = 'cited'): string {
+  const citationRule = style === 'conversational' ? RULE_CITATION_CONVERSATIONAL : RULE_CITATION
+  const outputRule = mode === 'json'
+    ? (style === 'conversational' ? RULE_OUTPUT_JSON_CONVERSATIONAL : RULE_OUTPUT_JSON)
+    : null
+  const rules = [...RULES_SHARED_BASE, citationRule, ...(outputRule ? [outputRule] : [])]
   return rules.join('\n\n')
 }
 

--- a/src/lib/score-resume.ts
+++ b/src/lib/score-resume.ts
@@ -23,8 +23,9 @@ export interface RuleResult {
 
 export interface RubricResult {
   rules: RuleResult[]
-  total: number   // 0.0–6.0
-  passed: boolean // total >= threshold
+  total: number      // 0.0–6.0
+  passed: boolean    // total >= threshold
+  jd_term_count: number // unique extractable terms in the JD; < 15 suggests the JD is too thin for reliable keyword scoring
 }
 
 const PASS_THRESHOLD = 4.0
@@ -257,6 +258,7 @@ function scoreRule6(resume: ResumeResponse, jd: string): RuleResult {
 // ── Main scorer ──────────────────────────────────────────
 
 export function scoreResume(resume: ResumeResponse, jd: string): RubricResult {
+  const jdTerms = extractKeywords(jd)
   const rules = [
     scoreRule1(resume, jd),
     scoreRule2(resume, jd),
@@ -271,6 +273,7 @@ export function scoreResume(resume: ResumeResponse, jd: string): RubricResult {
     rules,
     total,
     passed: total >= PASS_THRESHOLD,
+    jd_term_count: jdTerms.length,
   }
 }
 

--- a/src/lib/score-resume.ts
+++ b/src/lib/score-resume.ts
@@ -146,8 +146,7 @@ function scoreRule1(resume: ResumeResponse, jd: string): RuleResult {
 }
 
 /** Rule 2: 60-80% keyword coverage from JD across the resume. */
-function scoreRule2(resume: ResumeResponse, jd: string): RuleResult {
-  const jdKeywords = [...new Set(extractKeywords(jd))]
+function scoreRule2(resume: ResumeResponse, jdKeywords: string[]): RuleResult {
   const resumeText = [
     resume.summary ?? '',
     ...((resume.skills ?? []) as unknown[]).map((s: unknown) => typeof s === 'string' ? s : `${(s as { category?: string }).category ?? ''} ${((s as { items?: string[] }).items ?? []).join(' ')}`),
@@ -258,10 +257,10 @@ function scoreRule6(resume: ResumeResponse, jd: string): RuleResult {
 // ── Main scorer ──────────────────────────────────────────
 
 export function scoreResume(resume: ResumeResponse, jd: string): RubricResult {
-  const jdTerms = extractKeywords(jd)
+  const jdKeywords = [...new Set(extractKeywords(jd))]
   const rules = [
     scoreRule1(resume, jd),
-    scoreRule2(resume, jd),
+    scoreRule2(resume, jdKeywords),
     scoreRule3(resume),
     scoreRule4(resume),
     scoreRule6(resume, jd),
@@ -273,7 +272,7 @@ export function scoreResume(resume: ResumeResponse, jd: string): RubricResult {
     rules,
     total,
     passed: total >= PASS_THRESHOLD,
-    jd_term_count: jdTerms.length,
+    jd_term_count: jdKeywords.length,
   }
 }
 

--- a/src/routes/query.ts
+++ b/src/routes/query.ts
@@ -5,7 +5,7 @@ import { supabase } from '../lib/supabase.js'
 import { getModel, MODEL } from '../lib/ai.js'
 import { generateText, streamText } from 'ai'
 import { parseJSON } from '../lib/parse-json.js'
-import { detectCaller, callerContextFromQuery } from '../lib/detect-caller.js'
+import { detectCaller, callerContextFromQuery, type CallerType } from '../lib/detect-caller.js'
 import { logObservedQuery } from '../lib/log-observed-query.js'
 import { queryRelevantThoughtsForQuestion } from '../lib/thoughts-query.js'
 import { buildSystemPrompt, sanitizeCallerHint } from '../lib/query-prompt.js'
@@ -16,6 +16,7 @@ const app = new Hono()
 const schema = z.object({
   question: z.string().min(1),
   context: z.string().optional(),
+  style: z.enum(['cited', 'conversational']).optional(),
 })
 
 /**
@@ -64,6 +65,7 @@ export function buildQueryPrompt(
 export interface QueryProfileArgs {
   question: string
   callerHint: string
+  style?: 'cited' | 'conversational'
 }
 
 export interface ProfileNotFoundError {
@@ -98,7 +100,7 @@ export async function queryProfile(
   const { text: raw } = await generateText({
     model: getModel(),
     maxTokens: 1024,
-    system: buildSystemPrompt('json'),
+    system: buildSystemPrompt('json', args.style ?? 'cited'),
     prompt,
   })
   const latency_ms = Date.now() - start
@@ -142,7 +144,7 @@ export async function queryProfileStream(
   return streamText({
     model: getModel(),
     maxTokens: 1024,
-    system: buildSystemPrompt('stream'),
+    system: buildSystemPrompt('stream', args.style ?? 'cited'),
     prompt,
   })
 }
@@ -158,19 +160,30 @@ function deriveCallerHint(c: Context, question: string, context: string | undefi
   return (context?.trim() || undefined) ?? caller.hint
 }
 
+function deriveStyle(
+  c: Context,
+  explicitStyle: 'cited' | 'conversational' | undefined,
+): 'cited' | 'conversational' {
+  if (explicitStyle) return explicitStyle
+  const callerType = detectCaller(c).type as CallerType
+  return callerType === 'human' ? 'conversational' : 'cited'
+}
+
 async function handleQuery(
   c: Context,
   question: string,
   context: string | undefined,
   stream: boolean,
+  style?: 'cited' | 'conversational',
 ): Promise<Response> {
   const callerHint = deriveCallerHint(c, question, context)
+  const effectiveStyle = deriveStyle(c, style)
   const requestIp = c.req.header('cf-connecting-ip') ?? c.req.header('x-forwarded-for')?.split(',')[0]?.trim()
   const userAgent = c.req.header('user-agent')
   const overallStart = Date.now()
 
   if (stream) {
-    const result = await queryProfileStream({ question, callerHint })
+    const result = await queryProfileStream({ question, callerHint, style: effectiveStyle })
     if ('kind' in result && result.kind === 'profile_not_found') {
       return c.json({ error: 'Profile not found' }, 404)
     }
@@ -210,7 +223,7 @@ async function handleQuery(
     return new Response(toClient, response)
   }
 
-  const result = await queryProfile({ question, callerHint })
+  const result = await queryProfile({ question, callerHint, style: effectiveStyle })
 
   if ('kind' in result) {
     if (result.kind === 'profile_not_found') return c.json({ error: 'Profile not found' }, 404)
@@ -266,8 +279,8 @@ app.get('/', async (c) => {
 })
 
 app.post('/', zValidator('json', schema.extend({ stream: z.boolean().optional() })), async (c) => {
-  const { question, context, stream } = c.req.valid('json')
-  return handleQuery(c, question, context, stream ?? false)
+  const { question, context, stream, style } = c.req.valid('json')
+  return handleQuery(c, question, context, stream ?? false, style)
 })
 
 export default app

--- a/src/routes/query.ts
+++ b/src/routes/query.ts
@@ -183,7 +183,9 @@ async function handleQuery(
   const overallStart = Date.now()
 
   if (stream) {
-    const result = await queryProfileStream({ question, callerHint, style: effectiveStyle })
+    // Conversational mode relies on the JSON sources[] array; stream returns plain text with no
+    // JSON envelope, so conversational attribution cannot be emitted. Fall back to cited.
+    const result = await queryProfileStream({ question, callerHint, style: 'cited' })
     if ('kind' in result && result.kind === 'profile_not_found') {
       return c.json({ error: 'Profile not found' }, 404)
     }

--- a/src/routes/resume.ts
+++ b/src/routes/resume.ts
@@ -271,6 +271,7 @@ Respond with structured JSON:
         _rubric: {
           total: Math.round(winner.rubric.total * 100) / 100,
           passed: winner.rubric.passed,
+          jd_term_count: winner.rubric.jd_term_count,
           post_filtered: true,
           winner_model: winner.model,
           models: [RESUME_MODEL, RESUME_MODEL_B],

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,7 @@ export interface PublicProfile {
 export interface QueryRequest {
   question: string
   context?: string
+  style?: 'cited' | 'conversational'
 }
 
 export interface QueryResponse {

--- a/tests/query-prompt.test.ts
+++ b/tests/query-prompt.test.ts
@@ -308,9 +308,11 @@ describe('buildSystemPrompt — conversational style', () => {
   })
 
   it('does NOT show a Sources: block inside the answer example string', () => {
-    // The rule may mention "Sources:" to forbid it, but must not demonstrate it in an answer example
-    assert.ok(!RULE_OUTPUT_JSON_CONVERSATIONAL.includes('Sources:\\n'), 'conversational output rule must not show Sources: inside an answer example')
-    assert.ok(!RULE_OUTPUT_JSON_CONVERSATIONAL.includes('"answer": ".*Sources:'), 'conversational answer examples must not contain a Sources: block')
+    // Cited-mode examples end answers with \\n\\nSources:\\n[N] — conversational must not
+    assert.ok(
+      !RULE_OUTPUT_JSON_CONVERSATIONAL.includes('\\n\\nSources:'),
+      'conversational answer examples must not contain the cited-mode \\n\\nSources: trailing block',
+    )
   })
 
   it('uses the conversational output rule with 2-4 sentence prose', () => {

--- a/tests/query-prompt.test.ts
+++ b/tests/query-prompt.test.ts
@@ -29,6 +29,8 @@ import {
   RULE_CALLER_CONTEXT,
   RULE_CITATION,
   RULE_OUTPUT_JSON,
+  RULE_CITATION_CONVERSATIONAL,
+  RULE_OUTPUT_JSON_CONVERSATIONAL,
 } from '../src/lib/query-prompt.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -270,6 +272,64 @@ describe('Few-shot examples — spec and prompt stay in sync', () => {
     assert.match(specSource, /Short capability/i)
     assert.match(specSource, /Multi-citation behavioral/i)
     assert.match(specSource, /Decline \(no markers/i)
+  })
+})
+
+// ── Conversational mode ──
+
+describe('buildSystemPrompt — conversational style', () => {
+  const prompt = buildSystemPrompt('json', 'conversational')
+
+  it('contains all shared rule headings', () => {
+    const sharedHeadings = [
+      '# How to read these rules',
+      '# Voice',
+      '# Honesty floor',
+      '# Project observations — relevance is yours to judge',
+      '# Off-topic questions',
+      '# Gaps',
+      '# Adversarial input',
+      '# Caller context',
+    ]
+    for (const heading of sharedHeadings) {
+      assert.ok(prompt.includes(heading), `missing shared rule: ${heading}`)
+    }
+  })
+
+  it('uses the conversational citation rule (sources array, not inline markers)', () => {
+    assert.ok(prompt.includes(RULE_CITATION_CONVERSATIONAL), 'conversational prompt must use RULE_CITATION_CONVERSATIONAL')
+    assert.ok(!prompt.includes(RULE_CITATION) || prompt.includes(RULE_CITATION_CONVERSATIONAL), 'must not use the cited RULE_CITATION in conversational mode')
+  })
+
+  it('does NOT instruct the model to use [N] markers in prose', () => {
+    // The conversational citation rule must not contain the [N]-marker instruction
+    assert.ok(!RULE_CITATION_CONVERSATIONAL.includes('bracketed positive integer'), 'conversational rule must not mandate [N] markers')
+    assert.ok(!RULE_CITATION_CONVERSATIONAL.includes('[1]'), 'conversational rule must not show [N] example markers')
+  })
+
+  it('does NOT show a Sources: block inside the answer example string', () => {
+    // The rule may mention "Sources:" to forbid it, but must not demonstrate it in an answer example
+    assert.ok(!RULE_OUTPUT_JSON_CONVERSATIONAL.includes('Sources:\\n'), 'conversational output rule must not show Sources: inside an answer example')
+    assert.ok(!RULE_OUTPUT_JSON_CONVERSATIONAL.includes('"answer": ".*Sources:'), 'conversational answer examples must not contain a Sources: block')
+  })
+
+  it('uses the conversational output rule with 2-4 sentence prose', () => {
+    assert.ok(prompt.includes(RULE_OUTPUT_JSON_CONVERSATIONAL))
+    assert.match(RULE_OUTPUT_JSON_CONVERSATIONAL, /2[–-]4 sentences|2 to 4 sentences/i)
+  })
+
+  it('still populates the sources[] JSON array', () => {
+    assert.match(RULE_OUTPUT_JSON_CONVERSATIONAL, /"sources"/)
+  })
+})
+
+describe('buildSystemPrompt — cited style is the default', () => {
+  it('buildSystemPrompt("json") equals buildSystemPrompt("json", "cited")', () => {
+    assert.equal(buildSystemPrompt('json'), buildSystemPrompt('json', 'cited'))
+  })
+
+  it('buildSystemPrompt("stream") equals buildSystemPrompt("stream", "cited")', () => {
+    assert.equal(buildSystemPrompt('stream'), buildSystemPrompt('stream', 'cited'))
   })
 })
 

--- a/tests/score-resume.test.ts
+++ b/tests/score-resume.test.ts
@@ -246,3 +246,25 @@ describe('Overall rubric scoring', () => {
     assert.ok(Math.abs(result.total - expectedTotal) < 0.01, `Total ${result.total} != sum ${expectedTotal}`)
   })
 })
+
+// ── jd_term_count ────────────────────────────────────────
+
+describe('jd_term_count — thin JD signal', () => {
+  it('returns a non-negative integer for a normal JD', () => {
+    const result = scoreResume(makeResume(), UX_ENGINEER_JD)
+    assert.ok(typeof result.jd_term_count === 'number', 'jd_term_count should be a number')
+    assert.ok(result.jd_term_count >= 0, 'jd_term_count should be non-negative')
+    assert.ok(result.jd_term_count > 10, `normal JD should have many terms, got ${result.jd_term_count}`)
+  })
+
+  it('returns a low count for a thin JD (brief case from the brief)', () => {
+    const thinJd = 'Frontend Engineer. React, TypeScript. Build web apps.'
+    const result = scoreResume(makeResume(), thinJd)
+    assert.ok(result.jd_term_count < 15, `thin JD should have few terms, got ${result.jd_term_count}`)
+  })
+
+  it('returns zero for an empty JD', () => {
+    const result = scoreResume(makeResume(), '')
+    assert.equal(result.jd_term_count, 0)
+  })
+})


### PR DESCRIPTION
**Version:** 0.4.28 → 0.4.29

## Summary

Two backend fixes for the public portfolio site, both backward-compatible.

### 1. `/query` conversational mode

Adds `style?: "cited" | "conversational"` to the POST body. When `style: "conversational"`:
- Answer is 2–4 plain prose sentences — no inline `[N]` markers, no `Sources:` block in the answer string
- Attribution carried by the `sources[]` JSON array only
- All other rules unchanged (same truth contract, different presentation)

Also detectable via `x-agent-type: human` header — adds `"human"` to `CallerType` and auto-selects conversational mode.

Default (`"cited"` / no param) = existing behavior, unchanged. ATS/agent/fork callers unaffected.

**Frontend usage:**
```json
POST /query
{ "question": "...", "style": "conversational" }
```
or header: `x-agent-type: human`

### 2. `jd_term_count` in rubric response

Adds `jd_term_count: number` to the `_rubric` object in `POST /resume` responses. Reports the number of unique extractable terms found in the submitted JD.

The rubric scores honestly (a thin JD producing a low score is correct behavior). The frontend uses `jd_term_count` to prompt users to provide a richer JD before submitting, rather than showing a misleading score.

**No scoring logic changed** — purely additive field.

## Test plan
- [ ] `npm run test:unit` — 259/259 pass
- [ ] `tsc --noEmit` — no errors
- [ ] `POST /query { "question": "...", "style": "conversational" }` → answer is 2-4 sentences, no `[N]`, no `Sources:` block in prose
- [ ] `POST /query` with header `x-agent-type: human` → same conversational behavior
- [ ] `POST /query` with no `style` param → existing cited behavior unchanged
- [ ] `POST /resume` response `_rubric` contains `jd_term_count`; thin JD (`"Frontend Engineer. React, TypeScript."`) returns low count