### PR TITLE
feat(oep): Phase 3 — signed git evidence, verify endpoint, CLI verifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-06-01 — feat(oep): Phase 3 — sign git evidence with Ed25519 key; GET /verify/git-evidence; CLI verify-git-evidence.ts; README fork/identity clarity
+
 - 2026-06-01 — chore: add MIT LICENSE file — closes #121
 
 - 2026-05-31 — feat(oep): Phase 2a — git evidence per project via nightly sync; provider abstraction (GitHub implemented, GitLab/Bitbucket stubs); verification_status on profile; oep-verification.md documents full chain and peer attestation model

--- a/README.md
+++ b/README.md
@@ -20,6 +20,27 @@ The public endpoint is not a portfolio site. It is not a chatbot. It is an agent
 
 ---
 
+## Fork the code. Your identity is yours.
+
+This repo is MIT-licensed — fork it, deploy your own instance, build a product on top of it. That is the explicit intent. The README guides you through it, the OpenAPI schema is published so any platform can integrate, and the `robots.txt` welcomes AI crawlers. This is a reference implementation meant to be replicated.
+
+But forking the code does not clone the identity. If someone deployed this repo with your name, your employment history, and your contact details — that is impersonation, not a license question. MIT licenses software; it does not license you.
+
+**This is where the Open Employment Protocol comes in.** OEP Phase 1 ties your agent to a domain you control via a DNS fingerprint. A fork deployed at a different domain cannot reproduce your `_oep.yourdomain.com` DNS record. Any AI or verifier running `verify-oep-domain yourdomain.com` gets a cryptographic PASS for your agent — and gets nothing for theirs. Your domain is your root of trust.
+
+The full chain — each layer independently verifiable:
+
+| Layer | What it proves | Who can verify |
+|---|---|---|
+| **MIT code** | Anyone can run this software | N/A — it's a license |
+| **OEP Phase 1** — domain fingerprint | Only you operate the agent at your domain | Anyone with DNS + `scripts/verify-oep-domain.ts` |
+| **OEP Phase 2** — git evidence | The work you claim is backed by real commit history | Anyone fetching `GET /projects/:slug` |
+| **OEP Phase 3** — signed evidence | The evidence is signed by the key only you control | Anyone with `scripts/verify-git-evidence.ts` |
+
+The code is for everyone. The proof chain is yours alone.
+
+---
+
 ## What it is not
 
 - No web UI. No dashboard. No frontend.
@@ -596,4 +617,6 @@ Contributions welcome — particularly around the job match scoring methodology 
 
 ## License
 
-MIT
+MIT — fork freely, deploy your own instance, build on top of it. See [LICENSE](LICENSE).
+
+The code is open. Your identity proof (OEP domain fingerprint, signed evidence) is yours. A fork of this repo is a new agent, not a copy of you.

--- a/docs/plans/oep-verification.md
+++ b/docs/plans/oep-verification.md
@@ -1,5 +1,17 @@
 # OEP Verification — Philosophy and Roadmap
 
+## The one-paragraph version
+
+Fork the code freely — that is the point. But forking the code does not clone the identity. MIT licenses software; it does not license you. If someone deployed this with your name and claimed to be your canonical agent, that is impersonation. The Open Employment Protocol is the technical defense: each layer in the chain below is independently verifiable by any third party, and no fork can reproduce it without controlling your DNS and your private key.
+
+| Layer | What it proves |
+|---|---|
+| **OEP Phase 1** — domain fingerprint | Only you operate the agent at your domain |
+| **OEP Phase 2** — git evidence | The work you claim is backed by real commit history |
+| **OEP Phase 3** — signed evidence | The evidence is signed by the key only you control |
+
+---
+
 ## The problem
 
 A professional profile makes claims about work history. Those claims are self-reported. The gap between "I built X" and "I provably built X" is where most resume fraud lives — and where most AI hiring tools have no ground truth.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.33",
