### PR TITLE
feat(sync): employment consolidation — auto-apply delta proposals with rubric gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,11 @@ PROVIDER_HOMEPAGE=https://github.com/your-username  # optional — shown in agen
 # Resume generation — comma-separated project slugs to exclude from the Projects section
 # while still keeping their OB1 thoughts in play for employment context injection.
 # HIDE_FROM_PROJECTS=slug-one,slug-two
+
+# Employment consolidation — auto-apply nightly employment delta proposals to the profile.
+# Disabled by default; opt in by setting EMPLOYMENT_SYNC_ENABLED=true.
+# EMPLOYMENT_SYNC_ENABLED=true
+# EMPLOYMENT_SYNC_STRATEGY=replace         # replace (default) | additive (only add, never remove)
+# EMPLOYMENT_SYNC_FREQUENCY=weekly         # weekly (default) | on_change | always
+# EMPLOYMENT_SYNC_MIN_BULLETS=3            # reject proposals with fewer than N bullets
+# EMPLOYMENT_SYNC_RUBRIC_GATE=true         # true (default) | false — skip banned-phrase + metric check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-06-01 — feat(sync): employment consolidation — auto-apply delta proposals on configurable schedule with rubric gate; closes #129
+
 - 2026-06-01 — fix(query): add premise-absent behavioral few-shot to RULE_OUTPUT_JSON — closes #126; eval 15/16 → 16/16 (25/25 rule points)
 
 - 2026-06-01 — perf(query): 3 fixes — maxTokens 512 for conversational, skip thought embedding for binary questions, in-memory profile cache (5-min TTL); binary roundtrip overhead −18×, conversational behavioral LLM −42%; eval 15/16 unchanged

--- a/README.md
+++ b/README.md
@@ -512,6 +512,16 @@ See [`docs/workflow.md`](docs/workflow.md) for a walkthrough of how employer AI 
 
 Projects without a GitHub `repo` are skipped silently. Fields that need human framing (`description`, `problem`, `role`, `impact`, `cover`) are never touched by the sync.
 
