### PR TITLE
feat(sync): auto-infer status, url, and tech from GitHub repo metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-05-30 — feat(sync): auto-infer status, url, and tech from GitHub repo metadata on each nightly sync run — closes #116
+
 - 2026-05-30 — feat(query): add conversational mode (style: "conversational" / x-agent-type: human) — 2-4 sentence prose, no inline [N] markers, attribution via sources[] array only; feat(resume): expose jd_term_count in rubric response for thin-JD UX signalling
 
 - 2026-05-29 — chore(seed): replace personal data with generic fork-starter template; real profile lives in Supabase

--- a/README.md
+++ b/README.md
@@ -476,7 +476,15 @@ See [`docs/workflow.md`](docs/workflow.md) for a walkthrough of how employer AI 
 
 `npm run sync` keeps every project in your `public_profile.projects` array up-to-date from GitHub — no configuration needed beyond what's already in the profile.
 
-**How it works:** For each project that has a `repo` field pointing to a GitHub URL, the sync script fetches the README and CHANGELOG, reconciles the `architecture` and `highlights` fields via LLM semantic diff, and extracts new OB1 thoughts for downstream context injection. Projects without a GitHub `repo` are skipped silently.
+**How it works:** For each project that has a `repo` field pointing to a GitHub URL, the sync script:
+
+1. Fetches the README and CHANGELOG and reconciles `architecture` and `highlights` via LLM semantic diff
+2. **Infers `status`** from last-push activity — projects pushed within 60 days become `active`; dormant for > 1 year become `archived`
+3. **Infers `url`** from the GitHub repo homepage field or deployment URL patterns in the README (only fills if the field is empty — never overwrites a manually-set URL)
+4. **Infers `tech`** from `package.json` dependencies — maps package names to canonical display names and merges additively with existing entries
+5. Extracts new OB1 thoughts for downstream semantic retrieval
+
+Projects without a GitHub `repo` are skipped silently. Fields that need human framing (`description`, `problem`, `role`, `impact`, `cover`) are never touched by the sync.
 
 **Controlling what appears on the resume:** Not every synced project belongs in the Projects section of a generated resume. Some projects are better represented as context for the employment section (e.g. a SaaS platform that's already covered by a self-employment entry). Use `HIDE_FROM_PROJECTS` to exclude specific slugs from the resume output at generation time — the project continues to sync and its OB1 thoughts continue to flow into employment bullet context.
 

--- a/README.md
+++ b/README.md
@@ -194,11 +194,16 @@ Request:
 {
   "question": "Has this person shipped production systems using TypeScript?",
   "context": "ATS screening for a senior backend role",
-  "stream": false
+  "stream": false,
+  "style": "cited"
 }
 ```
 
-Set `"stream": true` (or `?stream=true` on GET) to receive a plain text chunked response (`Content-Type: text/plain`) instead of JSON — useful for demo surfaces and human-readable interfaces.
+**`style`** (optional, default `"cited"`):
+- `"cited"` — full citation rules: inline `[N]` markers and a `Sources:` block in the answer string. Best for ATS, AI agents, and machine consumers.
+- `"conversational"` — 2–4 plain prose sentences, no inline markers, attribution via `sources[]` array only. Best for human chat UIs. Also triggered by `x-agent-type: human` header.
+
+Set `"stream": true` (or `?stream=true` on GET) to receive a plain text chunked response (`Content-Type: text/plain`) instead of JSON — stream mode always uses cited style.
 
 Response (default, `stream: false`):
 ```json
@@ -236,7 +241,7 @@ Response:
 ### `POST /resume` _(private, key-protected)_
 Feed a job description (and optional `framing_hints`), get back a tailored 2-page resume as structured JSON. This endpoint is for the candidate's own use — not exposed to employer agents.
 
-**v2 behavior:** The endpoint generates two independent resumes in parallel, scores both against a deterministic 6-rule ATS rubric (title matching, keyword coverage, quantified bullets, authenticity, bullet prioritization, skills ordering), and returns the higher-scoring candidate. The response includes `_rubric` metadata with per-rule scores. If neither generation passes the rubric threshold, a structured failure is logged to OB1 for pattern analysis. See [`docs/resume-pipeline-v2.md`](docs/resume-pipeline-v2.md) for architecture details.
+**v2 behavior:** The endpoint generates two independent resumes in parallel, scores both against a deterministic 6-rule ATS rubric (title matching, keyword coverage, quantified bullets, authenticity, bullet prioritization, skills ordering), and returns the higher-scoring candidate. The response includes `_rubric` metadata with per-rule scores and a `jd_term_count` field — the number of unique extractable terms found in the submitted JD. Low `jd_term_count` (< 15) signals that the JD may be too thin for reliable keyword-dependent scoring; callers can use this to prompt users to enrich the JD before submitting. If neither generation passes the rubric threshold, a structured failure is logged to OB1 for pattern analysis. See [`docs/resume-pipeline-v2.md`](docs/resume-pipeline-v2.md) for architecture details.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.29",
+      "version": "0.4.30",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "private": true,
   "type": "module",
   "engines": {

--- a/scripts/sync-helpers.ts
+++ b/scripts/sync-helpers.ts
@@ -1,0 +1,162 @@
+/**
+ * Pure helper functions for the GitHub-to-OB1 sync pipeline.
+ *
+ * Extracted here so they can be unit-tested without importing the
+ * full sync.ts entry point (which has side-effectful top-level code).
+ */
+
+// ── inferStatus ───────────────────────────────────────────
+
+/** Thresholds in days */
+const ACTIVE_THRESHOLD_DAYS = 60
+const ARCHIVE_THRESHOLD_DAYS = 365
+
+/**
+ * Infer project status from last GitHub push date.
+ *
+ * Returns the new status string, or null if no change is warranted.
+ * Never returns 'in-progress' — that is a human-set transitional state.
+ *
+ * @param pushedAt  ISO date string from GitHub repo metadata
+ * @param currentStatus  Existing status value in the profile
+ * @param now  Override current date (for testing)
+ */
+export function inferStatus(
+  pushedAt: string,
+  currentStatus: string,
+  now: Date = new Date(),
+): string | null {
+  const pushed = new Date(pushedAt)
+  if (isNaN(pushed.getTime())) return null
+
+  const ageDays = (now.getTime() - pushed.getTime()) / (1000 * 60 * 60 * 24)
+
+  if (ageDays <= ACTIVE_THRESHOLD_DAYS) {
+    return currentStatus === 'active' ? null : 'active'
+  }
+  if (ageDays > ARCHIVE_THRESHOLD_DAYS) {
+    return currentStatus === 'archived' ? null : 'archived'
+  }
+  // 61–365 days: keep existing, don't guess
+  return null
+}
+
+// ── inferUrl ──────────────────────────────────────────────
+
+/**
+ * Infer a project's live URL from GitHub metadata and README content.
+ *
+ * Only fires when currentUrl is falsy — never overwrites a manually-set URL.
+ * Priority: GitHub repo homepage field → README deployment patterns.
+ */
+export function inferUrl(
+  readme: string | null,
+  homepage: string | null,
+  currentUrl: string | undefined,
+): string | null {
+  if (currentUrl) return null
+
+  // GitHub repo homepage is the most reliable signal
+  if (homepage?.startsWith('https://') || homepage?.startsWith('http://')) {
+    return homepage
+  }
+
+  if (!readme) return null
+
+  // Match "Production ... endpoint: https://..." or "Live at https://..."
+  const deployPatterns = [
+    /\*\*Production[^:]*:\*\*\s*`?\s*(https?:\/\/[^\s)`\]]+)/i,
+    /Production[^:]*:\s*`?\s*(https?:\/\/[^\s)`\]]+)/i,
+    /Live at[:\s]+`?\s*(https?:\/\/[^\s)`\]]+)/i,
+    /Deployed at[:\s]+`?\s*(https?:\/\/[^\s)`\]]+)/i,
+    /Demo[:\s]+`?\s*(https?:\/\/[^\s)`\]]+)/i,
+  ]
+  for (const pat of deployPatterns) {
+    const m = readme.match(pat)
+    if (m?.[1]) return m[1].replace(/[.,;]$/, '')
+  }
+
+  // Badge link pattern: [![...](img)](https://...)
+  const badgeLink = /\[!\[.*?\]\(.*?\)\]\((https?:\/\/[^\s)]+)\)/g
+  let m: RegExpExecArray | null
+  while ((m = badgeLink.exec(readme)) !== null) {
+    const url = m[1]
+    // Skip GitHub, shields.io, and other meta-service URLs
+    if (!/github\.com|shields\.io|badge|img\.shields/.test(url)) {
+      return url
+    }
+  }
+
+  return null
+}
+
+// ── inferTech ─────────────────────────────────────────────
+
+/** Maps npm package names to canonical portfolio display names. */
+export const PACKAGE_TO_DISPLAY: Record<string, string> = {
+  '@anthropic-ai/sdk': 'Anthropic Claude',
+  '@modelcontextprotocol/sdk': 'MCP (@modelcontextprotocol/sdk)',
+  'ai': 'Vercel AI SDK',
+  '@ai-sdk/anthropic': 'Vercel AI SDK',
+  '@ai-sdk/openai': 'Vercel AI SDK',
+  '@ai-sdk/google': 'Vercel AI SDK',
+  'hono': 'Hono',
+  '@supabase/supabase-js': 'Supabase',
+  '@prisma/client': 'Prisma',
+  'prisma': 'Prisma',
+  'zod': 'Zod',
+  'next': 'Next.js',
+  'react': 'React',
+  'stripe': 'Stripe',
+  'next-auth': 'NextAuth.js v5',
+  'vitest': 'Vitest',
+  'jest': 'Jest',
+  '@playwright/test': 'Playwright',
+  'playwright': 'Playwright',
+  'tailwindcss': 'Tailwind CSS',
+  'langchain': 'LangChain',
+  'openai': 'OpenAI SDK',
+}
+
+const TECH_CAP = 15
+
+/**
+ * Infer tech stack entries from a project's package.json content.
+ *
+ * Merges inferred entries with existing manual tech (additive — never removes).
+ * Returns the merged array, or null if nothing new was added.
+ */
+export function inferTech(
+  packageJson: string | null,
+  currentTech: string[] | undefined,
+): string[] | null {
+  if (!packageJson) return null
+
+  let pkg: { dependencies?: Record<string, string>; devDependencies?: Record<string, string> }
+  try {
+    pkg = JSON.parse(packageJson)
+  } catch {
+    return null
+  }
+
+  const allDeps = {
+    ...pkg.dependencies,
+    ...pkg.devDependencies,
+  }
+
+  const inferred = new Set<string>()
+  for (const [name, displayName] of Object.entries(PACKAGE_TO_DISPLAY)) {
+    if (name in allDeps) {
+      inferred.add(displayName)
+    }
+  }
+
+  if (inferred.size === 0) return null
+
+  const existing = new Set(currentTech ?? [])
+  const newEntries = [...inferred].filter(t => !existing.has(t))
+  if (newEntries.length === 0) return null
+
+  const merged = [...(currentTech ?? []), ...newEntries]
+  return merged.slice(0, TECH_CAP)
+}

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -27,6 +27,7 @@ import { createHash } from 'node:crypto'
 import { createClient } from '@supabase/supabase-js'
 import { createOpenAI } from '@ai-sdk/openai'
 import { embed, generateText } from 'ai'
