### PR TITLE
feat(query): instrument phase timings (Stage 1 of query-latency plan)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-06-03 — feat(query): instrument phase timings — persist `llm_ms` + `retrieval_ms` to observed_queries; Stage 1 of the query-latency plan (docs/plans/query-latency.md). Initial assessment: "recent projects" query is ~90% LLM generation (output length), ~10% retrieval, ~0 framework overhead
+
 - 2026-06-03 — docs(roadmap): rewrite ROADMAP.md — current through v0.4.42, Next and Exploring sections updated
 
 - 2026-06-03 — docs(readme): link resume-agent-web companion repo; fix architecture diagram; correct homepage to agent.yuens.me; roadmap updated to current state

--- a/docs/plans/query-latency.md
+++ b/docs/plans/query-latency.md
@@ -12,7 +12,7 @@ Optimize latency **subject to correctness held constant.** Same fixtures, two me
 We log wall-clock total but throw away the phase breakdown. Persist it:
 - `llm_ms` — `generateText` time (already computed in `meta.latency_ms`, just not stored)
 - `retrieval_ms` — the data-fetch phase (profile + thoughts `Promise.all`)
-- Overhead = `total − llm − retrieval` (framework / network / cold start), derivable
+- Overhead = `total − llm − retrieval` — prompt construction, JSON parse/serialize, framework, network, cold start (local CPU *and* infra, not just infra), derivable
 
 Migration adds two columns to `observed_queries`; `queryProfile` surfaces `retrieval_ms` in `meta`; logger persists both. Non-streaming only for now (streaming logs a partial payload — acceptable gap).
 

--- a/docs/plans/query-latency.md
+++ b/docs/plans/query-latency.md
@@ -1,0 +1,32 @@
+# Plan: query latency — measure, then optimize
+
+## Goal
+`/query` averages ~6.6s wall-clock (p95 ~11s) on a fast model (Haiku). Reduce roundtrip **without degrading answer quality**. The eval harness already guards correctness; this plan adds the latency dimension and a disciplined loop.
+
+## Core principle
+Optimize latency **subject to correctness held constant.** Same fixtures, two metrics, measured on one pass — so you can't win on speed by quietly degrading answers.
+
+## Stages
+
+### Stage 1 — Production instrumentation (this PR)
+We log wall-clock total but throw away the phase breakdown. Persist it:
+- `llm_ms` — `generateText` time (already computed in `meta.latency_ms`, just not stored)
+- `retrieval_ms` — the data-fetch phase (profile + thoughts `Promise.all`)
+- Overhead = `total − llm − retrieval` (framework / network / cold start), derivable
+
+Migration adds two columns to `observed_queries`; `queryProfile` surfaces `retrieval_ms` in `meta`; logger persists both. Non-streaming only for now (streaming logs a partial payload — acceptable gap).
+
+### Stage 2 — Latency on `eval:query` (later)
+Add per-case timing + aggregate p50/p95 to the existing eval run. One command → correctness **and** latency on a fixed set. Write each run (version, date, pass rate, p50/p95) to a **committed** baseline file so git history shows which commit moved latency.
+
+### Stage 3 — Optimize against a target (later)
+Set a target (e.g. p50 < 3s cited, < 1.5s conversational). Loop: change → `eval:query` → correctness held + latency down? → keep/revert.
+
+## Key areas to investigate
+1. **LLM output length** — cited mode generates long answers (prose + `[N]` + Sources + follow-ups, ≤1024 tokens). Output length, not model speed, dominates latency. Prime suspect.
+2. **OpenRouter hop** — hot path routes through OpenRouter to reach Anthropic. Direct Anthropic could cut latency + p95 variance.
+3. **Cold starts** — Railway container spin-up would show in p95/max tail, not p50.
+
+## Cautions
+- **Upstream variance is real** — same query swings seconds run-to-run. Run fixtures N times, compare medians, treat sub-second deltas as noise.
+- **Two stores, complementary** — `observed_queries` = real traffic distribution + regression trend; eval harness = controlled "did my change help." Don't collapse them.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.43",
+  "version": "0.4.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.43",
+      "version": "0.4.44",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.43",
+  "version": "0.4.44",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "seed": "tsx --env-file=.env.local scripts/seed.ts",
     "db:link": "supabase link --project-ref $SUPABASE_PROJECT_REF",
     "db:push": "supabase db push",