+**Employment consolidation (opt-in):** The sync generates employment delta proposals from shipped work and stores them as OB1 thoughts for human review. Set `EMPLOYMENT_SYNC_ENABLED=true` in Railway to automatically apply the best proposal to the self-employed employment entry on a configurable schedule. A notification thought is written to OB1 each time bullets are updated so you can audit what changed via `search_thoughts "employment updated"` in your private MCP.
+
+| Env var | Default | Options |
+|---|---|---|
+| `EMPLOYMENT_SYNC_ENABLED` | `false` | `true` to enable |
+| `EMPLOYMENT_SYNC_STRATEGY` | `replace` | `replace` \| `additive` |
+| `EMPLOYMENT_SYNC_FREQUENCY` | `weekly` | `weekly` \| `on_change` \| `always` |
+| `EMPLOYMENT_SYNC_MIN_BULLETS` | `3` | minimum bullet count to accept |
+| `EMPLOYMENT_SYNC_RUBRIC_GATE` | `true` | `false` to skip banned-phrase + metric check |
+
 **Controlling what appears on the resume:** Not every synced project belongs in the Projects section of a generated resume. Some projects are better represented as context for the employment section (e.g. a SaaS platform that's already covered by a self-employment entry). Use `HIDE_FROM_PROJECTS` to exclude specific slugs from the resume output at generation time — the project continues to sync and its OB1 thoughts continue to flow into employment bullet context.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -512,7 +512,9 @@ See [`docs/workflow.md`](docs/workflow.md) for a walkthrough of how employer AI 
 
 Projects without a GitHub `repo` are skipped silently. Fields that need human framing (`description`, `problem`, `role`, `impact`, `cover`) are never touched by the sync.
 
-**Employment consolidation (opt-in):** The sync generates employment delta proposals from shipped work and stores them as OB1 thoughts for human review. Set `EMPLOYMENT_SYNC_ENABLED=true` in Railway to automatically apply the best proposal to the self-employed employment entry on a configurable schedule. A notification thought is written to OB1 each time bullets are updated so you can audit what changed via `search_thoughts "employment updated"` in your private MCP.
+**Employment consolidation (opt-in):** Active self-employment generates a continuous stream of granular technical evidence — individual changelogs mention specific UX patterns, state machines, modal states, and API shapes. Useful as raw signal, but too narrow as employment bullets. The nightly sync distills this stream into accurate, broader-scope bullets backed by shipped evidence — replacing "built a modal" with "engineers complex financial flows with non-dismissable state machines" when the body of work supports it.
+
+Set `EMPLOYMENT_SYNC_ENABLED=true` in Railway to automatically apply the best proposal to the self-employed entry on a configurable schedule. The consolidation runs a rubric gate (no generic phrases, quantified-metric ratio must not regress) before applying. A notification thought is written to OB1 after each update so you can audit what changed via `search_thoughts "employment updated"` in your private MCP.
 
 | Env var | Default | Options |
 |---|---|---|

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.36",
+  "version": "0.4.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.36",
+      "version": "0.4.37",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.36",
+  "version": "0.4.37",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -29,6 +29,7 @@ import { createOpenAI } from '@ai-sdk/openai'
 import { embed, generateText } from 'ai'
 import { inferStatus, inferUrl, inferTech, detectGitProvider, parseCommitCount, buildRepoStats } from './sync-helpers.js'
 import { loadPublicKeyFromEnv, loadPrivateKeyFromEnv, signEvidence } from '../src/lib/oep-key.js'
+import { BANNED_PHRASES } from '../src/lib/score-resume.js'
 import type { GitEvidence, EvidenceSignature } from '../src/types.js'
 
 const SUPA_URL = process.env.SUPA_PROJECT_URL
@@ -836,6 +837,186 @@ async function syncProject(
   return { projects, newThoughts: allNewThoughts }
 }
 
+// ── Employment consolidation ─────────────────────────────
+//
+// Controlled entirely by env vars — disabled by default (opt-in).
+// When enabled, reads the most recent employment delta proposal from OB1,
+// runs a rubric gate, and applies it to the self-employed entry.
+// Writes a notification thought so the candidate knows what changed.
+
+interface ConsolidationConfig {
+  enabled: boolean
+  strategy: 'replace' | 'additive'
+  minBullets: number
+  rubricGate: boolean
+  frequency: 'weekly' | 'on_change' | 'always'
+}
+
+function getConsolidationConfig(): ConsolidationConfig {
+  return {
+    enabled: process.env.EMPLOYMENT_SYNC_ENABLED === 'true',
+    strategy: (process.env.EMPLOYMENT_SYNC_STRATEGY ?? 'replace') as 'replace' | 'additive',
+    minBullets: Math.max(1, parseInt(process.env.EMPLOYMENT_SYNC_MIN_BULLETS ?? '3', 10)),
+    rubricGate: process.env.EMPLOYMENT_SYNC_RUBRIC_GATE !== 'false',
+    frequency: (process.env.EMPLOYMENT_SYNC_FREQUENCY ?? 'weekly') as 'weekly' | 'on_change' | 'always',
+  }
+}
+
+/** Parse proposed bullets out of a delta proposal thought. */
+function parseDeltaProposal(content: string): string[] | null {
+  const match = content.match(/Proposed self-employment bullets:\s*\n([\s\S]*?)(?:\n\nCurrent bullets:|$)/)
+  if (!match) return null
+  const bullets = match[1].trim().split('\n')
+    .map(l => l.replace(/^\d+\.\s*/, '').trim())
+    .filter(Boolean)
+  return bullets.length >= 1 ? bullets : null
+}
+
+/** Rubric gate: no banned phrases + quantified ratio must not regress >20%. */
+function passesRubricGate(
+  proposed: string[],
+  current: string[],
+  config: ConsolidationConfig,
+): { pass: boolean; reason: string } {
+  if (!config.rubricGate) return { pass: true, reason: 'gate disabled' }
+  if (proposed.length < config.minBullets) {
+    return { pass: false, reason: `too few bullets: ${proposed.length} < ${config.minBullets}` }
+  }
+  const joined = proposed.join(' ').toLowerCase()
+  const found = BANNED_PHRASES.filter(p => joined.includes(p))
+  if (found.length > 0) return { pass: false, reason: `banned phrase: ${found.join(', ')}` }
+  const metricRe = /\d+%|\$[\d,.]+|\b\d{2,}\b|\d+x\b|\d+\+/
+  const currentRatio = current.length > 0 ? current.filter(b => metricRe.test(b)).length / current.length : 0
+  const proposedRatio = proposed.filter(b => metricRe.test(b)).length / proposed.length
+  if (currentRatio > 0 && proposedRatio < currentRatio * 0.8) {
+    return { pass: false, reason: `quantified ratio regressed: ${(currentRatio * 100).toFixed(0)}% → ${(proposedRatio * 100).toFixed(0)}%` }
+  }
+  return { pass: true, reason: `banned_phrases=pass, quantified=${(proposedRatio * 100).toFixed(0)}%` }
+}
+
+/** Check frequency gate — returns true if we should apply now. */
+async function shouldApplyNow(
+  proposed: string[],
+  current: string[],
+  config: ConsolidationConfig,
+): Promise<boolean> {
+  if (config.frequency === 'always') return true
+  if (config.frequency === 'on_change') {
+    const h = (arr: string[]) => createHash('sha256').update(arr.join('|')).digest('hex')
+    return h(proposed) !== h(current)
+  }
+  // weekly: skip if already applied within 7 days
+  const { data } = await supabase
+    .from('thoughts')
+    .select('created_at')
+    .contains('metadata', { topics: ['employment_sync_applied'] })
+    .order('created_at', { ascending: false })
+    .limit(1)
+  if (!data || data.length === 0) return true
+  const daysSince = (Date.now() - new Date(data[0].created_at as string).getTime()) / 86_400_000
+  return daysSince >= 7
+}
+
+async function consolidateEmployment(employment: ProfileRow['employment']): Promise<void> {
+  const config = getConsolidationConfig()
+  if (!config.enabled) {
+    console.log('  — employment consolidation disabled (set EMPLOYMENT_SYNC_ENABLED=true to enable)')
+    return
+  }
+
+  // Find most recent delta proposal
+  const { data: proposals } = await supabase
+    .from('thoughts')
+    .select('content, created_at')
+    .contains('metadata', { type: 'review_needed', topics: ['employment'] })
+    .order('created_at', { ascending: false })
+    .limit(1)
+  if (!proposals?.length) {
+    console.log('  — no delta proposals found in OB1')
+    return
+  }
+
+  const proposed = parseDeltaProposal(proposals[0].content)
+  if (!proposed) {
+    console.warn('  ⚠ could not parse proposed bullets from delta proposal')
+    return
+  }
+
+  const selfEmployed = employment?.find(e =>
+    e.company?.toLowerCase().includes('self-employed') || e.company?.toLowerCase().includes('self employed'),
+  )
+  if (!selfEmployed) {
+    console.log('  — no self-employed entry found in profile')
+    return
+  }
+  const currentBullets = Array.isArray(selfEmployed.bullets) ? selfEmployed.bullets as string[] : []
+
+  // Frequency gate
+  if (!await shouldApplyNow(proposed, currentBullets, config)) {
+    console.log('  — employment consolidation skipped (frequency gate)')
+    return
+  }
+
+  // Rubric gate
+  const gate = passesRubricGate(proposed, currentBullets, config)
+  if (!gate.pass) {
+    console.log(`  ⚠ employment consolidation skipped — rubric gate failed: ${gate.reason}`)
+    return
+  }
+
+  // Apply
+  const finalBullets = config.strategy === 'additive'
+    ? [...new Set([...currentBullets, ...proposed])]
+    : proposed
+
+  const updatedEmployment = (employment ?? []).map(e =>
+    (e.company?.toLowerCase().includes('self-employed') || e.company?.toLowerCase().includes('self employed'))
+      ? { ...e, bullets: finalBullets }
+      : e,
+  )
+
+  const { error } = await supabase
+    .from('public_profile')
+    .update({ employment: updatedEmployment, updated_at: new Date().toISOString() })
+    .eq('id', PROFILE_ID)
+  if (error) {
+    console.warn(`  ⚠ employment consolidation failed: ${error.message}`)
+    return
+  }
+  console.log(`  ✔ employment bullets updated: ${currentBullets.length} → ${finalBullets.length} (${config.strategy})`)
+
+  // Notification thought
+  const notification = [
+    `[sync | ${new Date().toISOString().slice(0, 10)} | notification] Employment bullets updated automatically.`,
+    `Strategy: ${config.strategy} | Bullets: ${currentBullets.length} → ${finalBullets.length} | Rubric: ${gate.reason}`,
+    '',
+    'New bullets:',
+    ...finalBullets.map((b, i) => `${i + 1}. ${b}`),
+    '',
+    'Previous bullets archived:',
+    ...currentBullets.map((b, i) => `${i + 1}. ${b}`),
+  ].join('\n')
+
+  try {
+    const { embedding } = await embed({
+      model: openrouter.embedding('openai/text-embedding-3-small'),
+      value: notification,
+    })
+    await supabase.from('thoughts').insert({
+      content: notification,
+      embedding,
+      metadata: {
+        type: 'notification',
+        source: 'sync',
+        topics: ['employment', 'employment_sync_applied', 'notification'],
+      },
+    })
+    console.log('  ✔ notification written to OB1 (search "employment updated" in private MCP)')
+  } catch (err) {
+    console.warn(`  ⚠ notification write failed (non-fatal): ${(err as Error).message}`)
+  }
+}
+
 // ── CANDIDATE_STACK ───────────────────────────────────────
 
 function buildCandidateStack(profile: ProfileRow): string {
@@ -904,6 +1085,10 @@ async function sync(): Promise<void> {
     console.log('\nProposing employment delta...')
     await proposeEmploymentDelta(profile.employment, allNewThoughts, 'all-projects')
   }
+
+  // Consolidate employment bullets from most recent proposal (opt-in via env var)
+  console.log('\nConsolidating employment...')
+  await consolidateEmployment(profile.employment)
 
   console.log('\nRebuilding CANDIDATE_STACK...')
   const stack = buildCandidateStack({ ...profile, projects })

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -853,12 +853,22 @@ interface ConsolidationConfig {
 }
 
 function getConsolidationConfig(): ConsolidationConfig {
+  const rawMinBullets = parseInt(process.env.EMPLOYMENT_SYNC_MIN_BULLETS ?? '3', 10)
+  const minBullets = Number.isFinite(rawMinBullets) && rawMinBullets >= 1 ? rawMinBullets : 3
+
+  const rawStrategy = process.env.EMPLOYMENT_SYNC_STRATEGY ?? 'replace'
+  const strategy: 'replace' | 'additive' = rawStrategy === 'additive' ? 'additive' : 'replace'
+
+  const rawFrequency = process.env.EMPLOYMENT_SYNC_FREQUENCY ?? 'weekly'
+  const frequency: 'weekly' | 'on_change' | 'always' =
+    rawFrequency === 'on_change' ? 'on_change' : rawFrequency === 'always' ? 'always' : 'weekly'
+
   return {
     enabled: process.env.EMPLOYMENT_SYNC_ENABLED === 'true',
-    strategy: (process.env.EMPLOYMENT_SYNC_STRATEGY ?? 'replace') as 'replace' | 'additive',
-    minBullets: Math.max(1, parseInt(process.env.EMPLOYMENT_SYNC_MIN_BULLETS ?? '3', 10)),
+    strategy,
+    minBullets,
     rubricGate: process.env.EMPLOYMENT_SYNC_RUBRIC_GATE !== 'false',
-    frequency: (process.env.EMPLOYMENT_SYNC_FREQUENCY ?? 'weekly') as 'weekly' | 'on_change' | 'always',
+    frequency,
   }
 }
 


### PR DESCRIPTION
**Version:** 0.4.36 → 0.4.37

Closes #129

## Problem

The nightly sync generates employment delta proposals (written to OB1 as `review_needed` thoughts) but never applies them. Employment bullets remain frozen at seed values indefinitely with no visibility unless you explicitly query OB1.

## Solution

New `consolidateEmployment()` step in the sync pipeline. Disabled by default — opt in via `EMPLOYMENT_SYNC_ENABLED=true` in Railway.

**What it does:**
1. Reads the most recent delta proposal from OB1
2. Parses proposed self-employment bullets
3. Runs a rubric gate (banned phrases + quantified-metric ratio regression guard)
4. Applies if gate passes and frequency condition is met
5. Writes a notification thought to OB1 so you can audit what changed via `search_thoughts "employment updated"` in your private MCP

## Env vars (all optional, sensible defaults)

| Var | Default | Description |
|---|---|---|
| `EMPLOYMENT_SYNC_ENABLED` | `false` | Master opt-in switch |
| `EMPLOYMENT_SYNC_STRATEGY` | `replace` | `replace` \| `additive` |
| `EMPLOYMENT_SYNC_FREQUENCY` | `weekly` | `weekly` \| `on_change` \| `always` |
| `EMPLOYMENT_SYNC_MIN_BULLETS` | `3` | Minimum bullet count to accept |
| `EMPLOYMENT_SYNC_RUBRIC_GATE` | `true` | Banned-phrase + metric regression check |

## Rubric gate

- **Banned phrases** (Rule 4 from score-resume) — hard veto on any generic phrases
- **Quantified bullet ratio** — proposed bullets must not regress >20% below current ratio
- **Minimum bullet count** — reject proposals with fewer than N bullets

## Immediate fix

Self-employed bullets updated via `update_profile` MCP to reflect current work (multi-product ecosystem, AI-augmented dev systems, OEP/A2A, MCP). The automation will keep them current going forward.

## Test plan
- [ ] `tsc --noEmit` — no errors
- [ ] `npm run test:unit` — 307/307
- [ ] `npm run sync` with `EMPLOYMENT_SYNC_ENABLED=false` → shows "disabled" message, no update
- [ ] `npm run sync` with `EMPLOYMENT_SYNC_ENABLED=true` → applies proposal, writes notification
- [ ] `search_thoughts "employment updated"` in private MCP shows notification after enabled sync