### PR TITLE
ci(sync): pass EMPLOYMENT_SYNC and OEP signing vars to GitHub Actions

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -30,4 +30,13 @@ jobs:
           SUPA_SERVICE_ROLE: ${{ secrets.SUPA_SERVICE_ROLE }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLIC_URL: ${{ secrets.PUBLIC_URL }}
+          OEP_PUBLIC_KEY: ${{ secrets.OEP_PUBLIC_KEY }}
+          OEP_PRIVATE_KEY: ${{ secrets.OEP_PRIVATE_KEY }}
+          OEP_KEY_ISSUED_AT: ${{ secrets.OEP_KEY_ISSUED_AT }}
+          EMPLOYMENT_SYNC_ENABLED: ${{ secrets.EMPLOYMENT_SYNC_ENABLED }}
+          EMPLOYMENT_SYNC_STRATEGY: ${{ secrets.EMPLOYMENT_SYNC_STRATEGY }}
+          EMPLOYMENT_SYNC_FREQUENCY: ${{ secrets.EMPLOYMENT_SYNC_FREQUENCY }}
+          EMPLOYMENT_SYNC_MIN_BULLETS: ${{ secrets.EMPLOYMENT_SYNC_MIN_BULLETS }}
+          EMPLOYMENT_SYNC_RUBRIC_GATE: ${{ secrets.EMPLOYMENT_SYNC_RUBRIC_GATE }}
         run: npx tsx scripts/sync.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-06-02 — ci(sync): pass EMPLOYMENT_SYNC_* and OEP signing vars to GitHub Actions — consolidation and git_evidence signing were silently skipped in nightly runs
+
 - 2026-06-02 — refactor(observations): default to the authored "why" layer (observation/idea/task) and exclude the git-sync `reference` changelog ledger unless `?type=reference`; topic matching is now case-insensitive so casing variants resolve to one trail; type filter applied at the DB layer (before LIMIT) so the small authored corpus isn't crowded out by the freshly-synced ledger. Clarifies the split: `/observations` = authored why · `/verify` = proven what · `/query` grounds on both. Docs (README, openapi, .env.example) updated for self + downstream
 
 - 2026-06-01 — feat(observations): public `GET /observations` + `/observations/:id` — browsable, individually-citable OB1 reasoning/premise trail (the "edge-resolver made browsable"); private thoughts excluded at the same boundary as `/query`, `404`-not-`403` on a private/unknown id; `OBSERVATIONS_TOPICS` scopes the default listing; advertised in openapi + agent-card; pure helpers unit-tested

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.39",
+  "version": "0.4.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.39",
+      "version": "0.4.40",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.39",
+  "version": "0.4.40",
   "license": "MIT",
   "private": true,
   "type": "module",


### PR DESCRIPTION
**Version:** 0.4.39 → 0.4.40

## Problem

Two features were silently skipped in every nightly GitHub Actions run because their env vars were not passed to the workflow:

1. **Employment consolidation** — `EMPLOYMENT_SYNC_ENABLED=true` was set in Railway but GH Actions has its own isolated env, so consolidation showed "disabled" on every run
2. **OEP git evidence signing** — `PUBLIC_URL`, `OEP_PUBLIC_KEY`, `OEP_PRIVATE_KEY`, `OEP_KEY_ISSUED_AT` were not passed, so git_evidence was never signed by nightly sync

## Fix

Added all `EMPLOYMENT_SYNC_*` and OEP signing vars to the `sync.yml` workflow env block. The GH Actions secrets already exist for the OEP keys — they just weren't wired in.

## Test plan
- [ ] Trigger manual sync: `gh workflow run sync.yml`
- [ ] Log shows `✔ employment bullets updated` (if proposal passes gate)
- [ ] Log shows `✔ git_evidence signed` per project
- [ ] OB1 notification thought appears: `search_thoughts "employment updated"`