### PR TITLE
feat(observations): public /observations surface for the citable reasoning trail

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,11 @@ PORT=7000
 PUBLIC_URL=https://your-domain.com           # required — drives supportedInterfaces.url in the A2A agent card
 PROVIDER_HOMEPAGE=https://github.com/your-username  # optional — shown in agent card provider.url
 
+# Public /observations listing — optional. Comma-separated OB1 topic tags to scope the
+# default (no ?topic=) listing to a curated trail. Unset → most recent public observations.
+# Private thoughts (metadata.private:true) are always excluded regardless of this setting.
+# OBSERVATIONS_TOPICS=OEP,Open Employment Protocol,employment
+
 # Sync (npm run sync) — automatically syncs all projects in public_profile.projects that have a GitHub repo URL
 # No configuration needed; add a project to the profile and the next sync picks it up.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-06-01 — feat(observations): public `GET /observations` + `/observations/:id` — browsable, individually-citable OB1 reasoning/premise trail (the "edge-resolver made browsable"); private thoughts excluded at the same boundary as `/query`, `404`-not-`403` on a private/unknown id; `OBSERVATIONS_TOPICS` scopes the default listing; advertised in openapi + agent-card; pure helpers unit-tested
+
 - 2026-06-01 — feat(sync): employment consolidation — auto-apply delta proposals on configurable schedule with rubric gate; closes #129
 
 - 2026-06-01 — fix(query): add premise-absent behavioral few-shot to RULE_OUTPUT_JSON — closes #126; eval 15/16 → 16/16 (25/25 rule points)

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Four concrete commitments — enforced by code, prompt, and rubric, not aspirati
 | Table | Access | Purpose |
 |---|---|---|
 | `public_profile` | Public API (read-only) | Skills, experience, projects, availability |
-| `thoughts` | MCP only (private) | Raw notes, captures, work-in-progress |
+| `thoughts` | Public-eligible read via `/query` + `/observations`; private (`metadata.private:true`) stays MCP-only | Reasoning, observations, lessons — the "why" behind the work |
 | `job_applications` + `application_stages` + `job_contacts` | MCP only (private) | Job hunt pipeline — applications, stage history, contacts |
 
 Row Level Security in Supabase enforces the boundary. The public API has no knowledge of the private tables and no credentials to reach them.
