### PR TITLE
refactor(observations): authored why-layer by default + case-insensitive topics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,10 +25,13 @@ PORT=7000
 PUBLIC_URL=https://your-domain.com           # required — drives supportedInterfaces.url in the A2A agent card
 PROVIDER_HOMEPAGE=https://github.com/your-username  # optional — shown in agent card provider.url
 
-# Public /observations listing — optional. Comma-separated OB1 topic tags to scope the
-# default (no ?topic=) listing to a curated trail. Unset → most recent public observations.
-# Private thoughts (metadata.private:true) are always excluded regardless of this setting.
-# OBSERVATIONS_TOPICS=OEP,Open Employment Protocol,employment
+# Public /observations listing — optional. Comma-separated OB1 topic tags (case-insensitive)
+# to scope the default (no ?topic=) listing to a curated trail. Unset → most recent public
+# observations. /observations defaults to authored types (observation/idea/task) and excludes
+# the git-sync `reference` ledger; private thoughts (metadata.private:true) are always excluded.
+# Topic matching normalizes case but not synonyms — list both an acronym and its full name to
+# union them (e.g. OEP and "Open Employment Protocol").
+# OBSERVATIONS_TOPICS=resume-agent,artisan-roast,OEP,Open Employment Protocol
 
 # Sync (npm run sync) — automatically syncs all projects in public_profile.projects that have a GitHub repo URL
 # No configuration needed; add a project to the profile and the next sync picks it up.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-06-02 — refactor(observations): default to the authored "why" layer (observation/idea/task) and exclude the git-sync `reference` changelog ledger unless `?type=reference`; topic matching is now case-insensitive so casing variants resolve to one trail; type filter applied at the DB layer (before LIMIT) so the small authored corpus isn't crowded out by the freshly-synced ledger. Clarifies the split: `/observations` = authored why · `/verify` = proven what · `/query` grounds on both. Docs (README, openapi, .env.example) updated for self + downstream
+
 - 2026-06-01 — feat(observations): public `GET /observations` + `/observations/:id` — browsable, individually-citable OB1 reasoning/premise trail (the "edge-resolver made browsable"); private thoughts excluded at the same boundary as `/query`, `404`-not-`403` on a private/unknown id; `OBSERVATIONS_TOPICS` scopes the default listing; advertised in openapi + agent-card; pure helpers unit-tested
 
 - 2026-06-01 — feat(sync): employment consolidation — auto-apply delta proposals on configurable schedule with rubric gate; closes #129

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Four concrete commitments — enforced by code, prompt, and rubric, not aspirati
 | Table | Access | Purpose |
 |---|---|---|
 | `public_profile` | Public API (read-only) | Skills, experience, projects, availability |
-| `thoughts` | Public-eligible read via `/query` + `/observations`; private (`metadata.private:true`) stays MCP-only | Reasoning, observations, lessons — the "why" behind the work |
+| `thoughts` | Public-eligible read via `/query` + `/observations`; private (`metadata.private:true`) stays MCP-only | Two streams: **authored** `observation`/`idea`/`task` (the "why" — what `/observations` shows by default) and synced `reference` rows (the git/changelog ledger that grounds `/query` + `/resume`) |
 | `job_applications` + `application_stages` + `job_contacts` | MCP only (private) | Job hunt pipeline — applications, stage history, contacts |
 
 Row Level Security in Supabase enforces the boundary. The public API has no knowledge of the private tables and no credentials to reach them.
@@ -202,11 +202,16 @@ Current job-seeking status, preferred roles, start date, contact links.
 ### `GET /observations` · `GET /observations/:id`
 Browsable list of the candidate's **public-eligible OB1 observations** — the dated reasoning and lessons behind the profile (the "why", not just the "what"). Each item is individually addressable at `GET /observations/:id`, so a premise can be cited as a stable, verifiable node — the human/agent-browsable companion to the semantic grounding `/query` already draws on ("the edge-resolver made browsable", in OEP evidence-graph terms).
 
