### PR TITLE
chore: add MIT LICENSE file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-06-01 — chore: add MIT LICENSE file — closes #121
+
 - 2026-05-31 — feat(oep): Phase 2a — git evidence per project via nightly sync; provider abstraction (GitHub implemented, GitLab/Bitbucket stubs); verification_status on profile; oep-verification.md documents full chain and peer attestation model
 
 - 2026-05-30 — fix(query): follow_up_suggestions now written from visitor's perspective (third-person about the candidate, not second-person directed at them)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Sunny Yuen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.32",
+  "version": "0.4.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.32",
+      "version": "0.4.33",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.32",
+  "version": "0.4.33",
   "private": true,
   "type": "module",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "resume-agent",
   "version": "0.4.33",
+  "license": "MIT",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
**Version:** 0.4.32 → 0.4.33

Closes #121

## Summary
Adds `LICENSE` (MIT, © 2026 Sunny Yuen) at the repo root. README already had a `## License` section saying MIT — the file was the only missing piece.

Without a license file, GitHub defaults to "all rights reserved" — meaning forks, modifications, and reuse are technically not permitted even though the repo is clearly intended for public use (the README guides forks, the `robots.txt` welcomes AI bots, and the OpenAPI schema is explicitly for Custom GPT Actions integration).

## Test plan
- [ ] `LICENSE` file present at repo root
- [ ] GitHub UI shows "MIT license" on the repo page