### PR TITLE
feat(eval): Stage 2 — latency report + --runs/--baseline on the query eval harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-06-03 — feat(eval): Stage 2 of query-latency plan — `--runs N` (median-of-N latency + majority-vote correctness) and `--baseline` (append date/version/pass/p50/p95 to committed docs/eval-baselines.md); per-case + aggregate latency report. First baseline recorded. Surfaced behavioral-hard-tradeoff cites-source flake (#140)
+
 - 2026-06-03 — feat(query): progressive disclosure for enumeration questions — `RULE_PROGRESSIVE_DISCLOSURE` leads with the 3 most-recent projects + names the total + offers the rest via a follow-up ("show more"); projects pre-sorted by `git_evidence.last_push_at` (then `started`). New `overview` eval category (17/17, 28/28). Measured: "all projects" answer 2,613→1,361 chars, llm ~10s→~7s, with quality held — and stays bounded as project count grows
 
 - 2026-06-03 — feat(query): instrument phase timings — persist `llm_ms` + `retrieval_ms` to observed_queries; Stage 1 of the query-latency plan (docs/plans/query-latency.md). Initial assessment: "recent projects" query is ~90% LLM generation (output length), ~10% retrieval, ~0 framework overhead

--- a/README.md
+++ b/README.md
@@ -528,9 +528,18 @@ npm run eval:query -- --threshold 0.35
 # Add the LLM-as-judge rule (one Haiku call per case) — spot-checks the
 # semantic stuff the deterministic rules can't read (overclaim, real redirect)
 npm run eval:query -- --judge
+
+# Latency: run each case N times, report median-of-N per phase + p50/p95 aggregate.
+# Majority-vote across the N runs also stabilizes correctness (kills behavioral
+# single-run variance), so the recorded pass rate is trustworthy.
+npm run eval:query -- --runs 3
+
+# Record a baseline row (date, version, pass rate, p50/p95) to docs/eval-baselines.md
+# so git history shows which commit moved latency. Record from a clean run.
+npm run eval:query -- --runs 3 --baseline
 ```
 
-Read the per-case `PASS/FAIL — <rule>: <detail>` lines, then the category summary, then the overall score. A glance tells you whether off-topic cases are redirecting, capability cases are honest about gaps, behavioral cases are grounding in observations, and so on.
+Read the per-case `PASS/FAIL — <rule>: <detail>` lines, then the category summary, the overall score, and the **latency report** (p50/p95 for total / llm / retrieval, plus the slowest cases). The harness measures correctness **and** latency on one fixed set, so latency is only ever optimized with the pass rate held — see [`docs/plans/query-latency.md`](docs/plans/query-latency.md) and the recorded snapshots in [`docs/eval-baselines.md`](docs/eval-baselines.md).
 
 ---
 

--- a/docs/eval-baselines.md
+++ b/docs/eval-baselines.md
@@ -1,0 +1,10 @@
+# Eval baselines
+
+Correctness + latency snapshots recorded via `npm run eval:query -- --baseline --runs 3`.
+Each row aggregates the median-of-N per-case latency. Compare rows to see which
+commit moved latency. Upstream (OpenRouter/Haiku) variance is real — treat
+sub-second deltas as noise. Optimize latency only with the pass rate held.
+
+| date | version | runs/case | pass | total p50 | total p95 | llm p50 | retrieval p50 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 2026-06-03 | 0.4.46 | 3 | 16/17 | 2471 | 10137 | 2059 | 445 |

--- a/docs/plans/query-latency.md
+++ b/docs/plans/query-latency.md
@@ -16,8 +16,8 @@ We log wall-clock total but throw away the phase breakdown. Persist it:
 
 Migration adds two columns to `observed_queries`; `queryProfile` surfaces `retrieval_ms` in `meta`; logger persists both. Non-streaming only for now (streaming logs a partial payload — acceptable gap).
 
-### Stage 2 — Latency on `eval:query` (later)
-Add per-case timing + aggregate p50/p95 to the existing eval run. One command → correctness **and** latency on a fixed set. Write each run (version, date, pass rate, p50/p95) to a **committed** baseline file so git history shows which commit moved latency.
+### Stage 2 — Latency on `eval:query` ✅ shipped
+Per-case timing + aggregate p50/p95 in the eval run (`--runs N` for median-of-N). One command → correctness **and** latency on a fixed set. `--runs N` also majority-votes correctness across the N runs, killing behavioral single-run variance so the recorded pass rate is trustworthy. `--baseline` appends a row (date, version, pass rate, p50/p95) to the committed [`docs/eval-baselines.md`](../eval-baselines.md), so git history shows which commit moved latency.
 
 ### Stage 3 — Optimize against a target (later)
 Set a target (e.g. p50 < 3s cited, < 1.5s conversational). Loop: change → `eval:query` → correctness held + latency down? → keep/revert.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.45",
+  "version": "0.4.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.45",
+      "version": "0.4.46",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.45",
+  "version": "0.4.46",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/scripts/eval/run-eval.ts
+++ b/scripts/eval/run-eval.ts
@@ -90,7 +90,9 @@ function median(xs: number[]): number {
 function percentile(xs: number[], p: number): number {
   if (!xs.length) return 0
   const s = [...xs].sort((a, b) => a - b)
-  return s[Math.min(s.length - 1, Math.floor((p / 100) * s.length))]
+  // Nearest-rank: rank = ceil(p/100 * n), index = rank - 1, clamped to [0, n-1].
+  const rank = Math.ceil((p / 100) * s.length)
+  return s[Math.min(s.length - 1, Math.max(0, rank - 1))]
 }
 
 function avg(xs: number[]): number {
@@ -219,8 +221,14 @@ async function main(): Promise<void> {
     }
 
     const rules = judgeRule ? [...lastScore.rules, judgeRule] : lastScore.rules
-    const total = lastScore.total
-    const maxTotal = lastScore.maxTotal
+    // Compute the additive total over the *displayed* rules (including judge-llm,
+    // which is non-blocking) so the printed "(additive X/Y)" matches the rule list.
+    const additive = rules.filter((r) => !r.blocking)
+    const total = additive.reduce((sum, r) => sum + r.score, 0)
+    const maxTotal = additive.length
+    // Verdict: the majority-voted deterministic pass, with the judge (if enabled)
+    // as a semantic gate on top — it's a yes/no spot-check, so it gates rather
+    // than merely nudging the additive threshold.
     const pass = detPass && (judgeRule ? judgeRule.pass : true)
 
     process.stdout.write(`  A: ${result.answer.slice(0, 180).replace(/\s+/g, ' ')}${result.answer.length > 180 ? '…' : ''}\n`)
@@ -269,12 +277,19 @@ async function main(): Promise<void> {
   }
 
   // Baseline append — deliberate, only on --baseline. Records the current run so
-  // git history shows which commit moved latency.
-  if (flags.baseline && latencyByCase.length) {
-    const date = new Date().toISOString().slice(0, 10)
-    const row = `| ${date} | ${readVersion()} | ${flags.runs} | ${overallPass}/${overallTotal} | ${percentile(totals, 50)} | ${percentile(totals, 95)} | ${percentile(llms, 50)} | ${percentile(retrievals, 50)} |`
-    appendBaseline(row)
-    process.stdout.write(`\n  baseline recorded → ${BASELINE_PATH}\n`)
+  // git history shows which commit moved latency. Refuse to record if any case
+  // errored: those are counted in the pass column but excluded from the latency
+  // percentiles, which would make the row internally inconsistent / non-comparable.
+  if (flags.baseline) {
+    if (latencyByCase.length !== scores.length) {
+      const errored = scores.length - latencyByCase.length
+      process.stdout.write(`\n  baseline NOT recorded — ${errored} case(s) errored (no latency captured). Fix and re-run before baselining.\n`)
+    } else {
+      const date = new Date().toISOString().slice(0, 10)
+      const row = `| ${date} | ${readVersion()} | ${flags.runs} | ${overallPass}/${overallTotal} | ${percentile(totals, 50)} | ${percentile(totals, 95)} | ${percentile(llms, 50)} | ${percentile(retrievals, 50)} |`
+      appendBaseline(row)
+      process.stdout.write(`\n  baseline recorded → ${BASELINE_PATH}\n`)
+    }
   }
 
   process.exit(overallPass === overallTotal ? 0 : 1)

--- a/scripts/eval/run-eval.ts
+++ b/scripts/eval/run-eval.ts
@@ -1,24 +1,30 @@
 /**
- * Eval runner for the `/query` engagement rules.
+ * Eval runner for the `/query` engagement rules — correctness AND latency.
  *
  *   npm run eval:query
  *   npm run eval:query -- --case <id>
  *   npm run eval:query -- --category <name>
  *   npm run eval:query -- --threshold <n>     # override QUERY_THOUGHTS_THRESHOLD
  *   npm run eval:query -- --judge             # add the LLM-as-judge rule
+ *   npm run eval:query -- --runs <n>          # run each case n times, report median latency (default 1)
+ *   npm run eval:query -- --baseline          # append the run's aggregate to docs/eval-baselines.md
  *
  * Runs each case against `queryProfile()` directly (no HTTP server required;
  * reuses the shared core), scores it with the deterministic rubric in
- * `src/lib/eval-query-answer.ts`, optionally adds a Haiku judge call, and
- * prints per-case PASS/FAIL + a category summary + an overall score. Process
- * exit code is 0 if overall passes; 1 otherwise.
+ * `src/lib/eval-query-answer.ts`, optionally adds a Haiku judge call, times the
+ * query phases, and prints per-case PASS/FAIL + a category summary + a latency
+ * report. Process exit code is 0 if overall passes; 1 otherwise.
  *
- * The runner is on-demand (makes LLM calls); it is NOT in `test:unit`.
+ * Latency note: upstream (OpenRouter/Haiku) variance is real. Use `--runs 3+`
+ * to take the median per case before recording a baseline; treat sub-second
+ * deltas between runs as noise, not signal. The runner is on-demand (makes LLM
+ * calls); it is NOT in `test:unit`.
  */
 
 import { config } from 'dotenv'
 config({ path: '.env.local' })
 
+import { readFileSync, existsSync, writeFileSync, appendFileSync } from 'node:fs'
 import { generateText } from 'ai'
 import { getModel } from '../../src/lib/ai.js'
 import { parseJSON } from '../../src/lib/parse-json.js'
@@ -33,10 +39,12 @@ interface Flags {
   category?: string
   threshold?: number
   judge: boolean
+  runs: number
+  baseline: boolean
 }
 
 function parseFlags(argv: string[]): Flags {
-  const flags: Flags = { judge: false }
+  const flags: Flags = { judge: false, runs: 1, baseline: false }
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]
     if (arg === '--case') flags.case = argv[++i]
@@ -45,14 +53,20 @@ function parseFlags(argv: string[]): Flags {
       const n = Number(argv[++i])
       if (Number.isFinite(n)) flags.threshold = n
     } else if (arg === '--judge') flags.judge = true
+    else if (arg === '--runs') {
+      const n = Number(argv[++i])
+      if (Number.isFinite(n) && n >= 1) flags.runs = Math.floor(n)
+    } else if (arg === '--baseline') flags.baseline = true
     else if (arg === '--help' || arg === '-h') {
       process.stdout.write([
         'Usage: npm run eval:query [-- <flags>]',
         '',
         '  --case <id>          Run a single case by id',
-        '  --category <name>    Run one category (binary|capability|behavioral|off_topic|adversarial|no_data)',
+        '  --category <name>    Run one category (binary|capability|behavioral|off_topic|adversarial|no_data|overview)',
         '  --threshold <n>      Override QUERY_THOUGHTS_THRESHOLD for this run (e.g. 0.5)',
         '  --judge              Add an LLM-as-judge rule (one Haiku call per case)',
+        '  --runs <n>           Run each case n times; report median latency (default 1)',
+        '  --baseline           Append this run\'s aggregate to docs/eval-baselines.md',
         '  --help, -h           Show this',
         '',
       ].join('\n'))
@@ -60,6 +74,57 @@ function parseFlags(argv: string[]): Flags {
     }
   }
   return flags
+}
+
+// ── Latency helpers ──────────────────────────────────────────
+
+interface Sample { total: number; llm: number; retrieval: number }
+
+function median(xs: number[]): number {
+  if (!xs.length) return 0
+  const s = [...xs].sort((a, b) => a - b)
+  const mid = Math.floor(s.length / 2)
+  return s.length % 2 ? s[mid] : Math.round((s[mid - 1] + s[mid]) / 2)
+}
+
+function percentile(xs: number[], p: number): number {
+  if (!xs.length) return 0
+  const s = [...xs].sort((a, b) => a - b)
+  return s[Math.min(s.length - 1, Math.floor((p / 100) * s.length))]
+}
+
+function avg(xs: number[]): number {
+  return xs.length ? Math.round(xs.reduce((a, b) => a + b, 0) / xs.length) : 0
+}
+
+function readVersion(): string {
+  try {
+    return (JSON.parse(readFileSync('package.json', 'utf8')) as { version?: string }).version ?? 'unknown'
+  } catch {
+    return 'unknown'
+  }
+}
+
+const BASELINE_PATH = 'docs/eval-baselines.md'
+const BASELINE_HEADER = [
+  '# Eval baselines',
+  '',
+  'Correctness + latency snapshots recorded via `npm run eval:query -- --baseline --runs 3`.',
+  'Each row aggregates the median-of-N per-case latency. Compare rows to see which',
+  'commit moved latency. Upstream (OpenRouter/Haiku) variance is real — treat',
+  'sub-second deltas as noise. Optimize latency only with the pass rate held.',
+  '',
+  '| date | version | runs/case | pass | total p50 | total p95 | llm p50 | retrieval p50 |',
+  '| --- | --- | --- | --- | --- | --- | --- | --- |',
+  '',
+].join('\n')
+
+function appendBaseline(row: string): void {
+  if (!existsSync(BASELINE_PATH)) {
+    writeFileSync(BASELINE_PATH, BASELINE_HEADER + row + '\n')
+  } else {
+    appendFileSync(BASELINE_PATH, row + '\n')
+  }
 }
 
 // ── Main ─────────────────────────────────────────────────────
@@ -86,24 +151,58 @@ async function main(): Promise<void> {
     `Running ${selected.length} case(s)`,
     flags.threshold !== undefined ? `  threshold=${flags.threshold}` : `  threshold=${process.env.QUERY_THOUGHTS_THRESHOLD ?? '0.35 (default)'}`,
     `  judge=${flags.judge ? 'on' : 'off'}`,
+    `  runs=${flags.runs}`,
     '',
   ].join('\n') + '\n')
 
   const scores: { caseId: string; category: string; pass: boolean; total: number; maxTotal: number }[] = []
+  const latencyByCase: { caseId: string; category: string; med: Sample }[] = []
 
   for (const caseDef of selected) {
     process.stdout.write(`\n[${caseDef.id}] (${caseDef.category})\n  Q: ${caseDef.question}\n`)
 
     const callerHint = caseDef.callerHint ?? 'Unknown caller. Balance structure and readability. Be honest and direct.'
-    const result = await queryProfile({ question: caseDef.question, callerHint })
-    if ('kind' in result) {
-      process.stdout.write(`  FAIL — queryProfile error: ${result.kind}\n`)
+
+    // Run the query `runs` times, timing only the queryProfile call (not the judge).
+    // Score the deterministic rubric on EVERY run and majority-vote the pass — this
+    // makes --runs stabilize correctness (kills single-run model variance, e.g.
+    // behavioral cases flipping) as well as giving a latency median. At runs=1
+    // this is identical to scoring the single run.
+    const samples: Sample[] = []
+    const runPasses: boolean[] = []
+    let result: Awaited<ReturnType<typeof queryProfile>> | undefined
+    let lastScore: ReturnType<typeof scoreAnswer> | undefined
+    for (let run = 0; run < flags.runs; run++) {
+      const t0 = Date.now()
+      const r = await queryProfile({ question: caseDef.question, callerHint })
+      const totalMs = Date.now() - t0
+      result = r
+      if ('kind' in r) break // error — stop repeating this case
+      samples.push({ total: totalMs, llm: r.meta.latency_ms, retrieval: r.meta.retrieval_ms ?? 0 })
+      const s = scoreAnswer(caseDef, r)
+      lastScore = s
+      runPasses.push(s.pass)
+    }
+
+    if (!result || 'kind' in result || !lastScore) {
+      process.stdout.write(`  FAIL — queryProfile error: ${result && 'kind' in result ? result.kind : 'no result'}\n`)
       scores.push({ caseId: caseDef.id, category: caseDef.category, pass: false, total: 0, maxTotal: 1 })
       continue
     }
 
-    const score = scoreAnswer(caseDef, result)
-    let extraRule: RuleResult | undefined
+    const med: Sample = {
+      total: median(samples.map((s) => s.total)),
+      llm: median(samples.map((s) => s.llm)),
+      retrieval: median(samples.map((s) => s.retrieval)),
+    }
+    latencyByCase.push({ caseId: caseDef.id, category: caseDef.category, med })
+
+    // Majority of runs must pass the deterministic rubric.
+    const passCount = runPasses.filter(Boolean).length
+    const detPass = passCount > runPasses.length / 2
+
+    // The judge (if enabled) runs once on the last result — folded into the verdict.
+    let judgeRule: RuleResult | undefined
     if (flags.judge) {
       try {
         const { text } = await generateText({
@@ -112,40 +211,27 @@ async function main(): Promise<void> {
           prompt: buildJudgePrompt(caseDef, result.answer),
         })
         const parsed = parseJSON(text) as { pass?: boolean; reason?: string }
-        const pass = Boolean(parsed.pass)
-        extraRule = {
-          rule: 'judge-llm',
-          pass,
-          score: pass ? 1 : 0,
-          detail: parsed.reason ?? '(judge returned no reason)',
-        }
+        const jp = Boolean(parsed.pass)
+        judgeRule = { rule: 'judge-llm', pass: jp, score: jp ? 1 : 0, detail: parsed.reason ?? '(judge returned no reason)' }
       } catch (err) {
-        extraRule = {
-          rule: 'judge-llm',
-          pass: false,
-          score: 0,
-          detail: `judge call failed: ${(err as Error).message}`,
-        }
+        judgeRule = { rule: 'judge-llm', pass: false, score: 0, detail: `judge call failed: ${(err as Error).message}` }
       }
     }
 
-    const rules = extraRule ? [...score.rules, extraRule] : score.rules
-    // Blocking rules don't contribute to the additive total — match scoreAnswer's math.
-    // When a category has only blocking rules, pass rests on those alone.
-    const blockingFailed = rules.some((r) => r.blocking && !r.pass)
-    const additive = rules.filter((r) => !r.blocking)
-    const total = additive.reduce((sum, r) => sum + r.score, 0)
-    const maxTotal = additive.length
-    const passByThreshold = maxTotal === 0 ? true : total >= maxTotal * PASS_RATIO
-    const pass = !blockingFailed && passByThreshold
+    const rules = judgeRule ? [...lastScore.rules, judgeRule] : lastScore.rules
+    const total = lastScore.total
+    const maxTotal = lastScore.maxTotal
+    const pass = detPass && (judgeRule ? judgeRule.pass : true)
 
     process.stdout.write(`  A: ${result.answer.slice(0, 180).replace(/\s+/g, ' ')}${result.answer.length > 180 ? '…' : ''}\n`)
     process.stdout.write(`  confidence=${result.confidence}  sources=${JSON.stringify(result.sources ?? [])}\n`)
+    process.stdout.write(`  latency(median of ${samples.length}): total ${med.total}ms  llm ${med.llm}ms  retrieval ${med.retrieval}ms\n`)
     for (const r of rules) {
       const tag = r.blocking ? (r.pass ? '✓ (blocking)' : '✗ BLOCKING-FAIL') : (r.pass ? '✓' : '✗')
       process.stdout.write(`  ${tag} ${r.rule} — ${r.detail}\n`)
     }
-    process.stdout.write(`  ${pass ? 'PASS' : 'FAIL'} (additive ${total.toFixed(1)}/${maxTotal}${blockingFailed ? '; blocking-rule failure' : ''})\n`)
+    const voteNote = runPasses.length > 1 ? ` [passed ${passCount}/${runPasses.length} runs]` : ''
+    process.stdout.write(`  ${pass ? 'PASS' : 'FAIL'} (additive ${total.toFixed(1)}/${maxTotal})${voteNote}\n`)
 
     scores.push({ caseId: caseDef.id, category: caseDef.category, pass, total, maxTotal })
   }
@@ -168,6 +254,28 @@ async function main(): Promise<void> {
   const overallMax = scores.reduce((s, c) => s + c.maxTotal, 0)
   process.stdout.write(`  ─────────────────────────────────\n`)
   process.stdout.write(`  Overall:       ${overallPass}/${overallTotal} cases   ${overallScore.toFixed(1)}/${overallMax} rule points\n`)
+
+  // Latency report — aggregate over per-case medians
+  const totals = latencyByCase.map((l) => l.med.total)
+  const llms = latencyByCase.map((l) => l.med.llm)
+  const retrievals = latencyByCase.map((l) => l.med.retrieval)
+  if (latencyByCase.length) {
+    process.stdout.write('\n── Latency (median per case, aggregated, ms) ─\n')
+    process.stdout.write(`  total      p50 ${percentile(totals, 50)}   p95 ${percentile(totals, 95)}   avg ${avg(totals)}\n`)
+    process.stdout.write(`  llm        p50 ${percentile(llms, 50)}   p95 ${percentile(llms, 95)}   avg ${avg(llms)}\n`)
+    process.stdout.write(`  retrieval  p50 ${percentile(retrievals, 50)}   p95 ${percentile(retrievals, 95)}   avg ${avg(retrievals)}\n`)
+    const slowest = [...latencyByCase].sort((a, b) => b.med.total - a.med.total).slice(0, 3)
+    process.stdout.write(`  slowest:   ${slowest.map((s) => `${s.caseId} (${s.med.total}ms)`).join(', ')}\n`)
+  }
+
+  // Baseline append — deliberate, only on --baseline. Records the current run so
+  // git history shows which commit moved latency.
+  if (flags.baseline && latencyByCase.length) {
+    const date = new Date().toISOString().slice(0, 10)
+    const row = `| ${date} | ${readVersion()} | ${flags.runs} | ${overallPass}/${overallTotal} | ${percentile(totals, 50)} | ${percentile(totals, 95)} | ${percentile(llms, 50)} | ${percentile(retrievals, 50)} |`
+    appendBaseline(row)
+    process.stdout.write(`\n  baseline recorded → ${BASELINE_PATH}\n`)
+  }
 
   process.exit(overallPass === overallTotal ? 0 : 1)
 }


### PR DESCRIPTION
**Version:** 0.4.45 → 0.4.46

Stage 2 of [docs/plans/query-latency.md](docs/plans/query-latency.md). The eval harness now measures correctness **and** latency on one fixed fixture set — so latency can only be optimized with the pass rate held.

## Changes
- **`--runs N`** — runs each case N times, reports median-of-N per phase (total / llm / retrieval). Also **majority-votes correctness** across the N runs, which kills behavioral single-run variance so the recorded pass rate is trustworthy. At `--runs 1` (default) behavior is unchanged.
- **`--baseline`** — appends a row (date, version, pass, total p50/p95, llm p50, retrieval p50) to the committed `docs/eval-baselines.md`. Deliberate (flag-gated), so casual runs don't dirty git. Git history then shows which commit moved latency.
- **Latency report** — per-case median line + aggregate p50/p95/avg for total/llm/retrieval + the 3 slowest cases.

## First baseline (runs=3)

| total p50 | total p95 | llm p50 | retrieval p50 |
|---|---|---|---|
| 2,471ms | 10,137ms | 2,059ms | 445ms |

Confirms the Stage 1 diagnosis at fleet scale: the p95 tail is the behavioral cases (8–10s, long cited answers), retrieval is a flat ~450ms, and the fast caller paths (binary/off-topic/adversarial) sit at 2–3s.

## Note
The baseline pass shows **16/17** — `behavioral-hard-tradeoff` is dropping its `Sources:` block this session (passed earlier today). That's the chronic behavioral cites-source flake, now filed as **#140**. The harness catching it is the feature working. Not in scope here; latency is the Stage 2 deliverable and those numbers are valid (query path unchanged by this PR).

## Test plan
- [ ] `npm run test:unit` — 332/332
- [ ] `tsc --noEmit` clean
- [ ] `npm run eval:query -- --runs 3` prints per-case latency + aggregate + "passed N/3 runs"
- [ ] `npm run eval:query -- --baseline` appends a row to docs/eval-baselines.md