-Private thoughts (`metadata.private: true`) are always excluded — the same boundary as `/query` — and a private or unknown id returns `404`, never `403` (the surface never confirms a private thought's existence). Optional filters: `?topic=` (exact OB1 tag), `?type=`, `?since=YYYY-MM-DD`, `?limit=` (1–100, default 25). Without `topic`, the listing is scoped to the `OBSERVATIONS_TOPICS` env (comma-separated) when set, otherwise the most recent public observations.
+**Authored "why", not the commit ledger.** By default this returns the *authored* reasoning types — `observation`, `idea`, `task` — and **excludes `type: reference`**, which is the git-to-OB1 sync's commit/changelog ledger ("what shipped"). That ledger still grounds `/query` and `/resume` semantically; it's just noise in a reflective browse. Pass `?type=reference` to read it explicitly. This keeps a clean split:
+
+> **`/observations` = the authored *why*** · **`/verify` = the *proven what*** (Ed25519-signed git evidence per project, a different data path) · **`/query` grounds on both.**
+
+Private thoughts (`metadata.private: true`) are always excluded — the same boundary as `/query` — and a private or unknown id returns `404`, never `403` (the surface never confirms a private thought's existence). Filters: `?topic=` (OB1 tag, **case-insensitive** so casing variants resolve to one trail), `?type=` (override the default; e.g. `reference`), `?since=YYYY-MM-DD`, `?limit=` (1–100, default 25). Without `topic`, the listing is scoped to the `OBSERVATIONS_TOPICS` env (comma-separated, case-insensitive) when set, otherwise the most recent public observations. *Note: topic matching normalizes case but not synonyms — `OEP` and `Open Employment Protocol` are distinct tags; list both in `OBSERVATIONS_TOPICS` to union them in the default view.*
 
 ```bash
-curl "https://agent.yuens.me/observations?topic=OEP&limit=5"
-curl "https://agent.yuens.me/observations/<id>"
+curl "https://agent.yuens.me/observations?topic=OEP&limit=5"          # authored OEP trail
+curl "https://agent.yuens.me/observations?type=reference&topic=resume-agent"  # the changelog ledger
+curl "https://agent.yuens.me/observations/<id>"                       # one premise, by stable id
 ```
 
 ### `GET /try`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.38",
+  "version": "0.4.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.38",
+      "version": "0.4.39",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.38",
+  "version": "0.4.39",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/src/lib/observations.ts
+++ b/src/lib/observations.ts
@@ -17,6 +17,16 @@ export interface ThoughtRow {
   created_at: string
 }
 
+/**
+ * The thought types `/observations` returns by default — the *authored* reasoning
+ * layer (the "why / lessons / aha"). This deliberately EXCLUDES `type: reference`,
+ * which is the git-to-OB1 sync's commit/changelog ledger (the "what shipped"): that
+ * ledger still grounds `/query` and `/resume` semantically and is reachable here via
+ * an explicit `?type=reference`, but it does not belong in the default reflective
+ * view. See README "GET /observations" for the observations-vs-verify distinction.
+ */
+export const DEFAULT_OBSERVATION_TYPES = ['observation', 'idea', 'task'] as const
+
 export interface PublicObservation {
   id: string
   date: string // YYYY-MM-DD

--- a/src/routes/observations.ts
+++ b/src/routes/observations.ts
@@ -15,9 +15,12 @@ const app = new Hono()
 const baseUrlOf = (url: string): string =>
   (process.env.PUBLIC_URL ?? new URL(url).origin).replace(/\/$/, '')
 
-// We exclude private thoughts and apply topic scope in app code, so over-fetch a
-// bounded window of recent rows, then slice to the caller's limit.
-const FETCH_CEILING = 300
+// Topic is matched in app code (case-insensitive), so we fetch the per-type window and
+// filter in memory. The ceiling sits above the largest single thought type (the
+// `reference` ledger) so a `?topic` filter sees *every* candidate of that type, not just
+// the most recent — otherwise `?type=reference&topic=…` could miss matches outside the
+// window. Revisit if any one type ever grows past this.
+const FETCH_CEILING = 1000
 
 /**
  * GET /observations — browsable list of public-eligible OB1 observations: the
@@ -49,10 +52,10 @@ app.get('/', async (c) => {
     ? Math.min(Math.max(Math.trunc(limitRaw), 1), 100)
     : 25
 
-  // Type filter is applied at the DB layer (before LIMIT) so the small, older
-  // authored corpus isn't crowded out of the fetch window by the large, freshly-
-  // synced `reference` ledger. Topic is matched in app code (case-insensitive),
-  // which is correct because the authored set is small enough to fit the window.
+  // Type filter is applied at the DB layer (before LIMIT) so a small, older type isn't
+  // crowded out of the window by a large, freshly-synced one. With FETCH_CEILING above
+  // the largest type's row count, the in-memory topic filter sees the complete per-type
+  // set, so case-insensitive `?topic` matching is exact, not recency-bounded.
   let q = supabase
     .from('thoughts')
     .select('id, content, metadata, created_at')

--- a/src/routes/observations.ts
+++ b/src/routes/observations.ts
@@ -6,6 +6,7 @@ import {
   hasAnyTopic,
   parseTopicScope,
   isUuid,
+  DEFAULT_OBSERVATION_TYPES,
   type ThoughtRow,
 } from '../lib/observations.js'
 
@@ -24,14 +25,20 @@ const FETCH_CEILING = 300
  * (`metadata.private === true`) are always excluded. Each item carries a stable
  * URL so a premise can be cited as a verifiable node (OEP `EVIDENCE-GRAPH.md`).
  *
+ * Defaults to the *authored* reasoning layer ({@link DEFAULT_OBSERVATION_TYPES} —
+ * observation/idea/task: the "why & lessons"), and excludes the git-sync `reference`
+ * ledger ("what shipped"). The ledger still grounds `/query` and `/resume`; fetch it
+ * here explicitly with `?type=reference`.
+ *
  * Query params:
- *   - `topic`  — filter by an exact OB1 topic tag
- *   - `type`   — filter by type (observation, idea, task, reference, …)
+ *   - `topic`  — filter by an OB1 topic tag (case-insensitive)
+ *   - `type`   — override the type filter (e.g. `reference` for the changelog ledger)
  *   - `since`  — only observations on/after this date (YYYY-MM-DD)
  *   - `limit`  — 1–100, default 25
  *
  * Without `topic`, the listing is scoped to `OBSERVATIONS_TOPICS` (comma-separated
- * env) when set; otherwise it returns the most recent public observations.
+ * env, case-insensitive) when set; otherwise it returns the most recent public
+ * observations.
  */
 app.get('/', async (c) => {
   const topic = c.req.query('topic')?.trim()
@@ -42,6 +49,10 @@ app.get('/', async (c) => {
     ? Math.min(Math.max(Math.trunc(limitRaw), 1), 100)
     : 25
 
+  // Type filter is applied at the DB layer (before LIMIT) so the small, older
+  // authored corpus isn't crowded out of the fetch window by the large, freshly-
+  // synced `reference` ledger. Topic is matched in app code (case-insensitive),
+  // which is correct because the authored set is small enough to fit the window.
   let q = supabase
     .from('thoughts')
     .select('id, content, metadata, created_at')
@@ -49,7 +60,7 @@ app.get('/', async (c) => {
     .limit(FETCH_CEILING)
 
   if (type) q = q.contains('metadata', { type })
-  if (topic) q = q.contains('metadata', { topics: [topic] })
+  else q = q.in('metadata->>type', [...DEFAULT_OBSERVATION_TYPES])
   if (since) {
     const d = new Date(since)
     if (!Number.isNaN(d.getTime())) q = q.gte('created_at', d.toISOString())
@@ -58,20 +69,25 @@ app.get('/', async (c) => {
   const { data, error } = await q
   if (error) return c.json({ error: error.message }, 500)
 
-  // When no explicit topic is requested, fall back to the owner-configured scope.
-  const scope = topic ? [] : parseTopicScope(process.env.OBSERVATIONS_TOPICS)
+  // Topic scope: an explicit `?topic` (single tag) overrides the owner-configured
+  // default scope. Matching is case-insensitive (see hasAnyTopic) so casing variants
+  // of the same tag — e.g. "open employment protocol" vs "Open Employment Protocol" —
+  // resolve to one trail.
+  const envScope = parseTopicScope(process.env.OBSERVATIONS_TOPICS)
+  const wantedTopics = topic ? [topic] : envScope
   const baseUrl = baseUrlOf(c.req.url)
 
   const filtered = ((data ?? []) as ThoughtRow[])
     .filter((r) => isPublicThought(r.metadata))
-    .filter((r) => (topic ? true : hasAnyTopic(r.metadata, scope)))
+    .filter((r) => hasAnyTopic(r.metadata, wantedTopics))
     .slice(0, limit)
 
   c.header('Cache-Control', 'public, max-age=300')
   return c.json({
     count: filtered.length,
-    scope: topic ? { topic } : scope.length ? { topics: scope } : { recent: true },
-    note: 'Public-eligible OB1 observations — the dated reasoning/premise trail behind this profile. Private thoughts are excluded; each item has a stable URL for citation. Context: OEP EVIDENCE-GRAPH.md.',
+    scope: topic ? { topic } : envScope.length ? { topics: envScope } : { recent: true },
+    types: type ? [type] : [...DEFAULT_OBSERVATION_TYPES],
+    note: 'Public-eligible OB1 observations — the dated, authored reasoning trail (the "why"). Excludes the git-sync changelog ledger by default; pass ?type=reference for that. Private thoughts are excluded; each item has a stable URL for citation. See README "GET /observations" and OEP EVIDENCE-GRAPH.md.',
     observations: filtered.map((r) => shapeObservation(r, baseUrl)),
   })
 })

--- a/src/routes/openapi.ts
+++ b/src/routes/openapi.ts
@@ -211,7 +211,9 @@ app.get('/', (c) => {
                     type: 'object',
                     properties: {
                       count: { type: 'integer' },
-                      scope: { type: 'object' },
+                      scope: { type: 'object', description: 'The active topic scope: {topic}, {topics}, or {recent:true}' },
+                      types: { type: 'array', items: { type: 'string' }, description: 'The thought types included (default observation/idea/task, or the explicit ?type)' },
+                      note: { type: 'string', description: 'Human-readable description of what this surface returns' },
                       observations: {
                         type: 'array',
                         items: {

--- a/src/routes/openapi.ts
+++ b/src/routes/openapi.ts
@@ -194,11 +194,11 @@ app.get('/', (c) => {
       '/observations': {
         get: {
           operationId: 'listObservations',
-          summary: 'Browse the candidate\'s reasoning/premise trail',
-          description: 'Returns public-eligible OB1 observations — the dated "why and lessons" notes behind the profile, each with a stable URL for citation. Use this to examine the evidence trail behind the candidate\'s claims and reasoning. Private notes are excluded.',
+          summary: 'Browse the candidate\'s authored reasoning/premise trail',
+          description: 'Returns public-eligible OB1 observations — the dated, authored "why and lessons" notes behind the profile (types observation/idea/task), each with a stable URL for citation. Excludes the git-sync changelog ledger (type=reference) by default; pass type=reference to read it. Private notes are always excluded.',
           parameters: [
-            { name: 'topic', in: 'query', required: false, schema: { type: 'string' }, description: 'Filter by an exact OB1 topic tag' },
-            { name: 'type', in: 'query', required: false, schema: { type: 'string' }, description: 'Filter by type: observation, idea, task, reference' },
+            { name: 'topic', in: 'query', required: false, schema: { type: 'string' }, description: 'Filter by an OB1 topic tag (case-insensitive)' },
+            { name: 'type', in: 'query', required: false, schema: { type: 'string', enum: ['observation', 'idea', 'task', 'reference'] }, description: 'Override the default type filter (observation/idea/task). Use "reference" for the git/changelog ledger.' },
             { name: 'since', in: 'query', required: false, schema: { type: 'string', format: 'date' }, description: 'Only observations on or after this date (YYYY-MM-DD)' },
             { name: 'limit', in: 'query', required: false, schema: { type: 'integer', minimum: 1, maximum: 100, default: 25 } },
           ],

--- a/tests/observations.test.ts
+++ b/tests/observations.test.ts
@@ -95,7 +95,7 @@ describe('observations helpers', () => {
     // These are the types the bare /observations listing returns by default.
     assert.deepEqual([...DEFAULT_OBSERVATION_TYPES], ['observation', 'idea', 'task'])
     // The git-sync changelog ledger must NOT be in the default (reachable via ?type=reference).
-    assert.equal(DEFAULT_OBSERVATION_TYPES.includes('reference' as never), false)
+    assert.equal((DEFAULT_OBSERVATION_TYPES as readonly string[]).includes('reference'), false)
   })
 })
 

--- a/tests/observations.test.ts
+++ b/tests/observations.test.ts
@@ -24,6 +24,7 @@ import {
   hasAnyTopic,
   parseTopicScope,
   isUuid,
+  DEFAULT_OBSERVATION_TYPES,
 } from '../src/lib/observations.js'
 
 describe('observations helpers', () => {
@@ -88,6 +89,13 @@ describe('observations helpers', () => {
     assert.equal(isUuid('not-a-uuid'), false)
     assert.equal(isUuid('../../etc/passwd'), false)
     assert.equal(isUuid(''), false)
+  })
+
+  it('DEFAULT_OBSERVATION_TYPES: the authored "why" layer, excluding the reference ledger', () => {
+    // These are the types the bare /observations listing returns by default.
+    assert.deepEqual([...DEFAULT_OBSERVATION_TYPES], ['observation', 'idea', 'task'])
+    // The git-sync changelog ledger must NOT be in the default (reachable via ?type=reference).
+    assert.equal(DEFAULT_OBSERVATION_TYPES.includes('reference' as never), false)
   })
 })
 


### PR DESCRIPTION
**Version:** 0.4.38 → 0.4.39

## Summary
Refines the `/observations` surface so it is the **authored "why" layer**, not a commit log — and fixes the topic-casing split. No data migration; `/query`, `/resume`, `/verify` and the sync pipeline are untouched.

- **Default excludes the `reference` ledger.** `/observations` now returns authored types (`observation`/`idea`/`task`) by default and excludes `type: reference` (the git-to-OB1 sync's changelog ledger). That ledger was swamping the reflective notes ~7:1 and floating to the top on every sync. It still grounds `/query` + `/resume`, and is reachable here via `?type=reference`.
- **Type filter is applied at the DB layer (before LIMIT)** so the small, older authored corpus isn't crowded out of the fetch window by the large, freshly-synced ledger.
- **Case-insensitive topic matching.** `open employment protocol` and `Open Employment Protocol` now resolve to one trail (app-side `hasAnyTopic`, which is correct because the authored set fits the fetch window). *Synonyms are still distinct (`OEP` ≠ `Open Employment Protocol`) — documented, list both in `OBSERVATIONS_TOPICS` to union.*
- **Docs for ourselves + downstream:** README now states the `/observations` (authored why) vs `/verify` (proven what) vs `/query` (grounds on both) split, the data-tiers note distinguishes authored vs synced rows, openapi + `.env.example` updated.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:unit` — 315 pass (+1: `DEFAULT_OBSERVATION_TYPES` excludes `reference`)
- [x] Live assert (new code vs prod DB): default → `types:[observation,idea,task]`, **0** reference leaking; `?type=reference` → ledger returns; `?topic=open employment protocol` **and** `?topic=Open Employment Protocol` both include the roadmap thought (casing un-split)
- [x] Related OB1 hygiene (data, not in this PR): split a coffee-domain "Market-Roast" tail out of an OEP roadmap thought into its own **private** note — confirmed 0 leak under the OEP topic
- [ ] Post-merge: redeploy; `agent.yuens.me/observations` default shows authored notes; `?type=reference` shows the ledger