+import { inferStatus, inferUrl, inferTech } from './sync-helpers.js'
 
 const SUPA_URL = process.env.SUPA_PROJECT_URL
 const SUPA_KEY = process.env.SUPA_SERVICE_ROLE
@@ -87,6 +88,27 @@ async function fetchGitHubFile(owner: string, repo: string, path: string): Promi
   const data = await res.json() as { content?: string }
   if (!data.content) return null
   return Buffer.from(data.content.replace(/\n/g, ''), 'base64').toString('utf8')
+}
+
+interface RepoMetadata { pushedAt: string; homepage: string | null }
+
+async function fetchRepoMetadata(owner: string, repo: string): Promise<RepoMetadata | null> {
+  const url = `https://api.github.com/repos/${owner}/${repo}`
+  const headers: Record<string, string> = {
+    'Accept': 'application/vnd.github+json',
+    'X-GitHub-Api-Version': GITHUB_API_VERSION,
+  }
+  if (GITHUB_TOKEN) headers['Authorization'] = `Bearer ${GITHUB_TOKEN}`
+  const res = await fetch(url, { headers })
+  if (!res.ok) {
+    console.warn(`  GitHub metadata ${res.status} for ${owner}/${repo}`)
+    return null
+  }
+  const data = await res.json() as { pushed_at?: string; homepage?: string | null }
+  return {
+    pushedAt: data.pushed_at ?? '',
+    homepage: data.homepage ?? null,
+  }
 }
 
 // ── GitHub tree + feature doc fetching ────────────────────
