### PR TITLE
docs(roadmap): rewrite ROADMAP.md — current through v0.4.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-06-03 — docs(roadmap): rewrite ROADMAP.md — current through v0.4.42, Next and Exploring sections updated
+
 - 2026-06-03 — docs(readme): link resume-agent-web companion repo; fix architecture diagram; correct homepage to agent.yuens.me; roadmap updated to current state
 
 - 2026-06-02 — ci(sync): upgrade GitHub Actions runner to Node.js 24 (20 deprecated June 16)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,6 +9,10 @@ A running log of what's shipped and what's in flight. See the [README](README.md
 | Version | Feature | PR |
 | --- | --- | --- |
 | v0.2.12 | Dual-gen + rubric scorer pipeline for resume generation | [#59](https://github.com/yuens1002/resume-agent/pull/59) |
+| v0.2.13 | `/.well-known/agent-card` extensionless redirect; MCP session TTL + keepalive fixes | [#61](https://github.com/yuens1002/resume-agent/pull/61) |
+| v0.2.14 | Stateless MCP transport — session map removed, mid-conversation drops eliminated | [#62](https://github.com/yuens1002/resume-agent/pull/62) |
+| v0.2.15 | System prompt refactor — drop length + employment-trim rules | [#63](https://github.com/yuens1002/resume-agent/pull/63) |
+| v0.2.16 | Retire Supabase Edge Function artifacts; clarify Railway as runtime tier | [#65](https://github.com/yuens1002/resume-agent/pull/65) |
 | v0.3.0 | Public MCP endpoint — `ask_candidate` tool, logged to `observed_queries`, advertised in agent card | [#66](https://github.com/yuens1002/resume-agent/pull/66) |
 | v0.4.4 | OEP Phase 1 — Ed25519 domain verification (DNS TXT fingerprint, `/.well-known/oep-public-key.json`, CLI verifier) | [#90](https://github.com/yuens1002/resume-agent/pull/90) |
 | v0.4.7 | Thoughts-grounded `/query` — semantic search over OB1 thoughts layers lived experience above structured profile; behavioral questions answered from observations | [#93](https://github.com/yuens1002/resume-agent/pull/93) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,15 +9,24 @@ A running log of what's shipped and what's in flight. See the [README](README.md
 | Version | Feature | PR |
 | --- | --- | --- |
 | v0.2.12 | Dual-gen + rubric scorer pipeline for resume generation | [#59](https://github.com/yuens1002/resume-agent/pull/59) |
-| v0.2.13 | `/.well-known/agent-card` extensionless redirect, MCP session TTL + keepalive fixes | [#61](https://github.com/yuens1002/resume-agent/pull/61) |
-| v0.2.14 | Stateless MCP transport — session map removed, mid-conversation drops eliminated | [#62](https://github.com/yuens1002/resume-agent/pull/62) |
-| v0.2.15 | System prompt refactor — drop length + employment-trim rules | [#63](https://github.com/yuens1002/resume-agent/pull/63) |
-| v0.2.16 | Retire Supabase Edge Function artifacts, clarify Railway as runtime tier | [#65](https://github.com/yuens1002/resume-agent/pull/65) |
-| v0.3.0 | Public MCP endpoint with `ask_candidate` tool — single unauthenticated MCP tool wrapping `/query`, advertised first in agent card `supportedInterfaces`, every call logged to `observed_queries` | [#66](https://github.com/yuens1002/resume-agent/pull/66) |
-| v0.4.4 | OEP Phase 1 — domain verification (DNS TXT). Ed25519 public key at `/.well-known/oep-public-key.json`, fingerprint mirrored in `_oep.<root>` TXT record, CLI verifier, fingerprint surfaced on agent card. Plan: [`docs/plans/oep-phase-1-domain-verification.md`](docs/plans/oep-phase-1-domain-verification.md) | [#90](https://github.com/yuens1002/resume-agent/pull/90) |
-| v0.4.7 | Thoughts-grounded `/query` and `/public-mcp` — semantic search over OB1 thoughts layered above `public_profile`; `match_thoughts_public` RPC excludes `metadata.private` thoughts; behavioral/judgment questions answered from lived experience; agent card `skills.query` updated, card → 1.3.0. Plan: [`docs/plans/thoughts-grounded-query.md`](docs/plans/thoughts-grounded-query.md) | [#93](https://github.com/yuens1002/resume-agent/pull/93) |
-| v0.4.13 | `/query` engagement rules + prompt-does-relevance + eval harness — named rule constants in `src/lib/query-prompt.ts` (voice / honesty / observations-relevance / off-topic / gaps / adversarial / output-json) composed by `buildSystemPrompt`; `QUERY_THOUGHTS_THRESHOLD` env-overridable; on-demand `npm run eval:query` runs ~14 fixture cases against a deterministic rubric with optional `--judge`. Plan: [`docs/plans/query-engagement-rules.md`](docs/plans/query-engagement-rules.md) | [#97](https://github.com/yuens1002/resume-agent/pull/97) |
-| v0.4.15 | `/query` engagement rules **v2** — third-person factual narrator + footnote citations. Voice flip from 1st → 3rd person ("Sunny built X [1]..." not "I built X..."); new `RULE_CITATION` requires `[N]` markers + `Sources:` block on every factual claim; drops calendly contact-offer; unifies no-data + off-topic around a factual-decline posture; rubric drops `no-data-offers-contact` and adds `cites-source`; fixes the `"Kubernetes in production"` overclaim false positive. Live behavior: [`docs/query-engagement-rules.md`](docs/query-engagement-rules.md). Plan: [`docs/plans/query-engagement-rules-v2.md`](docs/plans/query-engagement-rules-v2.md) | _this PR_ |
+| v0.3.0 | Public MCP endpoint — `ask_candidate` tool, logged to `observed_queries`, advertised in agent card | [#66](https://github.com/yuens1002/resume-agent/pull/66) |
+| v0.4.4 | OEP Phase 1 — Ed25519 domain verification (DNS TXT fingerprint, `/.well-known/oep-public-key.json`, CLI verifier) | [#90](https://github.com/yuens1002/resume-agent/pull/90) |
+| v0.4.7 | Thoughts-grounded `/query` — semantic search over OB1 thoughts layers lived experience above structured profile; behavioral questions answered from observations | [#93](https://github.com/yuens1002/resume-agent/pull/93) |
+| v0.4.13 | `/query` engagement rules + eval harness — named `RULE_*` constants, on-demand `npm run eval:query` with deterministic rubric | [#97](https://github.com/yuens1002/resume-agent/pull/97) |
+| v0.4.15 | `/query` v2 — third-person narrator, footnote citations (`[N]` markers + `Sources:` block required on every factual claim) | [#100](https://github.com/yuens1002/resume-agent/pull/100) |
+| v0.4.20 | `GET /` serves agent card; `GET /health` endpoint | [#106](https://github.com/yuens1002/resume-agent/pull/106) |
+| v0.4.23 | `GET /openapi.json` (Custom GPT Actions schema); `GET /qr` (QR code PNG, `QR_TARGET_URL`-controlled) | [#108](https://github.com/yuens1002/resume-agent/pull/108) |
+| v0.4.25 | `cover` image URL field on Project schema; populated from Supabase Storage | [#111](https://github.com/yuens1002/resume-agent/pull/111) |
+| v0.4.29 | Conversational mode (`style: "conversational"` / `x-agent-type: human`) — 2–4 sentence prose, no inline citations; `jd_term_count` in rubric response | [#115](https://github.com/yuens1002/resume-agent/pull/115) |
+| v0.4.30 | Sync auto-infers `status`, `url`, `tech` from GitHub repo metadata; `parseCommitCount`, `buildRepoStats`, `detectGitProvider` helpers | [#117](https://github.com/yuens1002/resume-agent/pull/117) |
+| v0.4.32 | **OEP Phase 2a** — git evidence per project (commit count, file stats, contributors); `GitProvider` abstraction; `verification_status` on `GET /info` | [#122](https://github.com/yuens1002/resume-agent/pull/122) |
+| v0.4.33 | MIT `LICENSE` file | [#123](https://github.com/yuens1002/resume-agent/pull/123) |
+| v0.4.34 | **OEP Phase 3** — Ed25519-signed git evidence; `GET /verify/git-evidence`; `scripts/verify-git-evidence.ts` CLI; README identity arc | [#124](https://github.com/yuens1002/resume-agent/pull/124) |
+| v0.4.35 | Query performance — skip thought embedding for binary questions (18× overhead reduction), 5-min profile cache, `maxTokens: 512` for conversational | [#127](https://github.com/yuens1002/resume-agent/pull/127) |
+| v0.4.36 | `/query` eval 16/16, 25/25 — premise-absent behavioral few-shot closes the chronic `behavioral-when-you-stopped` citation gap | [#128](https://github.com/yuens1002/resume-agent/pull/128) |
+| v0.4.37 | Employment consolidation — auto-apply OB1 delta proposals on configurable schedule with rubric gate; OB1 notification on apply | [#130](https://github.com/yuens1002/resume-agent/pull/130) |
+| v0.4.41 | CI: Node.js 24 runner; OEP + employment sync env vars wired into GitHub Actions | [#133](https://github.com/yuens1002/resume-agent/pull/133), [#134](https://github.com/yuens1002/resume-agent/pull/134) |
+| v0.4.42 | Docs: `resume-agent-web` companion linked; architecture diagram updated; roadmap refreshed | [#136](https://github.com/yuens1002/resume-agent/pull/136) |
 
 ---
 
@@ -29,10 +38,21 @@ _None right now._
 
 ## Next
 
-### Public MCP traffic observations
+### OEP Phase 2b — peer attestation discovery
+LinkedIn public post search for third-party attestations ("I worked with X at Y at Z"). Organic consensus (N ≥ 2 independent witnesses) is the proof model — no timestamp required, retrospective posts are valid. Requires LinkedIn OAuth. See issue [#119](https://github.com/yuens1002/resume-agent/issues/119).
 
-Observations from live `/public-mcp` traffic — agent card fields consumed vs ignored, tool naming that AI clients discover reliably, rate-limit thresholds that hold up, errors worth surfacing. Deliverable: `docs/plans/base-layer-observations.md`, committed incrementally as patterns emerge.
+### GitLab + Bitbucket git evidence providers
+`GitLabProvider` and `BitbucketProvider` in `scripts/sync.ts` are stubs. Fill them in so non-GitHub repos get signed git evidence too.
+
+### A2A registry submission
+Submit `/.well-known/agent-card.json` to [a2aregistry.org](https://a2aregistry.org), [a2agent.net](https://a2agent.net/agent-registry), and open a PR on `prassanna-ravishankar/a2a-registry`.
+
+---
 
 ## Exploring
 
-A broader trust layer for agent authenticity — signed agent cards + invocation receipts + a public `/verify` endpoint. Early-stage design that builds on the Phase 1 domain-verification plan above. See [docs/plans/a2a-trust-layer.md](docs/plans/a2a-trust-layer.md).
+### OEP employer co-signatures
+The ideal proof for employed work: the employer's own agent co-signs the employment claim. Requires employer-side OEP adoption — an ecosystem problem, not a code problem. The reference implementation (this repo) is the argument for adoption. See [`docs/plans/oep-verification.md`](docs/plans/oep-verification.md).
+
+### A2A trust layer
+Signed agent cards and invocation receipts — prove that a specific AI response came from this agent, not a fabricated answer in your voice. Depends on Phase 3 signing infrastructure. See [`docs/plans/a2a-trust-layer.md`](docs/plans/a2a-trust-layer.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.42",
+  "version": "0.4.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.42",
+      "version": "0.4.43",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.42",
+  "version": "0.4.43",
   "license": "MIT",
   "private": true,
   "type": "module",


### PR DESCRIPTION
**Version:** 0.4.42 → 0.4.43

ROADMAP.md was frozen at v0.4.15. Rewrites it to reflect current state.

## What changed
- **Shipped**: 14 new rows spanning v0.4.20 → v0.4.42 (OEP Phases 2+3, conversational mode, employment consolidation, eval 16/16, perf improvements, MIT license, web companion, CI upgrades)
- **In progress**: cleared (nothing active right now)
- **Next**: replaced stale items with OEP Phase 2b peer attestation, GitLab/Bitbucket providers, A2A registry submission
- **Exploring**: OEP employer co-signatures, A2A trust layer