### PR TITLE
ci(sync): upgrade GitHub Actions runner to Node.js 24

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - run: npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-06-02 — ci(sync): upgrade GitHub Actions runner to Node.js 24 (20 deprecated June 16)
+
 - 2026-06-02 — ci(sync): pass EMPLOYMENT_SYNC_* and OEP signing vars to GitHub Actions — consolidation and git_evidence signing were silently skipped in nightly runs
 
 - 2026-06-02 — refactor(observations): default to the authored "why" layer (observation/idea/task) and exclude the git-sync `reference` changelog ledger unless `?type=reference`; topic matching is now case-insensitive so casing variants resolve to one trail; type filter applied at the DB layer (before LIMIT) so the small authored corpus isn't crowded out by the freshly-synced ledger. Clarifies the split: `/observations` = authored why · `/verify` = proven what · `/query` grounds on both. Docs (README, openapi, .env.example) updated for self + downstream

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.40",
+  "version": "0.4.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.40",
+      "version": "0.4.41",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.40",
+  "version": "0.4.41",
   "license": "MIT",
   "private": true,
   "type": "module",


### PR DESCRIPTION
**Version:** 0.4.40 → 0.4.41

Node.js 20 actions are deprecated. GitHub will force Node.js 24 on June 16, 2026 and remove 20 on September 16.

## Change
`node-version: '20'` → `node-version: '24'` in `.github/workflows/sync.yml`

## Test plan
- [ ] Next manual/nightly sync run completes without the Node.js 20 deprecation warning