@@ -155,7 +155,8 @@ A2A v1.0-compliant agent card (canonical path per RFC 8615). `/.well-known/agent
             "availability": { "url": "<baseUrl>/availability", "method": "GET"  },
             "query":        { "url": "<baseUrl>/query",        "method": "POST" },
             "match":        { "url": "<baseUrl>/match",        "method": "POST" },
-            "projects":     { "url": "<baseUrl>/projects",     "method": "GET"  }
+            "projects":     { "url": "<baseUrl>/projects",     "method": "GET"  },
+            "observations": { "url": "<baseUrl>/observations", "method": "GET"  }
           }
         }
       }
@@ -184,7 +185,7 @@ Serves the agent card JSON directly (alias for `/.well-known/agent-card.json`). 
 Health check. Returns `{ "status": "ok" }` with `Cache-Control: no-store`. Exempt from rate limiting — safe to poll from uptime monitors.
 
 ### `GET /openapi.json`
-OpenAPI 3.1.0 schema describing all five public endpoints (`/query`, `/match`, `/info`, `/availability`, `/projects`). Import this URL directly into ChatGPT's GPT builder (Actions → import from URL), Gemini Gems, or any platform that accepts OpenAPI for tool wiring. The `servers[0].url` is derived from the `PUBLIC_URL` env var — set it to your deployed domain.
+OpenAPI 3.1.0 schema describing all six public endpoints (`/query`, `/match`, `/info`, `/availability`, `/projects`, `/observations`). Import this URL directly into ChatGPT's GPT builder (Actions → import from URL), Gemini Gems, or any platform that accepts OpenAPI for tool wiring. The `servers[0].url` is derived from the `PUBLIC_URL` env var — set it to your deployed domain.
 
 ### `GET /qr`
 Returns a 300px QR code PNG. Target URL is controlled by the `QR_TARGET_URL` env var (e.g. a Custom GPT URL or your resume website). Falls back to `PUBLIC_URL` then the request origin if unset. Embed in any web page as a plain `<img>` tag:
@@ -197,6 +198,16 @@ Full structured profile snapshot. Skills, experience, projects, education. No Cl
 
 ### `GET /availability`
 Current job-seeking status, preferred roles, start date, contact links.
+
+### `GET /observations` · `GET /observations/:id`
+Browsable list of the candidate's **public-eligible OB1 observations** — the dated reasoning and lessons behind the profile (the "why", not just the "what"). Each item is individually addressable at `GET /observations/:id`, so a premise can be cited as a stable, verifiable node — the human/agent-browsable companion to the semantic grounding `/query` already draws on ("the edge-resolver made browsable", in OEP evidence-graph terms).
+
+Private thoughts (`metadata.private: true`) are always excluded — the same boundary as `/query` — and a private or unknown id returns `404`, never `403` (the surface never confirms a private thought's existence). Optional filters: `?topic=` (exact OB1 tag), `?type=`, `?since=YYYY-MM-DD`, `?limit=` (1–100, default 25). Without `topic`, the listing is scoped to the `OBSERVATIONS_TOPICS` env (comma-separated) when set, otherwise the most recent public observations.
+
+```bash
+curl "https://agent.yuens.me/observations?topic=OEP&limit=5"
+curl "https://agent.yuens.me/observations/<id>"
+```
 
 ### `GET /try`
 Demo shortcut — redirects to `/query?question=Tell+me+about+yourself&stream=true`. Shareable CTA for humans and AI systems to see the agent in action.
@@ -579,6 +590,7 @@ The included `.github/workflows/sync.yml` runs `npm run sync` on a nightly sched
 8. Deploy to Railway (connect the repo — `railway.toml` handles build + start)
 9. Set env vars in Railway dashboard (see `.env.example` for the full list)
 10. Set `QR_TARGET_URL` in Railway to the URL you want the QR to point to (e.g. your resume website or a Custom GPT URL). `GET /qr` on your deployed domain generates the QR automatically — embed it anywhere as an `<img>` tag.
+11. _(Optional)_ Set `OBSERVATIONS_TOPICS` (comma-separated OB1 topic tags) to scope the default `GET /observations` listing to a curated trail (e.g. `OEP,Open Employment Protocol,employment`). Unset, the endpoint lists your most recent public-eligible observations. Private thoughts are never included.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.37",
+  "version": "0.4.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.37",
+      "version": "0.4.38",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.37",
+  "version": "0.4.38",
   "license": "MIT",
   "private": true,
   "type": "module",
@@ -14,7 +14,7 @@
     "seed": "tsx --env-file=.env.local scripts/seed.ts",
     "db:link": "supabase link --project-ref $SUPABASE_PROJECT_REF",
     "db:push": "supabase db push",
-    "test:unit": "tsx --test tests/resume-framing.test.ts tests/score-resume.test.ts tests/strip-banned.test.ts tests/sync-enrichment.test.ts tests/summarize-observed-queries.test.ts tests/inject-project-urls.test.ts tests/oep-domain.test.ts tests/thoughts-grounded-query.test.ts tests/thought-metadata.test.ts tests/query-prompt.test.ts tests/eval-query-answer.test.ts tests/agent-card-routing.test.ts tests/qr-openapi.test.ts",
+    "test:unit": "tsx --test tests/resume-framing.test.ts tests/score-resume.test.ts tests/strip-banned.test.ts tests/sync-enrichment.test.ts tests/summarize-observed-queries.test.ts tests/inject-project-urls.test.ts tests/oep-domain.test.ts tests/thoughts-grounded-query.test.ts tests/thought-metadata.test.ts tests/query-prompt.test.ts tests/eval-query-answer.test.ts tests/agent-card-routing.test.ts tests/qr-openapi.test.ts tests/observations.test.ts",
     "test:rubric": "tsx --test tests/score-resume.test.ts",
     "test": "echo 'Run npm run test:unit for unit tests, npm run test:integration for live integration tests.'",
     "test:integration": "tsx --env-file=.env.local --test tests/pipeline.test.ts tests/update-profile.test.ts tests/projects-and-scoring.test.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import qrRoute from './routes/qr.js'
 import verifyRoute from './routes/verify.js'
 import profileRoute from './routes/profile.js'
 import projectsRoute from './routes/projects.js'
+import observationsRoute from './routes/observations.js'
 import mcpRoute from './routes/mcp.js'
 import publicMcpRoute from './routes/public-mcp.js'
 import oauthRoute from './routes/oauth.js'
@@ -107,6 +108,7 @@ app.get('/robots.txt', (c) =>
 )
 app.route('/profile', profileRoute)
 app.route('/projects', projectsRoute)
+app.route('/observations', observationsRoute)
 app.route('/mcp', mcpRoute)
 app.route('/public-mcp', publicMcpRoute)
 app.route('/', oauthRoute)
@@ -125,7 +127,7 @@ const port = parseInt(process.env.PORT ?? '3000')
 serve({ fetch: app.fetch, port }, () => {
   const authMode = process.env.AUTH_MODE ?? 'open'
   console.log(`resume-agent running on http://localhost:${port}`)
