### PR TITLE
fix(query): follow_up_suggestions use third-person visitor voice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-05-30 — fix(query): follow_up_suggestions now written from visitor's perspective (third-person about the candidate, not second-person directed at them)
+
 - 2026-05-30 — feat(sync): auto-infer status, url, and tech from GitHub repo metadata on each nightly sync run — closes #116
 
 - 2026-05-30 — feat(query): add conversational mode (style: "conversational" / x-agent-type: human) — 2-4 sentence prose, no inline [N] markers, attribution via sources[] array only; feat(resume): expose jd_term_count in rubric response for thin-JD UX signalling

--- a/docs/query-engagement-rules.md
+++ b/docs/query-engagement-rules.md
@@ -91,6 +91,8 @@ Required shape:
 }
 ```
 
+`follow_up_suggestions`: 2–3 questions the asker might want to ask next. Write them from the visitor's perspective about the candidate — third-person, consistent with the answer's voice. Example: "What kind of work is Sunny looking for?" — **not** "What kind of work are you looking for?" The visitor is talking to an agent about a candidate, not to the candidate directly.
+
 The shape of the `answer` *string* depends on whether the response makes factual claims:
 
 **Claim-bearing answer** (binary, capability, behavioral — anything grounded in the corpus): include `[N]` markers and a `Sources:` block inside the `answer` string. Full example response:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.30",
+  "version": "0.4.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.30",
+      "version": "0.4.31",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.30",
+  "version": "0.4.31",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/lib/query-prompt.ts
+++ b/src/lib/query-prompt.ts
@@ -114,6 +114,8 @@ Required shape:
   "follow_up_suggestions": ["...", "..."]
 }
 
+\`follow_up_suggestions\`: 2–3 questions the asker might want to ask next. Write them from the visitor's perspective about the candidate — third-person, consistent with the answer's voice. Example: "What kind of work is Sunny looking for?" or "Has Sunny shipped anything with Rust?" — **not** "What kind of work are you looking for?" or "Have you shipped anything with Rust?" The visitor is talking to an agent about a candidate, not to the candidate directly.
+
 The shape of the \`answer\` *string* depends on whether the response makes factual claims about the candidate:
 
 **Claim-bearing answer** (binary / capability / behavioral — anything grounded in the corpus): include footnote markers and a \`Sources:\` block inside the \`answer\` string. Full example response:
@@ -207,6 +209,8 @@ export const RULE_OUTPUT_JSON_CONVERSATIONAL = `# Output format (conversational 
   "sources": ["experience.<company>", "projects.<slug>", "observations"],
   "follow_up_suggestions": ["...", "..."]
 }
+
+\`follow_up_suggestions\`: 2–3 questions the asker might want to ask next. Write them from the visitor's perspective about the candidate — third-person. Example: "What kind of work is Sunny looking for?" — **not** "What kind of work are you looking for?" The visitor is talking to an agent about a candidate, not to the candidate directly.
 
 The \`answer\` string is plain, natural prose — 2 to 4 sentences. No footnote markers. No Sources block. Write as if answering a chat message, not filing a report.
 


### PR DESCRIPTION
**Version:** 0.4.30 → 0.4.31

## Summary
- Adds explicit voice guidance to `RULE_OUTPUT_JSON` and `RULE_OUTPUT_JSON_CONVERSATIONAL`: follow-up suggestions must be written from the visitor's perspective about the candidate (third-person), not directed at the candidate (second-person)
- Before: "What kind of work are **you** interested in discussing?"
- After: "What kind of work is **Sunny** looking for?"
- `docs/query-engagement-rules.md` updated to match

## Test plan
- [ ] `npm run test:unit` — 281/281 pass
- [ ] Live `/query` response: `follow_up_suggestions` use "Sunny" or "the candidate", not "you" / "your"