-    "test:unit": "tsx --test tests/resume-framing.test.ts tests/score-resume.test.ts tests/strip-banned.test.ts tests/sync-enrichment.test.ts tests/summarize-observed-queries.test.ts tests/inject-project-urls.test.ts tests/oep-domain.test.ts tests/thoughts-grounded-query.test.ts tests/thought-metadata.test.ts tests/query-prompt.test.ts tests/eval-query-answer.test.ts tests/agent-card-routing.test.ts tests/qr-openapi.test.ts tests/observations.test.ts",
+    "test:unit": "tsx --test tests/resume-framing.test.ts tests/score-resume.test.ts tests/strip-banned.test.ts tests/sync-enrichment.test.ts tests/summarize-observed-queries.test.ts tests/inject-project-urls.test.ts tests/oep-domain.test.ts tests/thoughts-grounded-query.test.ts tests/thought-metadata.test.ts tests/query-prompt.test.ts tests/eval-query-answer.test.ts tests/agent-card-routing.test.ts tests/qr-openapi.test.ts tests/observations.test.ts tests/observed-query-row.test.ts",
     "test:rubric": "tsx --test tests/score-resume.test.ts",
     "test": "echo 'Run npm run test:unit for unit tests, npm run test:integration for live integration tests.'",
     "test:integration": "tsx --env-file=.env.local --test tests/pipeline.test.ts tests/update-profile.test.ts tests/projects-and-scoring.test.ts",

--- a/src/lib/log-observed-query.ts
+++ b/src/lib/log-observed-query.ts
@@ -67,6 +67,8 @@ export async function logObservedQuery(input: LogInput): Promise<void> {
       sources: input.response.sources ?? null,
       model: input.response.meta?.model ?? null,
       latency_ms: input.latency_ms,
+      llm_ms: input.response.meta?.latency_ms ?? null,
+      retrieval_ms: input.response.meta?.retrieval_ms ?? null,
       ip_hash: hashIp(input.ip),
       user_agent: input.user_agent ?? null,
     })

--- a/src/lib/log-observed-query.ts
+++ b/src/lib/log-observed-query.ts
@@ -56,22 +56,35 @@ function hashIp(ip: string | undefined): string | null {
   return createHash('sha256').update(`${ip}:${IP_SALT}`).digest('hex')
 }
 