-  console.log('[routes] GET /, /health, /openapi.json, /qr, /info, /availability, /projects, /projects/:slug, /try, /.well-known/agent-card.json, /.well-known/agent-card (agent.json → 301)')
+  console.log('[routes] GET /, /health, /openapi.json, /qr, /info, /availability, /projects, /projects/:slug, /observations, /observations/:id, /try, /.well-known/agent-card.json, /.well-known/agent-card (agent.json → 301)')
   console.log(`[routes] POST /query, /match | POST /resume (auth: ${authMode}) | PATCH /profile (auth: key)`)
   console.log('[middleware] rate-limit: 30 req/min per IP (excludes OPTIONS, /health)')
 })

--- a/src/lib/observations.ts
+++ b/src/lib/observations.ts
@@ -1,0 +1,83 @@
+/**
+ * Pure helpers for the public `/observations` surface — the browsable
+ * "reasoning/premise trail" behind the profile. Each public-eligible OB1
+ * thought gets a stable, citable URL so a premise can be referenced as a
+ * verifiable node (see the OEP `EVIDENCE-GRAPH.md` — "the edge-resolver made
+ * browsable").
+ *
+ * Kept free of any I/O (no supabase import) so the privacy + shaping logic is
+ * unit-testable without database env. The route (`src/routes/observations.ts`)
+ * wires these to the `thoughts` table.
+ */
+
+export interface ThoughtRow {
+  id: string
+  content: string
+  metadata: Record<string, unknown> | null
+  created_at: string
+}
+
+export interface PublicObservation {
+  id: string
+  date: string // YYYY-MM-DD
+  captured_at: string // full ISO timestamp
+  type: string | null
+  topics: string[]
+  content: string
+  url: string
+}
+
+/**
+ * A thought reaches a public surface unless it is explicitly flagged
+ * `metadata.private === true`. Mirrors the DB-layer rule in
+ * `match_thoughts_public` (see `lib/thoughts-query.ts`): only the boolean `true`
+ * excludes — a stray truthy string must not be mistaken for the private flag,
+ * and a missing flag means public-eligible.
+ */
+export function isPublicThought(metadata: Record<string, unknown> | null | undefined): boolean {
+  return (metadata?.private as unknown) !== true
+}
+
+/** Map a raw `thoughts` row to the public, citable observation shape. */
+export function shapeObservation(row: ThoughtRow, baseUrl: string): PublicObservation {
+  const m = row.metadata ?? {}
+  const topics = Array.isArray(m.topics) ? (m.topics as unknown[]).map(String) : []
+  return {
+    id: row.id,
+    date: row.created_at.slice(0, 10),
+    captured_at: row.created_at,
+    type: typeof m.type === 'string' ? m.type : null,
+    topics,
+    content: row.content,
+    url: `${baseUrl.replace(/\/$/, '')}/observations/${row.id}`,
+  }
+}
+
+/**
+ * Case-insensitive topic membership. An empty `wanted` list means "no scope
+ * restriction" → matches everything.
+ */
+export function hasAnyTopic(
+  metadata: Record<string, unknown> | null | undefined,
+  wanted: string[],
+): boolean {
+  if (!wanted.length) return true
+  const set = new Set(wanted.map((t) => t.toLowerCase()))
+  const topics = Array.isArray(metadata?.topics) ? (metadata!.topics as unknown[]) : []
+  return topics.some((t) => set.has(String(t).toLowerCase()))
+}
+
+/** Parse the `OBSERVATIONS_TOPICS` env (comma-separated) into a clean list. */
+export function parseTopicScope(raw: string | undefined): string[] {
+  return (raw ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/** Guard `:id` before it reaches the database — reject anything non-canonical. */
+export function isUuid(s: string): boolean {
+  return UUID_RE.test(s)
+}

--- a/src/routes/agent-card.ts
+++ b/src/routes/agent-card.ts
@@ -82,6 +82,7 @@ app.get('/', async (c) => {
               query: { url: `${baseUrl}/query`, method: 'POST' },
               match: { url: `${baseUrl}/match`, method: 'POST' },
               projects: { url: `${baseUrl}/projects`, method: 'GET' },
+              observations: { url: `${baseUrl}/observations`, method: 'GET' },
             },
           },
         },

--- a/src/routes/observations.ts
+++ b/src/routes/observations.ts
@@ -1,0 +1,103 @@
+import { Hono } from 'hono'
+import { supabase } from '../lib/supabase.js'
+import {
+  isPublicThought,
+  shapeObservation,
+  hasAnyTopic,
+  parseTopicScope,
+  isUuid,
+  type ThoughtRow,
+} from '../lib/observations.js'
+
+const app = new Hono()
+
+const baseUrlOf = (url: string): string =>
+  (process.env.PUBLIC_URL ?? new URL(url).origin).replace(/\/$/, '')
+
+// We exclude private thoughts and apply topic scope in app code, so over-fetch a
+// bounded window of recent rows, then slice to the caller's limit.
+const FETCH_CEILING = 300
+
+/**
+ * GET /observations — browsable list of public-eligible OB1 observations: the
+ * dated reasoning/premise trail behind the profile. Private thoughts
+ * (`metadata.private === true`) are always excluded. Each item carries a stable
+ * URL so a premise can be cited as a verifiable node (OEP `EVIDENCE-GRAPH.md`).
+ *
+ * Query params:
+ *   - `topic`  — filter by an exact OB1 topic tag
+ *   - `type`   — filter by type (observation, idea, task, reference, …)
+ *   - `since`  — only observations on/after this date (YYYY-MM-DD)
+ *   - `limit`  — 1–100, default 25
+ *
+ * Without `topic`, the listing is scoped to `OBSERVATIONS_TOPICS` (comma-separated
+ * env) when set; otherwise it returns the most recent public observations.
+ */
+app.get('/', async (c) => {
+  const topic = c.req.query('topic')?.trim()
+  const type = c.req.query('type')?.trim()
+  const since = c.req.query('since')?.trim()
+  const limitRaw = Number(c.req.query('limit'))
+  const limit = Number.isFinite(limitRaw)
+    ? Math.min(Math.max(Math.trunc(limitRaw), 1), 100)
+    : 25
+
+  let q = supabase
+    .from('thoughts')
+    .select('id, content, metadata, created_at')
+    .order('created_at', { ascending: false })
+    .limit(FETCH_CEILING)
+
+  if (type) q = q.contains('metadata', { type })
+  if (topic) q = q.contains('metadata', { topics: [topic] })
+  if (since) {
+    const d = new Date(since)
+    if (!Number.isNaN(d.getTime())) q = q.gte('created_at', d.toISOString())
+  }
+
+  const { data, error } = await q
+  if (error) return c.json({ error: error.message }, 500)
+
+  // When no explicit topic is requested, fall back to the owner-configured scope.
+  const scope = topic ? [] : parseTopicScope(process.env.OBSERVATIONS_TOPICS)
+  const baseUrl = baseUrlOf(c.req.url)
+
+  const filtered = ((data ?? []) as ThoughtRow[])
+    .filter((r) => isPublicThought(r.metadata))
+    .filter((r) => (topic ? true : hasAnyTopic(r.metadata, scope)))
+    .slice(0, limit)
+
+  c.header('Cache-Control', 'public, max-age=300')
+  return c.json({
+    count: filtered.length,
+    scope: topic ? { topic } : scope.length ? { topics: scope } : { recent: true },
+    note: 'Public-eligible OB1 observations — the dated reasoning/premise trail behind this profile. Private thoughts are excluded; each item has a stable URL for citation. Context: OEP EVIDENCE-GRAPH.md.',
+    observations: filtered.map((r) => shapeObservation(r, baseUrl)),
+  })
+})
+
+/**
+ * GET /observations/:id — a single public-eligible observation by stable id.
+ * Returns 404 (never 403) for a private or missing thought, so the endpoint
+ * never confirms the existence of a private thought.
+ */
+app.get('/:id', async (c) => {
+  const id = c.req.param('id')
+  if (!isUuid(id)) return c.json({ error: 'Not found' }, 404)
+
+  const { data, error } = await supabase
+    .from('thoughts')
+    .select('id, content, metadata, created_at')
+    .eq('id', id)
+    .limit(1)
+
+  if (error) return c.json({ error: error.message }, 500)
+
+  const row = (data?.[0] ?? null) as ThoughtRow | null
+  if (!row || !isPublicThought(row.metadata)) return c.json({ error: 'Not found' }, 404)
+
+  c.header('Cache-Control', 'public, max-age=300')
+  return c.json(shapeObservation(row, baseUrlOf(c.req.url)))
+})
+
+export default app

--- a/src/routes/openapi.ts
+++ b/src/routes/openapi.ts
@@ -191,6 +191,49 @@ app.get('/', (c) => {
           },
         },
       },