@@ -606,6 +628,38 @@ async function syncProject(
     }
   } else {
     console.log(`  ⚠ CHANGELOG.md not found — skipping highlights + thought extraction`)
+  }
+
+  // ── Status / URL / Tech inference ────────────────────────
+  const meta = await fetchRepoMetadata(r.owner, r.repo)
+  if (meta) {
+    const newStatus = inferStatus(meta.pushedAt, project.status ?? '')
+    if (newStatus) {
+      project.status = newStatus
+      updated = true
+      console.log(`  ✔ status inferred: ${newStatus}`)
+    } else {
+      console.log(`  — status unchanged`)
+    }
+
+    const newUrl = inferUrl(archDoc, meta.homepage, project.url as string | undefined)
+    if (newUrl) {
+      project.url = newUrl
+      updated = true
+      console.log(`  ✔ url inferred: ${newUrl}`)
+    } else {
+      console.log(`  — url unchanged`)
+    }
+  }
+
+  const pkgJson = await fetchGitHubFile(r.owner, r.repo, 'package.json')
+  const newTech = inferTech(pkgJson, project.tech as string[] | undefined)
+  if (newTech) {
+    project.tech = newTech
+    updated = true
+    console.log(`  ✔ tech merged (${newTech.length} entries)`)
+  } else {
+    console.log(`  — tech unchanged`)
   }
 
   // ── Extract thoughts from feature docs ──

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -573,12 +573,16 @@ async function syncProject(
     ? (project.highlights as string[])
     : []
 
-  // Fetch both docs in parallel
+  // Fetch docs in parallel; always fetch README.md for URL inference even when
+  // docsPath points to a custom architecture doc.
   const archPath = r.docsPath ?? 'README.md'
-  const [archDoc, changelog] = await Promise.all([
+  const needsSeparateReadme = archPath !== 'README.md'
+  const [archDoc, changelog, readmeDoc] = await Promise.all([
     fetchGitHubFile(r.owner, r.repo, archPath),
     fetchGitHubFile(r.owner, r.repo, 'CHANGELOG.md'),
+    needsSeparateReadme ? fetchGitHubFile(r.owner, r.repo, 'README.md') : Promise.resolve(null),
   ])
+  const readmeForUrl = needsSeparateReadme ? readmeDoc : archDoc
 
   let updated = false
 
@@ -642,7 +646,7 @@ async function syncProject(
       console.log(`  — status unchanged`)
     }
 
-    const newUrl = inferUrl(archDoc, meta.homepage, project.url as string | undefined)
+    const newUrl = inferUrl(readmeForUrl, meta.homepage, project.url as string | undefined)
     if (newUrl) {
       project.url = newUrl
       updated = true

--- a/tests/sync-enrichment.test.ts
+++ b/tests/sync-enrichment.test.ts
@@ -12,12 +12,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { createHash } from 'node:crypto'
-
-// The pure helpers below are currently re-implemented locally for unit
-// testing because sync.ts is a script entry point, not an importable
-// module. These tests do not currently exercise the production
-// implementation directly; once the helpers are extracted to a shared
-// module, this file should import them instead of duplicating them.
+import { inferStatus, inferUrl, inferTech, PACKAGE_TO_DISPLAY } from '../scripts/sync-helpers.js'
 
 // ── splitChangelogSections (re-implemented for test) ─────
 
@@ -131,6 +126,140 @@ describe('splitChangelogSections', () => {
     assert.ok(sections.shipped.includes('shipped item'))
   })
 })
+
+// ── inferStatus ──────────────────────────────────────────
+
+describe('inferStatus', () => {
+  const now = new Date('2026-05-30T00:00:00Z')
+
+  it('returns "active" when pushed within 60 days', () => {
+    const pushed = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString()
+    assert.equal(inferStatus(pushed, 'in-progress', now), 'active')
+  })
+
+  it('returns null when already active and pushed within 60 days', () => {
+    const pushed = new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000).toISOString()
+    assert.equal(inferStatus(pushed, 'active', now), null)
+  })
+
+  it('returns null when pushed 61–365 days ago (keep existing)', () => {
+    const pushed = new Date(now.getTime() - 120 * 24 * 60 * 60 * 1000).toISOString()
+    assert.equal(inferStatus(pushed, 'in-progress', now), null)
+    assert.equal(inferStatus(pushed, 'active', now), null)
+  })
+
+  it('returns "archived" when pushed > 365 days ago', () => {
+    const pushed = new Date(now.getTime() - 400 * 24 * 60 * 60 * 1000).toISOString()
+    assert.equal(inferStatus(pushed, 'active', now), 'archived')
+  })
+
+  it('returns null when already archived and pushed > 365 days ago', () => {
+    const pushed = new Date(now.getTime() - 400 * 24 * 60 * 60 * 1000).toISOString()
+    assert.equal(inferStatus(pushed, 'archived', now), null)
+  })
+
+  it('returns "active" when previously archived project is pushed within 60 days', () => {
+    const pushed = new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000).toISOString()
+    assert.equal(inferStatus(pushed, 'archived', now), 'active')
+  })
+
+  it('returns null for invalid date string', () => {
+    assert.equal(inferStatus('not-a-date', 'active', now), null)
+  })
+})
+
+// ── inferUrl ────────────────────────────────────────────
+
+describe('inferUrl', () => {
+  it('returns null when currentUrl is already set', () => {
+    assert.equal(inferUrl('readme text', 'https://example.com', 'https://existing.com'), null)
+  })
+
+  it('returns GitHub homepage when set and currentUrl is empty', () => {
+    assert.equal(inferUrl(null, 'https://myproject.com', undefined), 'https://myproject.com')
+  })
+
+  it('extracts "Production MCP endpoint:" URL from README', () => {
+    const readme = '**Production MCP endpoint:** `https://brew-guide-production.up.railway.app/mcp`'
+    assert.equal(inferUrl(readme, null, undefined), 'https://brew-guide-production.up.railway.app/mcp')
+  })
+
+  it('extracts "Live at" URL from README', () => {
+    const readme = 'Live at https://agent.yuens.me — fully operational.'
+    assert.equal(inferUrl(readme, null, undefined), 'https://agent.yuens.me')
+  })
+
+  it('skips GitHub and shields.io badge links', () => {
+    const readme = '[![CI](https://github.com/org/repo/actions)](https://github.com/org/repo)'
+    assert.equal(inferUrl(readme, null, undefined), null)
+  })
+
+  it('returns null when no URL found and currentUrl is empty', () => {
+    assert.equal(inferUrl('Just some text with no URL.', null, undefined), null)
+  })
+
+  it('prefers homepage over README patterns', () => {
+    const readme = 'Live at https://readme-url.com'
+    assert.equal(inferUrl(readme, 'https://homepage-url.com', undefined), 'https://homepage-url.com')
+  })
+})
+
+// ── inferTech ────────────────────────────────────────────
+
+describe('inferTech', () => {
+  it('returns null when packageJson is null', () => {
+    assert.equal(inferTech(null, ['TypeScript']), null)
+  })
+
+  it('returns null for invalid JSON', () => {
+    assert.equal(inferTech('not json', []), null)
+  })
+
+  it('maps @anthropic-ai/sdk to "Anthropic Claude"', () => {
+    const pkg = JSON.stringify({ dependencies: { '@anthropic-ai/sdk': '^1.0.0' } })
+    const result = inferTech(pkg, [])
+    assert.ok(result?.includes('Anthropic Claude'), `expected Anthropic Claude in ${result}`)
+  })
+
+  it('maps @modelcontextprotocol/sdk to MCP display name', () => {
+    const pkg = JSON.stringify({ dependencies: { '@modelcontextprotocol/sdk': '^1.0.0' } })
+    const result = inferTech(pkg, [])
+    assert.ok(result?.includes('MCP (@modelcontextprotocol/sdk)'), `expected MCP in ${result}`)
+  })
+
+  it('deduplicates Vercel AI SDK when multiple ai-sdk packages are present', () => {
+    const pkg = JSON.stringify({
+      dependencies: { 'ai': '^4.0.0', '@ai-sdk/anthropic': '^1.0.0', '@ai-sdk/openai': '^1.0.0' },
+    })
+    const result = inferTech(pkg, [])
+    const count = result?.filter(t => t === 'Vercel AI SDK').length ?? 0
+    assert.equal(count, 1, 'Vercel AI SDK should appear exactly once')
+  })
+
+  it('preserves manual tech entries not in package.json', () => {
+    const pkg = JSON.stringify({ dependencies: { 'hono': '^4.0.0' } })
+    const result = inferTech(pkg, ['Railway', 'OEP'])
+    assert.ok(result?.includes('Railway'), 'manual Railway entry should be preserved')
+    assert.ok(result?.includes('OEP'), 'manual OEP entry should be preserved')
+    assert.ok(result?.includes('Hono'), 'inferred Hono should be added')
+  })
+
+  it('returns null when all inferred entries are already in currentTech', () => {
+    const pkg = JSON.stringify({ dependencies: { 'hono': '^4.0.0' } })
+    assert.equal(inferTech(pkg, ['Hono']), null)
+  })
+
+  it('caps result at 15 entries', () => {
+    const existing = Array.from({ length: 13 }, (_, i) => `Tech${i}`)
+    const pkg = JSON.stringify({
+      dependencies: Object.fromEntries(Object.keys(PACKAGE_TO_DISPLAY).map(k => [k, '1.0.0'])),
+    })
+    const result = inferTech(pkg, existing)
+    assert.ok(!result || result.length <= 15, `result length ${result?.length} exceeds 15`)
+  })
+})
+
+// ── contentHash ──────────────────────────────────────────
 
 describe('contentHash', () => {
   it('produces deterministic hash for same input', () => {


### PR DESCRIPTION
**Version:** 0.4.29 → 0.4.30

Closes #116

## Summary
Extends the nightly sync to auto-infer three fields that previously drifted silently:

- **`status`** — inferred from last GitHub push: ≤60 days → `active`, 61-365 days → unchanged, >365 days → `archived`. Reactivates archived projects that see new commits.
- **`url`** — filled from GitHub repo `homepage` field or README deployment patterns (e.g. `Production MCP endpoint:`, `Live at`). Only fires when the field is empty — never overwrites a manually-set URL.
- **`tech`** — merges inferred entries from `package.json` dependencies (via a `PACKAGE_TO_DISPLAY` name map) with the existing tech array. Additive only — existing manual entries are preserved. Capped at 15 entries.

The three helpers are extracted to `scripts/sync-helpers.ts` (pure functions, no network) so they can be unit-tested directly — the old pattern of duplicating helpers in the test file is resolved.

## Test plan
- [ ] `npm run test:unit` — 281/281 pass including 22 new tests for `inferStatus`, `inferUrl`, `inferTech`
- [ ] `tsc --noEmit` — no errors
- [ ] `npm run sync` locally — console shows `✔ status inferred`, `✔ url inferred`, `✔ tech merged` for relevant repos