+/**
+ * Build the observed_queries row from a log input. Pure and exported so the
+ * column mapping — including the phase-timing fields (`llm_ms`, `retrieval_ms`)
+ * — is unit-testable without a live DB. `latency_ms` is the wall-clock total;
+ * `llm_ms` / `retrieval_ms` come from the response meta and are null when absent
+ * (e.g. streaming callers log a partial payload with no meta).
+ */
+export function buildObservedQueryRow(input: LogInput, ipHash: string | null) {
+  return {
+    source: input.source,
+    question: input.question,
+    caller_hint: input.caller_hint ?? null,
+    answer: input.response.answer ?? null,
+    confidence: input.response.confidence ?? null,
+    sources: input.response.sources ?? null,
+    model: input.response.meta?.model ?? null,
+    latency_ms: input.latency_ms,
+    llm_ms: input.response.meta?.latency_ms ?? null,
+    retrieval_ms: input.response.meta?.retrieval_ms ?? null,
+    ip_hash: ipHash,
+    user_agent: input.user_agent ?? null,
+  }
+}
+
 export async function logObservedQuery(input: LogInput): Promise<void> {
   try {
-    const { error } = await supabase.from('observed_queries').insert({
-      source: input.source,
-      question: input.question,
-      caller_hint: input.caller_hint ?? null,
-      answer: input.response.answer ?? null,
-      confidence: input.response.confidence ?? null,
-      sources: input.response.sources ?? null,
-      model: input.response.meta?.model ?? null,
-      latency_ms: input.latency_ms,
-      llm_ms: input.response.meta?.latency_ms ?? null,
-      retrieval_ms: input.response.meta?.retrieval_ms ?? null,
-      ip_hash: hashIp(input.ip),
-      user_agent: input.user_agent ?? null,
-    })
+    const { error } = await supabase
+      .from('observed_queries')
+      .insert(buildObservedQueryRow(input, hashIp(input.ip)))
     if (error) {
       // Supabase returns { error } without throwing for most failures; capture it.
       console.warn('[log-observed-query] insert returned error:', error.message)

--- a/src/routes/query.ts
+++ b/src/routes/query.ts
@@ -121,10 +121,12 @@ export async function queryProfile(
   args: QueryProfileArgs,
 ): Promise<QueryResponse | ProfileNotFoundError | ParseError> {
   const skipThoughts = isBinaryQuestion(args.question)
+  const retrievalStart = Date.now()
   const [{ data: profile, error }, thoughts] = await Promise.all([
     fetchProfile(),
     skipThoughts ? Promise.resolve([]) : queryRelevantThoughtsForQuestion(args.question),
   ])
+  const retrieval_ms = Date.now() - retrievalStart
 
   if (error || !profile) {
     return { kind: 'profile_not_found' }
@@ -154,7 +156,7 @@ export async function queryProfile(
       email: profile.contact?.email,
       calendly: profile.contact?.calendly,
     },
-    meta: { model: MODEL, latency_ms },
+    meta: { model: MODEL, latency_ms, retrieval_ms },
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,7 +127,7 @@ export interface QueryResponse {
   sources: string[]
   follow_up_suggestions: string[]
   contact: Partial<Pick<Contact, 'email' | 'calendly'>>
-  meta: { model: string; latency_ms: number }
+  meta: { model: string; latency_ms: number; retrieval_ms?: number }
 }
 
 export interface MatchRequest {

--- a/supabase/migrations/20260603000000_observed_queries_phase_timings.sql
+++ b/supabase/migrations/20260603000000_observed_queries_phase_timings.sql
@@ -1,0 +1,9 @@
+-- Phase timing breakdown for observed_queries.
+-- `latency_ms` (existing) remains the wall-clock total. These split it:
+--   llm_ms       — generateText() duration (the LLM generation phase)
+--   retrieval_ms — data-fetch phase (profile + thoughts Promise.all)
+-- Overhead = latency_ms - llm_ms - retrieval_ms (framework / network / cold start).
+-- Nullable: streaming callers log a partial payload without the breakdown.
+
+alter table observed_queries add column if not exists llm_ms integer;
+alter table observed_queries add column if not exists retrieval_ms integer;

--- a/supabase/migrations/20260603000000_observed_queries_phase_timings.sql
+++ b/supabase/migrations/20260603000000_observed_queries_phase_timings.sql
@@ -2,7 +2,8 @@
 -- `latency_ms` (existing) remains the wall-clock total. These split it:
 --   llm_ms       — generateText() duration (the LLM generation phase)
 --   retrieval_ms — data-fetch phase (profile + thoughts Promise.all)
--- Overhead = latency_ms - llm_ms - retrieval_ms (framework / network / cold start).
+-- Overhead = latency_ms - llm_ms - retrieval_ms (prompt construction, JSON
+-- parse/serialize, framework, network, cold start — local CPU + infra, not just infra).
 -- Nullable: streaming callers log a partial payload without the breakdown.
 
 alter table observed_queries add column if not exists llm_ms integer;

--- a/tests/observed-query-row.test.ts
+++ b/tests/observed-query-row.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests — buildObservedQueryRow (log-observed-query.ts)
+ *
+ * Verifies the column mapping, especially the phase-timing fields
+ * (`llm_ms`, `retrieval_ms`) added in the query-latency instrumentation.
+ * Pure function — no DB, no network.
+ *
+ * Run: npm run test:unit
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { buildObservedQueryRow } from '../src/lib/log-observed-query.js'
+
+function fullInput() {
+  return {
+    source: 'http' as const,
+    question: 'What are your recent projects?',
+    caller_hint: 'Recruiter reviewing candidates.',
+    response: {
+      answer: 'Sunny built X [1].',
+      confidence: 'high' as const,
+      sources: ['projects.resume-agent'],
+      follow_up_suggestions: ['What else?'],
+      contact: {},
+      meta: { model: 'anthropic/claude-haiku-4.5', latency_ms: 9755, retrieval_ms: 1046 },
+    },
+    latency_ms: 10801,
+    ip: '203.0.113.5',
+    user_agent: 'test-agent',
+  }
+}
+
+describe('buildObservedQueryRow', () => {
+  it('maps wall-clock total to latency_ms', () => {
+    const row = buildObservedQueryRow(fullInput(), 'hashed')
+    assert.equal(row.latency_ms, 10801)
+  })
+
+  it('maps LLM time from meta.latency_ms to llm_ms', () => {
+    const row = buildObservedQueryRow(fullInput(), 'hashed')
+    assert.equal(row.llm_ms, 9755)
+  })
+
+  it('maps meta.retrieval_ms to retrieval_ms', () => {
+    const row = buildObservedQueryRow(fullInput(), 'hashed')
+    assert.equal(row.retrieval_ms, 1046)
+  })
+
+  it('passes the supplied ip_hash through verbatim (never the raw ip)', () => {
+    const row = buildObservedQueryRow(fullInput(), 'deadbeef')
+    assert.equal(row.ip_hash, 'deadbeef')
+    assert.ok(!JSON.stringify(row).includes('203.0.113.5'), 'raw IP must never appear in the row')
+  })
+
+  it('nulls llm_ms and retrieval_ms when meta is absent (streaming partial payload)', () => {
+    const input = {
+      source: 'mcp' as const,
+      question: 'q',
+      response: { answer: 'collected stream text' },
+      latency_ms: 4200,
+    }
+    const row = buildObservedQueryRow(input, null)
+    assert.equal(row.llm_ms, null)
+    assert.equal(row.retrieval_ms, null)
+    assert.equal(row.latency_ms, 4200)
+    assert.equal(row.ip_hash, null)
+  })
+
+  it('nulls retrieval_ms when meta has llm timing but no retrieval (older shape)', () => {
+    const input = fullInput()
+    delete (input.response.meta as { retrieval_ms?: number }).retrieval_ms
+    const row = buildObservedQueryRow(input, 'h')
+    assert.equal(row.llm_ms, 9755)
+    assert.equal(row.retrieval_ms, null)
+  })
+})


### PR DESCRIPTION
**Version:** 0.4.43 → 0.4.44

Stage 1 of [docs/plans/query-latency.md](docs/plans/query-latency.md). We logged wall-clock total but discarded the phase breakdown — this persists it so we optimize from data, not guesses.

## Changes
- **Migration** `20260603000000` — adds nullable `llm_ms` + `retrieval_ms` to `observed_queries` (applied to live DB)
- **`queryProfile`** — times the retrieval phase (profile + thoughts `Promise.all`), surfaces it in `meta.retrieval_ms`. LLM time was already computed.
- **`logObservedQuery`** — persists `llm_ms` (from `meta.latency_ms`) and `retrieval_ms`. Wall-clock `latency_ms` unchanged. Non-streaming only (streaming logs a partial payload — known gap).

## Initial assessment — "What are your recent projects?" (cited, 3 runs)

| run | total | llm | retrieval | overhead |
|---|---|---|---|---|
| 1 | 11,722 | 10,268 | 1,451 | 3 |
| 2 | 10,801 | 9,755 | 1,046 | 0 |
| 3 | 10,800 | 9,922 | 878 | 0 |

**~90% LLM, ~10% retrieval, ~0 framework overhead.** Answer is 2,613 chars (~650 output tokens). The "fast model so it must be elsewhere" intuition is disproven — it's the LLM, driven by output length, not the DB or framework. Retrieval (~1s) is the OpenRouter embedding call. Optimization targets, data-ranked: (1) output length / generation, (2) OpenRouter→direct Anthropic hop, (3) embedding cache. Streaming would fix *perceived* latency for humans regardless.

## Test plan
- [ ] `npm run test:unit` — 315/315
- [ ] `tsc --noEmit` clean
- [ ] migration applied; new queries populate `llm_ms` / `retrieval_ms`