+      '/observations': {
+        get: {
+          operationId: 'listObservations',
+          summary: 'Browse the candidate\'s reasoning/premise trail',
+          description: 'Returns public-eligible OB1 observations — the dated "why and lessons" notes behind the profile, each with a stable URL for citation. Use this to examine the evidence trail behind the candidate\'s claims and reasoning. Private notes are excluded.',
+          parameters: [
+            { name: 'topic', in: 'query', required: false, schema: { type: 'string' }, description: 'Filter by an exact OB1 topic tag' },
+            { name: 'type', in: 'query', required: false, schema: { type: 'string' }, description: 'Filter by type: observation, idea, task, reference' },
+            { name: 'since', in: 'query', required: false, schema: { type: 'string', format: 'date' }, description: 'Only observations on or after this date (YYYY-MM-DD)' },
+            { name: 'limit', in: 'query', required: false, schema: { type: 'integer', minimum: 1, maximum: 100, default: 25 } },
+          ],
+          responses: {
+            '200': {
+              description: 'A list of public-eligible observations, each individually addressable',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      count: { type: 'integer' },
+                      scope: { type: 'object' },
+                      observations: {
+                        type: 'array',
+                        items: {
+                          type: 'object',
+                          properties: {
+                            id: { type: 'string' },
+                            date: { type: 'string', format: 'date' },
+                            type: { type: 'string' },
+                            topics: { type: 'array', items: { type: 'string' } },
+                            content: { type: 'string' },
+                            url: { type: 'string', format: 'uri', description: 'Stable URL for this observation (GET returns the single record)' },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     },
   })
 })

--- a/tests/observations.test.ts
+++ b/tests/observations.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for the public /observations surface.
+ *
+ *  - Pure helpers (privacy, shaping, topic scope, uuid guard) — no DB env needed.
+ *  - One routing test for the `:id` uuid guard: a non-uuid id must 404 *before*
+ *    any database call. Dummy SUPA_* env is set first so importing the supabase
+ *    client doesn't throw (the 404 path never issues a query).
+ *
+ * Run: npm run test:unit
+ */
+
+// Set before any import that may pull in the supabase client. dotenv does not
+// override already-set process.env keys, so this is honored locally and in CI.
+process.env.SUPA_PROJECT_URL ??= 'http://localhost:54321'
+process.env.SUPA_SERVICE_ROLE ??= 'test-dummy-key'
+
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { serve } from '@hono/node-server'
+import { Hono } from 'hono'
+import {
+  isPublicThought,
+  shapeObservation,
+  hasAnyTopic,
+  parseTopicScope,
+  isUuid,
+} from '../src/lib/observations.js'
+
+describe('observations helpers', () => {
+  it('isPublicThought: only boolean true excludes; missing/false/null is public', () => {
+    assert.equal(isPublicThought({ private: true }), false)
+    assert.equal(isPublicThought({ private: false }), true)
+    assert.equal(isPublicThought({}), true)
+    assert.equal(isPublicThought(null), true)
+    assert.equal(isPublicThought(undefined), true)
+    // a truthy-but-not-boolean value must NOT be treated as the private flag
+    assert.equal(isPublicThought({ private: 'true' }), true)
+  })
+
+  it('shapeObservation: maps a row to the public shape with a stable, normalized url', () => {
+    const o = shapeObservation(
+      {
+        id: 'a431455d-eaed-4d74-91d3-4e098fa7fbd2',
+        content: 'a dated premise',
+        metadata: { type: 'observation', topics: ['OEP', 'employment'] },
+        created_at: '2026-06-01T12:34:56.000Z',
+      },
+      'https://agent.example.com/', // trailing slash should be normalized away
+    )
+    assert.equal(o.id, 'a431455d-eaed-4d74-91d3-4e098fa7fbd2')
+    assert.equal(o.date, '2026-06-01')
+    assert.equal(o.captured_at, '2026-06-01T12:34:56.000Z')
+    assert.equal(o.type, 'observation')
+    assert.deepEqual(o.topics, ['OEP', 'employment'])
+    assert.equal(o.content, 'a dated premise')
+    assert.equal(o.url, 'https://agent.example.com/observations/a431455d-eaed-4d74-91d3-4e098fa7fbd2')
+  })
+
+  it('shapeObservation: tolerates missing metadata', () => {
+    const o = shapeObservation(
+      { id: 'x', content: 'c', metadata: null, created_at: '2026-01-02T00:00:00.000Z' },
+      'https://h',
+    )
+    assert.equal(o.type, null)
+    assert.deepEqual(o.topics, [])
+    assert.equal(o.date, '2026-01-02')
+  })
+
+  it('hasAnyTopic: case-insensitive match; empty scope matches everything', () => {
+    assert.equal(hasAnyTopic({ topics: ['Open Employment Protocol'] }, ['open employment protocol']), true)
+    assert.equal(hasAnyTopic({ topics: ['employment'] }, ['OEP']), false)
+    assert.equal(hasAnyTopic({ topics: ['x'] }, []), true)
+    assert.equal(hasAnyTopic(null, ['x']), false)
+    assert.equal(hasAnyTopic(null, []), true)
+  })
+
+  it('parseTopicScope: splits on commas, trims, drops empties', () => {
+    assert.deepEqual(
+      parseTopicScope('OEP, Open Employment Protocol ,, employment'),
+      ['OEP', 'Open Employment Protocol', 'employment'],
+    )
+    assert.deepEqual(parseTopicScope(undefined), [])
+    assert.deepEqual(parseTopicScope(''), [])
+  })
+
+  it('isUuid: accepts a canonical uuid, rejects junk and traversal', () => {
+    assert.equal(isUuid('a431455d-eaed-4d74-91d3-4e098fa7fbd2'), true)
+    assert.equal(isUuid('not-a-uuid'), false)
+    assert.equal(isUuid('../../etc/passwd'), false)
+    assert.equal(isUuid(''), false)
+  })
+})
+
+describe('GET /observations/:id guard (no DB call)', () => {
+  let baseUrl: string
+  let server: ReturnType<typeof serve>
+
+  before(async () => {
+    const { default: observationsRoute } = await import('../src/routes/observations.js')
+    const app = new Hono()
+    app.route('/observations', observationsRoute)
+    await new Promise<void>((resolve) => {
+      server = serve({ fetch: app.fetch, port: 0 }, (info) => {
+        baseUrl = `http://localhost:${info.port}`
+        resolve()
+      })
+    })
+  })
+
+  after(() => server.close())
+
+  it('returns 404 for a non-uuid id without touching the database', async () => {
+    const res = await fetch(`${baseUrl}/observations/not-a-uuid`)
+    assert.equal(res.status, 404)
+    const body = (await res.json()) as { error: string }
+    assert.equal(body.error, 'Not found')
+  })
+})

--- a/tests/qr-openapi.test.ts
+++ b/tests/qr-openapi.test.ts
@@ -41,17 +41,18 @@ describe('/openapi.json and /qr routes', () => {
       assert.match(res.headers.get('content-type') ?? '', /application\/json/)
     })
 
-    it('AC-2: body has openapi 3.1.0 and exactly 5 paths', async () => {
+    it('AC-2: body has openapi 3.1.0 and exactly 6 paths', async () => {
       const res = await fetch(`${baseUrl}/openapi.json`)
       const body = await res.json() as Record<string, unknown>
       assert.equal(body.openapi, '3.1.0')
       const paths = Object.keys(body.paths as object)
-      assert.equal(paths.length, 5, `expected 5 paths, got ${paths.length}: ${paths.join(', ')}`)
+      assert.equal(paths.length, 6, `expected 6 paths, got ${paths.length}: ${paths.join(', ')}`)
       assert.ok(paths.includes('/query'))
       assert.ok(paths.includes('/match'))
       assert.ok(paths.includes('/info'))
       assert.ok(paths.includes('/availability'))
       assert.ok(paths.includes('/projects'))
+      assert.ok(paths.includes('/observations'))
     })
 
     it('AC-3: servers[0].url uses PUBLIC_URL env var when set', async () => {


### PR DESCRIPTION
**Version:** 0.4.37 → 0.4.38

## Summary
- New public surface **`GET /observations`** + **`GET /observations/:id`** — a browsable, individually-citable list of public-eligible OB1 observations (the dated reasoning/premise trail behind the profile). This is "the edge-resolver made browsable": `/query` already grounds answers in these thoughts semantically; this makes each one a stable, linkable node so a claim can be cited and examined.
- **Privacy preserved.** Private thoughts (`metadata.private === true`) are excluded at the same boundary as `/query`. A private or unknown id returns `404`, never `403`, so the surface never confirms a private thought's existence. The `:id` route rejects non-uuid input before any DB call.
- **Curatable scope.** Optional `?topic=`, `?type=`, `?since=YYYY-MM-DD`, `?limit=` (1–100, default 25). Without `?topic`, the default listing is scoped to the new `OBSERVATIONS_TOPICS` env (comma-separated tags) when set, else most-recent public observations.
- **Discoverable.** Added to `openapi.json` (now 6 paths) and the agent-card `api-docs` endpoint list.
- **DRY/testable.** Pure logic (privacy, shaping, topic scope, uuid guard) lives in `src/lib/observations.ts` (no supabase import) and is unit-tested; the route wires it to the `thoughts` table.
- Docs: README (data-tiers note, endpoint section, env step), `.env.example`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:unit` — 314 pass (7 new: privacy filter, shaping, topic scope, uuid guard, non-uuid 404)
- [x] Live smoke vs prod DB: `/observations?limit=3` scoped to OEP topics returns the dated trail with stable URLs; `/observations/:id` returns the full record; junk id → 404
- [ ] Post-deploy: set `OBSERVATIONS_TOPICS` on the Railway service to scope the public default listing; verify `agent.yuens.me/observations` renders prod URLs