+  "version": "0.4.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.33",
+      "version": "0.4.34",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.33",
+  "version": "0.4.34",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -780,21 +780,31 @@ async function syncProject(
     const repoUrl = String(project.repo)
     const evidence = await fetchGitEvidence(r.owner, r.repo, repoUrl, meta, repoTree, project.git_evidence as GitEvidence | undefined)
     if (evidence) {
-      // Sign the evidence if OEP private key is configured
-      const privKey = loadPrivateKeyFromEnv()
-      const pubLoaded = loadPublicKeyFromEnv()
-      if (privKey && pubLoaded) {
-        const { signature: _existing, ...payload } = evidence
-        const baseUrl = (process.env.PUBLIC_URL ?? '').replace(/\/$/, '')
-        const sig: EvidenceSignature = {
-          alg: 'ed25519',
-          key_url: `${baseUrl}/.well-known/oep-public-key.json`,
-          fingerprint: pubLoaded.fingerprint,
-          value: signEvidence(payload, privKey),
-          signed_at: new Date().toISOString(),
+      // Sign the evidence if OEP keys are configured — best-effort, never abort sync on failure
+      try {
+        const baseUrl = process.env.PUBLIC_URL?.replace(/\/$/, '')
+        if (!baseUrl?.startsWith('http')) {
+          console.log(`  — git_evidence signing skipped: PUBLIC_URL not set or not absolute`)
+        } else {
+          const privKey = loadPrivateKeyFromEnv()
+          const pubLoaded = loadPublicKeyFromEnv()
+          if (privKey && pubLoaded) {
+            const { signature: _existing, ...payload } = evidence
+            const sig: EvidenceSignature = {
+              alg: 'ed25519',
+              key_url: `${baseUrl}/.well-known/oep-public-key.json`,
+              fingerprint: pubLoaded.fingerprint,
+              value: signEvidence(payload, privKey),
+              signed_at: new Date().toISOString(),
+            }
+            evidence.signature = sig
+            console.log(`  ✔ git_evidence signed (fingerprint: ${pubLoaded.fingerprint.slice(0, 12)}…)`)
+          } else {
+            console.log(`  — git_evidence signing skipped: OEP keys not configured`)
+          }
         }
-        evidence.signature = sig
-        console.log(`  ✔ git_evidence signed (fingerprint: ${pubLoaded.fingerprint.slice(0, 12)}…)`)
+      } catch (err) {
+        console.warn(`  ⚠ git_evidence signing failed (non-fatal): ${(err as Error).message}`)
       }
       project.git_evidence = evidence
       updated = true

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -28,7 +28,8 @@ import { createClient } from '@supabase/supabase-js'
 import { createOpenAI } from '@ai-sdk/openai'
 import { embed, generateText } from 'ai'
 import { inferStatus, inferUrl, inferTech, detectGitProvider, parseCommitCount, buildRepoStats } from './sync-helpers.js'
-import type { GitEvidence } from '../src/types.js'
+import { loadPublicKeyFromEnv, loadPrivateKeyFromEnv, signEvidence } from '../src/lib/oep-key.js'
+import type { GitEvidence, EvidenceSignature } from '../src/types.js'
 
 const SUPA_URL = process.env.SUPA_PROJECT_URL
 const SUPA_KEY = process.env.SUPA_SERVICE_ROLE
@@ -779,6 +780,22 @@ async function syncProject(
     const repoUrl = String(project.repo)
     const evidence = await fetchGitEvidence(r.owner, r.repo, repoUrl, meta, repoTree, project.git_evidence as GitEvidence | undefined)
     if (evidence) {
+      // Sign the evidence if OEP private key is configured
+      const privKey = loadPrivateKeyFromEnv()
+      const pubLoaded = loadPublicKeyFromEnv()
+      if (privKey && pubLoaded) {
+        const { signature: _existing, ...payload } = evidence
+        const baseUrl = (process.env.PUBLIC_URL ?? '').replace(/\/$/, '')
+        const sig: EvidenceSignature = {
+          alg: 'ed25519',
+          key_url: `${baseUrl}/.well-known/oep-public-key.json`,
+          fingerprint: pubLoaded.fingerprint,
+          value: signEvidence(payload, privKey),
+          signed_at: new Date().toISOString(),
+        }
+        evidence.signature = sig
+        console.log(`  ✔ git_evidence signed (fingerprint: ${pubLoaded.fingerprint.slice(0, 12)}…)`)
+      }
       project.git_evidence = evidence
       updated = true
       console.log(`  ✔ git_evidence updated (${evidence.commit_count} commits, ${evidence.repo_stats.total_files} files)`)

--- a/scripts/verify-git-evidence.ts
+++ b/scripts/verify-git-evidence.ts
@@ -6,13 +6,13 @@
  *
  * Exit 0 on PASS, exit 1 on FAIL.
  *
- * What it verifies:
- * 1. Fetches the project's git_evidence from the live agent endpoint
- * 2. Fetches the OEP public key from /.well-known/oep-public-key.json
- * 3. Confirms the key fingerprint matches the _oep.<domain> DNS TXT record (Phase 1 chain)
- * 4. Verifies the Ed25519 signature over the canonical JSON of the evidence
- *
- * A PASS means: whoever controls <domain> signed this evidence, and it hasn't been tampered with.
+ * Walks the full chain:
+ * 1. DNS TXT record at _oep.<domain> — Phase 1 fingerprint
+ * 2. Agent host discovery via agent card (mirrors verify-oep-domain.ts pattern)
+ * 3. OEP public key envelope from /.well-known/oep-public-key.json
+ * 4. Three-way fingerprint match: DNS == envelope == recomputed (Phase 1 chain)
+ * 5. Signature fingerprint in evidence matches the verified key
+ * 6. Ed25519 signature over canonical JSON of git_evidence (Phase 3)
  */
 
 import { resolveTxt } from 'node:dns/promises'
@@ -33,6 +33,7 @@ interface VerifyEvidenceResult {
   details?: {
     dns_fingerprint: string
     key_fingerprint: string
+    signature_fingerprint: string
     signature_valid: boolean
   }
 }
@@ -41,78 +42,98 @@ async function verifyGitEvidence(domain: string, slug: string): Promise<VerifyEv
   const cleanDomain = domain.replace(/^https?:\/\//, '').replace(/\/.*$/, '').replace(/:\d+$/, '').trim()
   if (!cleanDomain) return { ok: false, reason: 'empty domain', domain, slug }
 
-  const agentHost = `agent.${cleanDomain}`
-  const baseUrl = `https://${agentHost}`
-
-  // (1) Fetch project git_evidence
-  let evidence: GitEvidence
-  let signature: EvidenceSignature
+  // (1) DNS TXT lookup — candidate-selection, same pattern as verify-oep-domain.ts
+  let dnsFingerprint: string
   try {
-    const res = await fetch(`${baseUrl}/projects/${slug}`)
-    if (!res.ok) return { ok: false, reason: `project fetch failed: ${res.status}`, domain, slug, agentHost }
-    const project = await res.json() as Record<string, unknown>
-    const ev = project.git_evidence as GitEvidence | undefined
-    if (!ev) return { ok: false, reason: 'no git_evidence on project — run sync first', domain, slug, agentHost }
-    if (!ev.signature) return { ok: false, reason: 'git_evidence present but unsigned — configure OEP_PRIVATE_KEY and re-run sync', domain, slug, agentHost }
-    evidence = ev
-    signature = ev.signature
-  } catch (e) {
-    return { ok: false, reason: `project fetch error: ${(e as Error).message}`, domain, slug, agentHost }
+    const records = await resolveTxt(`_oep.${cleanDomain}`)
+    const candidates = records
+      .map(parts => parseTxtRecord(parts.join('')))
+      .filter((p): p is { version: string; alg: string; fp: string } => p !== null && p.version === 'oep1')
+    const parsed = candidates[0]
+    if (!parsed) return { ok: false, reason: `no _oep.${cleanDomain} TXT record with v=oep1`, domain: cleanDomain, slug }
+    if (parsed.alg !== 'ed25519') return { ok: false, reason: `unsupported alg in TXT: ${parsed.alg}`, domain: cleanDomain, slug }
+    dnsFingerprint = parsed.fp
+  } catch (err) {
+    return { ok: false, reason: `DNS lookup failed: ${(err as Error).message}`, domain: cleanDomain, slug }
   }
 
-  // (2) Fetch OEP public key
+  // (2) Agent host discovery via agent card (falls back to agent.<domain>)
+  let agentHost = `agent.${cleanDomain}`
+  try {
+    const card = await fetch(`https://${cleanDomain}/.well-known/agent-card.json`)
+    if (card.ok) {
+      const data = await card.json() as { url?: string }
+      if (typeof data.url === 'string' && data.url) {
+        agentHost = new URL(data.url).host
+      }
+    }
+  } catch { /* ignore — fall back to agent.<domain> */ }
+
+  const baseUrl = `https://${agentHost}`
+
+  // (3) Fetch OEP public key envelope
   let rawKey: Uint8Array
   let keyFingerprint: string
   try {
     const res = await fetch(`${baseUrl}/.well-known/oep-public-key.json`)
-    if (!res.ok) return { ok: false, reason: `OEP key fetch failed: ${res.status}`, domain, slug, agentHost }
-    const envelope = await res.json() as { key?: string; fingerprint?: string }
-    if (!envelope.key) return { ok: false, reason: 'OEP key envelope missing key field', domain, slug, agentHost }
+    if (!res.ok) return { ok: false, reason: `OEP key fetch failed: HTTP ${res.status}`, domain: cleanDomain, slug, agentHost }
+    const envelope = await res.json() as { alg?: string; key?: string; fingerprint?: string }
+    if (!envelope || envelope.alg !== 'ed25519' || typeof envelope.key !== 'string' || typeof envelope.fingerprint !== 'string') {
+      return { ok: false, reason: 'malformed OEP key envelope', domain: cleanDomain, slug, agentHost }
+    }
     rawKey = decodePublicKey(envelope.key)
-    keyFingerprint = computeFingerprint(rawKey)
+
+    // (4) Three-way fingerprint match: DNS == envelope == recomputed
+    const recomputed = computeFingerprint(rawKey)
+    if (envelope.fingerprint !== recomputed || dnsFingerprint !== recomputed) {
+      return {
+        ok: false,
+        reason: `fingerprint mismatch — DNS: ${dnsFingerprint.slice(0, 12)}…, envelope: ${envelope.fingerprint.slice(0, 12)}…, computed: ${recomputed.slice(0, 12)}…`,
+        domain: cleanDomain, slug, agentHost,
+      }
+    }
+    keyFingerprint = recomputed
   } catch (e) {
-    return { ok: false, reason: `OEP key fetch error: ${(e as Error).message}`, domain, slug, agentHost }
+    return { ok: false, reason: `OEP key error: ${(e as Error).message}`, domain: cleanDomain, slug, agentHost }
   }
 
-  // (3) DNS TXT fingerprint check (Phase 1 chain)
-  let dnsFingerprint: string
+  // (5) Fetch project git_evidence
+  let evidence: GitEvidence
+  let signature: EvidenceSignature
   try {
-    const records = await resolveTxt(`_oep.${cleanDomain}`)
-    const flat = records.flat().join('')
-    const parsed = parseTxtRecord(flat)
-    if (!parsed) return { ok: false, reason: `_oep.${cleanDomain} TXT record missing or malformed`, domain, slug, agentHost }
-    dnsFingerprint = parsed.fp
-  } catch {
-    return { ok: false, reason: `DNS lookup failed for _oep.${cleanDomain}`, domain, slug, agentHost }
+    const res = await fetch(`${baseUrl}/projects/${slug}`)
+    if (!res.ok) return { ok: false, reason: `project fetch failed: ${res.status}`, domain: cleanDomain, slug, agentHost }
+    const project = await res.json() as Record<string, unknown>
+    const ev = project.git_evidence as GitEvidence | undefined
+    if (!ev) return { ok: false, reason: 'no git_evidence on project — run sync first', domain: cleanDomain, slug, agentHost }
+    if (!ev.signature) return { ok: false, reason: 'git_evidence present but unsigned — configure OEP_PRIVATE_KEY and re-run sync', domain: cleanDomain, slug, agentHost }
+    evidence = ev
+    signature = ev.signature
+  } catch (e) {
+    return { ok: false, reason: `project fetch error: ${(e as Error).message}`, domain: cleanDomain, slug, agentHost }
   }
 
-  if (dnsFingerprint !== keyFingerprint) {
+  // (6) Validate evidence signature fingerprint matches the verified key
+  if (signature.fingerprint !== keyFingerprint) {
     return {
       ok: false,
-      reason: `DNS fingerprint (${dnsFingerprint.slice(0, 12)}…) does not match key fingerprint (${keyFingerprint.slice(0, 12)}…)`,
-      domain, slug, agentHost,
-      details: { dns_fingerprint: dnsFingerprint, key_fingerprint: keyFingerprint, signature_valid: false },
+      reason: `evidence signature fingerprint (${signature.fingerprint.slice(0, 12)}…) does not match OEP key (${keyFingerprint.slice(0, 12)}…) — evidence may have been signed by a different key`,
+      domain: cleanDomain, slug, agentHost,
+      details: { dns_fingerprint: dnsFingerprint, key_fingerprint: keyFingerprint, signature_fingerprint: signature.fingerprint, signature_valid: false },
     }
   }
 
-  // (4) Verify signature
+  // (7) Verify Ed25519 signature over canonical JSON
   const { signature: _sig, ...payload } = evidence
   const valid = verifyEvidenceSignature(payload, signature.value, rawKey)
 
-  if (!valid) {
-    return {
-      ok: false,
-      reason: 'Ed25519 signature verification failed — evidence may have been tampered with',
-      domain, slug, agentHost,
-      details: { dns_fingerprint: dnsFingerprint, key_fingerprint: keyFingerprint, signature_valid: false },
-    }
-  }
-
   return {
-    ok: true,
-    reason: `git evidence for '${slug}' is signed by the OEP key for ${cleanDomain} and has not been tampered with`,
-    domain, slug, agentHost,
-    details: { dns_fingerprint: dnsFingerprint, key_fingerprint: keyFingerprint, signature_valid: true },
+    ok: valid,
+    reason: valid
+      ? `git evidence for '${slug}' is signed by the OEP key for ${cleanDomain} and has not been tampered with`
+      : 'Ed25519 signature verification failed — evidence may have been tampered with',
+    domain: cleanDomain, slug, agentHost,
+    details: { dns_fingerprint: dnsFingerprint, key_fingerprint: keyFingerprint, signature_fingerprint: signature.fingerprint, signature_valid: valid },
   }
 }
 
@@ -129,8 +150,9 @@ const result = await verifyGitEvidence(domain, slug)
 const status = result.ok ? 'PASS' : 'FAIL'
 console.log(`OEP git evidence: ${status} — ${result.reason}`)
 if (result.details) {
-  console.log(`  DNS fingerprint:  ${result.details.dns_fingerprint}`)
-  console.log(`  Key fingerprint:  ${result.details.key_fingerprint}`)
-  console.log(`  Signature valid:  ${result.details.signature_valid}`)
+  console.log(`  DNS fingerprint:       ${result.details.dns_fingerprint}`)
+  console.log(`  Key fingerprint:       ${result.details.key_fingerprint}`)
+  console.log(`  Signature fingerprint: ${result.details.signature_fingerprint}`)
+  console.log(`  Signature valid:       ${result.details.signature_valid}`)
 }
 process.exit(result.ok ? 0 : 1)

--- a/scripts/verify-git-evidence.ts
+++ b/scripts/verify-git-evidence.ts
@@ -1,0 +1,136 @@
+/**
+ * OEP Phase 3 CLI verifier — signed git evidence.
+ *
+ * Usage: npx tsx scripts/verify-git-evidence.ts <domain> <slug>
+ * Example: npx tsx scripts/verify-git-evidence.ts yuens.me resume-agent
+ *
+ * Exit 0 on PASS, exit 1 on FAIL.
+ *
+ * What it verifies:
+ * 1. Fetches the project's git_evidence from the live agent endpoint
+ * 2. Fetches the OEP public key from /.well-known/oep-public-key.json
+ * 3. Confirms the key fingerprint matches the _oep.<domain> DNS TXT record (Phase 1 chain)
+ * 4. Verifies the Ed25519 signature over the canonical JSON of the evidence
+ *
+ * A PASS means: whoever controls <domain> signed this evidence, and it hasn't been tampered with.
+ */
+
+import { resolveTxt } from 'node:dns/promises'
+import {
+  decodePublicKey,
+  fingerprint as computeFingerprint,
+  parseTxtRecord,
+  verifyEvidenceSignature,
+} from '../src/lib/oep-key.js'
+import type { GitEvidence, EvidenceSignature } from '../src/types.js'
+
+interface VerifyEvidenceResult {
+  ok: boolean
+  reason: string
+  domain: string
+  slug: string
+  agentHost?: string
+  details?: {
+    dns_fingerprint: string
+    key_fingerprint: string
+    signature_valid: boolean
+  }
+}
+
+async function verifyGitEvidence(domain: string, slug: string): Promise<VerifyEvidenceResult> {
+  const cleanDomain = domain.replace(/^https?:\/\//, '').replace(/\/.*$/, '').replace(/:\d+$/, '').trim()
+  if (!cleanDomain) return { ok: false, reason: 'empty domain', domain, slug }
+
+  const agentHost = `agent.${cleanDomain}`
+  const baseUrl = `https://${agentHost}`
+
+  // (1) Fetch project git_evidence
+  let evidence: GitEvidence
+  let signature: EvidenceSignature
+  try {
+    const res = await fetch(`${baseUrl}/projects/${slug}`)
+    if (!res.ok) return { ok: false, reason: `project fetch failed: ${res.status}`, domain, slug, agentHost }
+    const project = await res.json() as Record<string, unknown>
+    const ev = project.git_evidence as GitEvidence | undefined
+    if (!ev) return { ok: false, reason: 'no git_evidence on project — run sync first', domain, slug, agentHost }
+    if (!ev.signature) return { ok: false, reason: 'git_evidence present but unsigned — configure OEP_PRIVATE_KEY and re-run sync', domain, slug, agentHost }
+    evidence = ev
+    signature = ev.signature
+  } catch (e) {
+    return { ok: false, reason: `project fetch error: ${(e as Error).message}`, domain, slug, agentHost }
+  }
+
+  // (2) Fetch OEP public key
+  let rawKey: Uint8Array
+  let keyFingerprint: string
+  try {
+    const res = await fetch(`${baseUrl}/.well-known/oep-public-key.json`)
+    if (!res.ok) return { ok: false, reason: `OEP key fetch failed: ${res.status}`, domain, slug, agentHost }
+    const envelope = await res.json() as { key?: string; fingerprint?: string }
+    if (!envelope.key) return { ok: false, reason: 'OEP key envelope missing key field', domain, slug, agentHost }
+    rawKey = decodePublicKey(envelope.key)
+    keyFingerprint = computeFingerprint(rawKey)
+  } catch (e) {
+    return { ok: false, reason: `OEP key fetch error: ${(e as Error).message}`, domain, slug, agentHost }
+  }
+
+  // (3) DNS TXT fingerprint check (Phase 1 chain)
+  let dnsFingerprint: string
+  try {
+    const records = await resolveTxt(`_oep.${cleanDomain}`)
+    const flat = records.flat().join('')
+    const parsed = parseTxtRecord(flat)
+    if (!parsed) return { ok: false, reason: `_oep.${cleanDomain} TXT record missing or malformed`, domain, slug, agentHost }
+    dnsFingerprint = parsed.fp
+  } catch {
+    return { ok: false, reason: `DNS lookup failed for _oep.${cleanDomain}`, domain, slug, agentHost }
+  }
+
+  if (dnsFingerprint !== keyFingerprint) {
+    return {
+      ok: false,
+      reason: `DNS fingerprint (${dnsFingerprint.slice(0, 12)}…) does not match key fingerprint (${keyFingerprint.slice(0, 12)}…)`,
+      domain, slug, agentHost,
+      details: { dns_fingerprint: dnsFingerprint, key_fingerprint: keyFingerprint, signature_valid: false },
+    }
+  }
+
+  // (4) Verify signature
+  const { signature: _sig, ...payload } = evidence
+  const valid = verifyEvidenceSignature(payload, signature.value, rawKey)
+
+  if (!valid) {
+    return {
+      ok: false,
+      reason: 'Ed25519 signature verification failed — evidence may have been tampered with',
+      domain, slug, agentHost,
+      details: { dns_fingerprint: dnsFingerprint, key_fingerprint: keyFingerprint, signature_valid: false },
+    }
+  }
+
+  return {
+    ok: true,
+    reason: `git evidence for '${slug}' is signed by the OEP key for ${cleanDomain} and has not been tampered with`,
+    domain, slug, agentHost,
+    details: { dns_fingerprint: dnsFingerprint, key_fingerprint: keyFingerprint, signature_valid: true },
+  }
+}
+
+// ── CLI entry point ───────────────────────────────────────
+
+const [,, domain, slug] = process.argv
+if (!domain || !slug) {
+  console.error('Usage: npx tsx scripts/verify-git-evidence.ts <domain> <slug>')
+  console.error('Example: npx tsx scripts/verify-git-evidence.ts yuens.me resume-agent')
+  process.exit(1)
+}
+
+const result = await verifyGitEvidence(domain, slug)
+const status = result.ok ? 'PASS' : 'FAIL'
+console.log(`OEP git evidence: ${status} — ${result.reason}`)
+if (result.details) {
+  console.log(`  DNS fingerprint:  ${result.details.dns_fingerprint}`)
+  console.log(`  Key fingerprint:  ${result.details.key_fingerprint}`)
+  console.log(`  Signature valid:  ${result.details.signature_valid}`)
+}
+process.exit(result.ok ? 0 : 1)

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import resumeRoute from './routes/resume.js'
 import agentCardRoute from './routes/agent-card.js'
 import openApiRoute from './routes/openapi.js'
 import qrRoute from './routes/qr.js'
+import verifyRoute from './routes/verify.js'
 import profileRoute from './routes/profile.js'
 import projectsRoute from './routes/projects.js'
 import mcpRoute from './routes/mcp.js'
@@ -110,6 +111,7 @@ app.route('/mcp', mcpRoute)
 app.route('/public-mcp', publicMcpRoute)
 app.route('/', oauthRoute)
 
+app.route('/verify', verifyRoute)
 app.get('/health', (c) => {
   c.header('Cache-Control', 'no-store')
   return c.json({ status: 'ok' })

--- a/src/lib/oep-key.ts
+++ b/src/lib/oep-key.ts
@@ -80,11 +80,16 @@ function base64url(buf: Buffer): string {
  * Both signer and verifier must use this to produce identical byte strings.
  */
 export function canonicalJson(obj: unknown): string {
+  if (obj === undefined) return 'null'
   if (obj === null || typeof obj !== 'object' || Array.isArray(obj)) {
-    return JSON.stringify(obj)
+    const s = JSON.stringify(obj)
+    return s ?? 'null'
   }
-  const keys = Object.keys(obj as object).sort()
-  const parts = keys.map(k => `${JSON.stringify(k)}:${canonicalJson((obj as Record<string, unknown>)[k])}`)
+  const record = obj as Record<string, unknown>
+  const keys = Object.keys(record)
+    .filter(k => record[k] !== undefined && typeof record[k] !== 'function' && typeof record[k] !== 'symbol')
+    .sort()
+  const parts = keys.map(k => `${JSON.stringify(k)}:${canonicalJson(record[k])}`)
   return `{${parts.join(',')}}`
 }
 

--- a/src/lib/oep-key.ts
+++ b/src/lib/oep-key.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto'
+import { createHash, createPrivateKey, createPublicKey, sign, verify } from 'node:crypto'
 
 const VERSION = 'oep1'
 const ALG = 'ed25519'
@@ -71,4 +71,65 @@ export function parseTxtRecord(value: string): { version: string; alg: string; f
 
 function base64url(buf: Buffer): string {
   return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+// ── Signing ───────────────────────────────────────────────
+
+/**
+ * Produce deterministic canonical JSON: sorted keys, no whitespace, recursive.
+ * Both signer and verifier must use this to produce identical byte strings.
+ */
+export function canonicalJson(obj: unknown): string {
+  if (obj === null || typeof obj !== 'object' || Array.isArray(obj)) {
+    return JSON.stringify(obj)
+  }
+  const keys = Object.keys(obj as object).sort()
+  const parts = keys.map(k => `${JSON.stringify(k)}:${canonicalJson((obj as Record<string, unknown>)[k])}`)
+  return `{${parts.join(',')}}`
+}
+
+// PKCS8 DER header for Ed25519 private key (seed): RFC 5958
+const ED25519_PRIVATE_DER_HEADER = Buffer.from('302e020100300506032b657004220420', 'hex')
+// SPKI DER header for Ed25519 public key: RFC 5480
+const ED25519_PUBLIC_DER_HEADER = Buffer.from('302a300506032b6570032100', 'hex')
+
+/**
+ * Load the OEP private key from `OEP_PRIVATE_KEY` env var.
+ * Returns raw 32-byte seed, or null if not configured.
+ * Call only from sync/CLI scripts — never on the public HTTP surface.
+ */
+export function loadPrivateKeyFromEnv(env: NodeJS.ProcessEnv = process.env): Uint8Array | null {
+  const encoded = env.OEP_PRIVATE_KEY
+  if (!encoded) return null
+  const padded = encoded.replace(/-/g, '+').replace(/_/g, '/')
+  const buf = Buffer.from(padded, 'base64')
+  if (buf.length !== 32) throw new Error(`OEP private key must be 32 bytes, got ${buf.length}`)
+  return new Uint8Array(buf)
+}
+
+/**
+ * Sign `data` (as canonical JSON) with the Ed25519 private key seed.
+ * Returns base64url-encoded signature.
+ */
+export function signEvidence(data: object, privateKeyRaw: Uint8Array): string {
+  const der = Buffer.concat([ED25519_PRIVATE_DER_HEADER, Buffer.from(privateKeyRaw)])
+  const key = createPrivateKey({ key: der, format: 'der', type: 'pkcs8' })
+  const payload = Buffer.from(canonicalJson(data), 'utf8')
+  return base64url(sign(null, payload, key))
+}
+
+/**
+ * Verify a signature produced by `signEvidence`.
+ * Returns true if the signature is valid, false otherwise.
+ */
+export function verifyEvidenceSignature(data: object, sigBase64url: string, publicKeyRaw: Uint8Array): boolean {
+  try {
+    const der = Buffer.concat([ED25519_PUBLIC_DER_HEADER, Buffer.from(publicKeyRaw)])
+    const key = createPublicKey({ key: der, format: 'der', type: 'spki' })
+    const payload = Buffer.from(canonicalJson(data), 'utf8')
+    const sig = Buffer.from(sigBase64url.replace(/-/g, '+').replace(/_/g, '/'), 'base64')
+    return verify(null, payload, key, sig)
+  } catch {
+    return false
+  }
 }

--- a/src/routes/verify.ts
+++ b/src/routes/verify.ts
@@ -1,0 +1,74 @@
+import { Hono } from 'hono'
+import { supabase } from '../lib/supabase.js'
+import { loadPublicKeyFromEnv, verifyEvidenceSignature } from '../lib/oep-key.js'
+import type { GitEvidence } from '../types.js'
+
+const app = new Hono()
+
+/**
+ * GET /verify/git-evidence?slug=<slug>
+ *
+ * Public endpoint — verify the OEP Phase 3 signature on a project's git evidence.
+ * Returns a structured result any AI or verifier can act on.
+ */
+app.get('/git-evidence', async (c) => {
+  const slug = c.req.query('slug')
+  if (!slug) return c.json({ error: 'Missing required query param: slug' }, 400)
+
+  const { data, error } = await supabase
+    .from('public_profile')
+    .select('projects, contact')
+    .eq('id', '00000000-0000-0000-0000-000000000001')
+    .single()
+
+  if (error || !data) return c.json({ error: 'Profile not found' }, 404)
+
+  const projects = (data.projects ?? []) as Array<Record<string, unknown>>
+  const project = projects.find(p => p.slug === slug)
+  if (!project) return c.json({ error: `Project '${slug}' not found` }, 404)
+
+  const evidence = project.git_evidence as GitEvidence | undefined
+  if (!evidence) {
+    return c.json({
+      slug,
+      evidence_signature: 'not_present',
+      summary: `No git evidence on record for '${slug}' — runs on next nightly sync.`,
+    })
+  }
+
+  const { signature, ...payload } = evidence
+  if (!signature) {
+    return c.json({
+      slug,
+      evidence_signature: 'unsigned',
+      summary: `Git evidence present but not yet signed — configure OEP_PRIVATE_KEY and re-run sync.`,
+    })
+  }
+
+  const loaded = loadPublicKeyFromEnv()
+  if (!loaded) {
+    return c.json({
+      slug,
+      evidence_signature: 'key_not_configured',
+      summary: 'OEP public key not configured on this instance.',
+    }, 503)
+  }
+
+  const valid = verifyEvidenceSignature(payload, signature.value, loaded.rawKey)
+  const baseUrl = (process.env.PUBLIC_URL ?? new URL(c.req.url).origin).replace(/\/$/, '')
+
+  return c.json({
+    slug,
+    domain: baseUrl.replace(/^https?:\/\/agent\./, '').replace(/^https?:\/\//, ''),
+    oep_phase1: 'see /.well-known/oep-public-key.json',
+    evidence_signature: valid ? 'pass' : 'fail',
+    key_fingerprint: signature.fingerprint,
+    signed_at: signature.signed_at,
+    verified_at: new Date().toISOString(),
+    summary: valid
+      ? `VERIFIED — git evidence for '${slug}' is signed by the OEP key at ${signature.key_url} and has not been tampered with.`
+      : `FAIL — signature verification failed. The evidence may have been tampered with or signed by a different key.`,
+  })
+})
+
+export default app

--- a/src/routes/verify.ts
+++ b/src/routes/verify.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import { supabase } from '../lib/supabase.js'
-import { loadPublicKeyFromEnv, verifyEvidenceSignature } from '../lib/oep-key.js'
+import { loadPublicKeyFromEnv, verifyEvidenceSignature, fingerprint as computeFingerprint } from '../lib/oep-key.js'
 import type { GitEvidence } from '../types.js'
 
 const app = new Hono()
@@ -45,13 +45,26 @@ app.get('/git-evidence', async (c) => {
     })
   }
 
-  const loaded = loadPublicKeyFromEnv()
+  let loaded: ReturnType<typeof loadPublicKeyFromEnv>
+  try {
+    loaded = loadPublicKeyFromEnv()
+  } catch {
+    return c.json({ slug, evidence_signature: 'key_not_configured', summary: 'OEP public key misconfigured on this instance.' }, 503)
+  }
   if (!loaded) {
+    return c.json({ slug, evidence_signature: 'key_not_configured', summary: 'OEP public key not configured on this instance.' }, 503)
+  }
+
+  // Compute fingerprint from the actual key in use — never trust attacker-controlled metadata
+  const actualFingerprint = computeFingerprint(loaded.rawKey)
+  if (signature.fingerprint !== actualFingerprint) {
     return c.json({
       slug,
-      evidence_signature: 'key_not_configured',
-      summary: 'OEP public key not configured on this instance.',
-    }, 503)
+      evidence_signature: 'fail',
+      signed_at: signature.signed_at,
+      verified_at: new Date().toISOString(),
+      summary: `FAIL — evidence fingerprint does not match this instance's OEP key. Evidence may have been signed by a different key.`,
+    })
   }
 
   const valid = verifyEvidenceSignature(payload, signature.value, loaded.rawKey)
@@ -62,12 +75,12 @@ app.get('/git-evidence', async (c) => {
     domain: baseUrl.replace(/^https?:\/\/agent\./, '').replace(/^https?:\/\//, ''),
     oep_phase1: 'see /.well-known/oep-public-key.json',
     evidence_signature: valid ? 'pass' : 'fail',
-    key_fingerprint: signature.fingerprint,
+    key_fingerprint: actualFingerprint,
     signed_at: signature.signed_at,
     verified_at: new Date().toISOString(),
     summary: valid
       ? `VERIFIED — git evidence for '${slug}' is signed by the OEP key at ${signature.key_url} and has not been tampered with.`
-      : `FAIL — signature verification failed. The evidence may have been tampered with or signed by a different key.`,
+      : `FAIL — signature verification failed. The evidence may have been tampered with.`,
   })
 })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,14 @@ export interface Project {
   git_evidence?: GitEvidence
 }
 
+export interface EvidenceSignature {
+  alg: 'ed25519'
+  key_url: string       // URL to /.well-known/oep-public-key.json
+  fingerprint: string   // base64url SHA256 of raw public key (same as Phase 1)
+  value: string         // base64url Ed25519 signature over canonical JSON of evidence
+  signed_at: string     // ISO timestamp
+}
+
 export interface GitEvidence {
   verified_at: string
   repo_created_at: string   // YYYY-MM-DD — when the repo was created on the host
@@ -64,6 +72,7 @@ export interface GitEvidence {
     test_files: number
   }
   source: string
+  signature?: EvidenceSignature
 }
 
 export interface PeerAttestation {

--- a/tests/oep-domain.test.ts
+++ b/tests/oep-domain.test.ts
@@ -18,6 +18,9 @@ import {
   fingerprint,
   loadPublicKeyFromEnv,
   parseTxtRecord,
+  canonicalJson,
+  signEvidence,
+  verifyEvidenceSignature,
 } from '../src/lib/oep-key.js'
 import oepRoute from '../src/routes/oep.js'
 import { verifyOepDomain } from '../scripts/verify-oep-domain.js'
@@ -271,5 +274,83 @@ describe('buildEnvelope()', () => {
     assert.deepEqual(Object.keys(env).sort(), ['alg', 'fingerprint', 'issued_at', 'key', 'version'])
     assert.equal(env.alg, 'ed25519')
     assert.equal(env.version, 'oep1')
+  })
+})
+
+// ── Phase 3: canonicalJson + sign/verify ─────────────────
+
+describe('canonicalJson', () => {
+  it('sorts keys alphabetically at top level', () => {
+    const result = canonicalJson({ z: 1, a: 2, m: 3 })
+    assert.equal(result, '{"a":2,"m":3,"z":1}')
+  })
+
+  it('sorts keys recursively in nested objects', () => {
+    const result = canonicalJson({ b: { z: 1, a: 2 }, a: 'x' })
+    assert.equal(result, '{"a":"x","b":{"a":2,"z":1}}')
+  })
+
+  it('is deterministic regardless of insertion order', () => {
+    const a = canonicalJson({ commit_count: 142, repo_created_at: '2026-03-01', source: 'https://github.com/x/y' })
+    const b = canonicalJson({ source: 'https://github.com/x/y', commit_count: 142, repo_created_at: '2026-03-01' })
+    assert.equal(a, b)
+  })
+
+  it('handles null and array values without sorting', () => {
+    const result = canonicalJson({ tags: ['b', 'a'], n: null })
+    assert.equal(result, '{"n":null,"tags":["b","a"]}')
+  })
+
+  it('returns primitive JSON for non-object inputs', () => {
+    assert.equal(canonicalJson(42), '42')
+    assert.equal(canonicalJson('hello'), '"hello"')
+    assert.equal(canonicalJson(null), 'null')
+  })
+})
+
+describe('signEvidence + verifyEvidenceSignature', () => {
+  const { rawPublic, encodedPrivate } = makeKeypair()
+  // Decode private seed from base64url (same as loadPrivateKeyFromEnv logic)
+  const rawPrivate = new Uint8Array(Buffer.from(encodedPrivate.replace(/-/g, '+').replace(/_/g, '/'), 'base64'))
+
+  const sampleEvidence = {
+    verified_at: '2026-06-01T00:00:00.000Z',
+    repo_created_at: '2026-03-01',
+    last_push_at: '2026-06-01',
+    commit_count: 142,
+    contributors: 1,
+    default_branch: 'main',
+    provider: 'github',
+    repo_stats: { total_files: 87, typescript_files: 48, test_files: 19 },
+    source: 'https://github.com/yuens1002/resume-agent',
+  }
+
+  it('produces a non-empty base64url signature string', () => {
+    const sig = signEvidence(sampleEvidence, rawPrivate)
+    assert.ok(typeof sig === 'string' && sig.length > 0)
+    assert.ok(!/[+/=]/.test(sig), 'should be base64url (no +, /, or =)')
+  })
+
+  it('verifies a valid signature', () => {
+    const sig = signEvidence(sampleEvidence, rawPrivate)
+    assert.ok(verifyEvidenceSignature(sampleEvidence, sig, rawPublic))
+  })
+
+  it('rejects a tampered payload', () => {
+    const sig = signEvidence(sampleEvidence, rawPrivate)
+    const tampered = { ...sampleEvidence, commit_count: 999 }
+    assert.ok(!verifyEvidenceSignature(tampered, sig, rawPublic))
+  })
+
+  it('rejects a signature from a different key', () => {
+    const { rawPublic: otherPub, encodedPrivate: otherPrivEnc } = makeKeypair()
+    const otherPriv = new Uint8Array(Buffer.from(otherPrivEnc.replace(/-/g, '+').replace(/_/g, '/'), 'base64'))
+    const sig = signEvidence(sampleEvidence, otherPriv)
+    assert.ok(!verifyEvidenceSignature(sampleEvidence, sig, rawPublic))
+    assert.ok(verifyEvidenceSignature(sampleEvidence, sig, otherPub))
+  })
+
+  it('rejects a malformed signature string', () => {
+    assert.ok(!verifyEvidenceSignature(sampleEvidence, 'not-a-real-sig', rawPublic))
   })
 })


### PR DESCRIPTION
**Version:** 0.4.33 → 0.4.34

Closes #120

## Summary

Completes the OEP verification chain. After this PR:

```
DNS (_oep.yuens.me) → OEP key → git_evidence → Ed25519 signature → /verify endpoint
```

Every link is independently verifiable by any third party.

### New: `src/lib/oep-key.ts` signing functions
- `canonicalJson(obj)` — recursive deterministic JSON (sorted keys, no whitespace) for consistent signing
- `loadPrivateKeyFromEnv()` — reads `OEP_PRIVATE_KEY` env var (sync/CLI only, never HTTP surface)
- `signEvidence(data, privateKeyRaw)` — Ed25519 signature over canonical JSON, base64url encoded
- `verifyEvidenceSignature(data, sig, publicKeyRaw)` — verification counterpart

### New: `EvidenceSignature` type + `signature?` on `GitEvidence`
Each nightly sync signs the evidence block if `OEP_PRIVATE_KEY` is configured in Railway.

### New: `GET /verify/git-evidence?slug=<slug>`
Public endpoint. Returns structured pass/fail for the evidence signature. AIs and verifiers can call this directly.

### New: `scripts/verify-git-evidence.ts <domain> <slug>`
CLI verifier. Walks the full chain: DNS fingerprint (Phase 1) → public key → signature verification (Phase 3). Exit 0/PASS or 1/FAIL.

### README + docs
New **"Fork the code. Your identity is yours."** section explains the architectural arc in plain language: MIT licenses the code; OEP proves the identity. The License section is expanded to make this explicit. `docs/plans/oep-verification.md` gets the same one-paragraph summary at the top.

## Test plan
- [ ] `npm run test:unit` — 306/306 pass including 10 new tests for `canonicalJson`, `signEvidence`, `verifyEvidenceSignature`
- [ ] `tsc --noEmit` — no errors
- [ ] `npm run sync` — console shows `✔ git_evidence signed` per project (requires `OEP_PRIVATE_KEY` in env)
- [ ] `GET /projects/resume-agent` — `git_evidence.signature` present after sync
- [ ] `GET /verify/git-evidence?slug=resume-agent` → `"evidence_signature": "pass"`
- [ ] `npx tsx scripts/verify-git-evidence.ts yuens.me resume-agent` → `OEP git evidence: PASS`