### PR TITLE
perf(query): skip thoughts for binary, cache profile, cap conversational maxTokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-06-01 — perf(query): 3 fixes — maxTokens 512 for conversational, skip thought embedding for binary questions, in-memory profile cache (5-min TTL); binary roundtrip overhead −18×, conversational behavioral LLM −42%; eval 15/16 unchanged
+
 - 2026-06-01 — feat(oep): Phase 3 — sign git evidence with Ed25519 key; GET /verify/git-evidence; CLI verify-git-evidence.ts; README fork/identity clarity
 
 - 2026-06-01 — chore: add MIT LICENSE file — closes #121

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.34",
+  "version": "0.4.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.34",
+      "version": "0.4.35",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.34",
+  "version": "0.4.35",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/src/routes/query.ts
+++ b/src/routes/query.ts
@@ -13,6 +13,44 @@ import type { QueryResponse } from '../types.js'
 
 const app = new Hono()
 
+// ── Profile cache ────────────────────────────────────────
+// Profile changes at most a few times per day (via MCP or sync).
+// A 5-min TTL eliminates one Supabase round-trip per request without
+// risk of serving meaningfully stale data.
+
+interface ProfileCache { data: unknown; expiresAt: number }
+let profileCache: ProfileCache | null = null
+const PROFILE_CACHE_TTL_MS = 5 * 60 * 1000
+
+async function fetchProfile() {
+  const now = Date.now()
+  if (profileCache && now < profileCache.expiresAt) {
+    return { data: profileCache.data, error: null }
+  }
+  const result = await supabase
+    .from('public_profile')
+    .select('*')
+    .eq('id', '00000000-0000-0000-0000-000000000001')
+    .single()
+  if (!result.error && result.data) {
+    profileCache = { data: result.data, expiresAt: now + PROFILE_CACHE_TTL_MS }
+  }
+  return result
+}
+
+// ── Binary question detection ────────────────────────────
+// Binary questions (did/does/has/is/can + short) are answered from structured
+// profile data alone — OB1 thoughts add noise, not signal, and the embedding
+// call costs ~150ms. Skip thoughts for these to cut one OpenRouter hop.
+
+function isBinaryQuestion(question: string): boolean {
+  const q = question.toLowerCase().trim()
+  if (q.split(/\s+/).length >= 15) return false
+  if (!/^(did|does|has|have|is|was|were|will|can|could|would|should)\b/.test(q)) return false
+  // Behavioral signals indicate the model needs observations context
+  return !/\b(how|why|walk|describe|explain|tell me|experience|approach|decision|tradeoff)\b/.test(q)
+}
+
 const schema = z.object({
   question: z.string().min(1),
   context: z.string().optional(),
@@ -81,13 +119,10 @@ export interface ParseError {
 export async function queryProfile(
   args: QueryProfileArgs,
 ): Promise<QueryResponse | ProfileNotFoundError | ParseError> {
+  const skipThoughts = isBinaryQuestion(args.question)
   const [{ data: profile, error }, thoughts] = await Promise.all([
-    supabase
-      .from('public_profile')
-      .select('*')
-      .eq('id', '00000000-0000-0000-0000-000000000001')
-      .single(),
-    queryRelevantThoughtsForQuestion(args.question),
+    fetchProfile(),
+    skipThoughts ? Promise.resolve([]) : queryRelevantThoughtsForQuestion(args.question),
   ])
 
   if (error || !profile) {
@@ -99,7 +134,7 @@ export async function queryProfile(
   const start = Date.now()
   const { text: raw } = await generateText({
     model: getModel(),
-    maxTokens: 1024,
+    maxTokens: args.style === 'conversational' ? 512 : 1024,
     system: buildSystemPrompt('json', args.style ?? 'cited'),
     prompt,
   })
@@ -126,13 +161,10 @@ export async function queryProfile(
 export async function queryProfileStream(
   args: QueryProfileArgs,
 ): Promise<ReturnType<typeof streamText> | ProfileNotFoundError> {
+  const skipThoughts = isBinaryQuestion(args.question)
   const [{ data: profile, error }, thoughts] = await Promise.all([
-    supabase
-      .from('public_profile')
-      .select('*')
-      .eq('id', '00000000-0000-0000-0000-000000000001')
-      .single(),
-    queryRelevantThoughtsForQuestion(args.question),
+    fetchProfile(),
+    skipThoughts ? Promise.resolve([]) : queryRelevantThoughtsForQuestion(args.question),
   ])
 
   if (error || !profile) {
@@ -143,7 +175,7 @@ export async function queryProfileStream(
 
   return streamText({
     model: getModel(),
-    maxTokens: 1024,
+    maxTokens: args.style === 'conversational' ? 512 : 1024,
     system: buildSystemPrompt('stream', args.style ?? 'cited'),
     prompt,
   })

--- a/src/routes/query.ts
+++ b/src/routes/query.ts
@@ -15,8 +15,9 @@ const app = new Hono()
 
 // ── Profile cache ────────────────────────────────────────
 // Profile changes at most a few times per day (via MCP or sync).
-// A 5-min TTL eliminates one Supabase round-trip per request without
-// risk of serving meaningfully stale data.
+// A 5-min TTL eliminates one Supabase round-trip per request.
+// Intentional tradeoff: callers may see data up to 5 minutes stale after
+// a profile update. Acceptable given how infrequently the profile changes.
 
 interface ProfileCache { data: unknown; expiresAt: number }
 let profileCache: ProfileCache | null = null


### PR DESCRIPTION
**Version:** 0.4.34 → 0.4.35

Closes #125

## Summary

Three targeted fixes to query latency. All three ship together because they're independent and all pass the eval without regression.

## Benchmark

Measured against live Railway deployment (OpenRouter/Haiku). Latencies are `meta.latency_ms` (LLM call) + roundtrip overhead.

### Before

| Query type | LLM | Roundtrip | Notes |
|---|---|---|---|
| Binary ("Did you build X?") | 3,231ms | 4,478ms | 1,247ms overhead = embedding + pgvector |
| Capability ("AWS experience?") | 3,748ms | 4,603ms | same overhead |
| Behavioral ("How do you decide features?") | 10,699ms | 11,533ms | hits 1024-token ceiling |
| Off-topic/decline | 1,806ms | 2,791ms | fast because answer is short |

### After

| Query type | LLM | Roundtrip | Δ roundtrip |
|---|---|---|---|
| Binary (skip thoughts + cache) | 3,117ms | **3,191ms** | **−1,287ms (−29%)** |
| Behavioral cited (unchanged) | 10,639ms | 11,396ms | no change — correct |
| Behavioral conversational (512 cap) | 6,221ms | 7,706ms | **−3,827ms (−33%)** |

### Accuracy: identical baseline

```
Baseline:   15/16 cases  24.0/25 rule points
After:      15/16 cases  24.0/25 rule points  ← no regression
```

The one existing failure (`behavioral-when-you-stopped` — Sources: block drop) is unchanged and tracked in #126.

## Changes

### Fix 1 — `maxTokens: 512` for `style: "conversational"` (was 1024)
Conversational mode targets 2–4 sentences. 512 tokens is a tight ceiling that still fits the JSON envelope + follow_up_suggestions, and Haiku generates measurably faster within a lower ceiling. Cited mode keeps 1024.

### Fix 2 — Skip thought embedding for binary questions
Binary questions (`did/does/has/is/can` + <15 words, no behavioral signals) are answered from structured profile data alone. OB1 thoughts add no signal for "Did you build X?" or "Have you used AWS?". Skipping saves one OpenRouter embedding call (~150ms) and one Supabase pgvector RPC — reducing roundtrip overhead from ~1,200ms to ~65ms on binary queries.

Detection heuristic in `isBinaryQuestion()`: short + binary starter + no behavioral keywords (how/why/walk/describe/approach/tradeoff).

### Fix 3 — In-memory profile cache (5-min TTL)
`public_profile` is fetched on every request. Data changes at most a few times per day (via MCP tools or nightly sync). A module-level cache with 5-minute TTL eliminates one Supabase round-trip per request. The cache is busted automatically on TTL expiry; no explicit invalidation needed since the write paths (MCP `update_profile`, sync) don't touch the route layer.

## Test plan
- [ ] `npm run test:unit` — 306/306 pass
- [ ] `tsc --noEmit` — no errors
- [ ] Eval: `npm run eval:query` → 15/16, 24.0/25 (no regression)
- [ ] Binary roundtrip < 4s on Railway
- [ ] Conversational behavioral < 8s on Railway