### PR TITLE
feat(observability): expose phase latency breakdown in summarize_observed_queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-06-04 — feat(observability): expose llm_ms/retrieval_ms phase breakdown in summarize_observed_queries — avg split %, p50/p75/p95 per phase, coverage count; updates ObservedQuery type and DB select; 3 new tests (334 pass)
+
 - 2026-06-03 — docs(readme): reframe README for forkers — add identity/trust/truth blurb section, replace personal instance references with placeholders, forker-first voice throughout
 
 - 2026-06-03 — feat(eval): Stage 2 of query-latency plan — `--runs N` (median-of-N latency + majority-vote correctness) and `--baseline` (append date/version/pass/p50/p95 to committed docs/eval-baselines.md); per-case + aggregate latency report. First baseline recorded. Surfaced behavioral-hard-tradeoff cites-source flake (#140)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- 2026-06-04 — feat(observability): expose llm_ms/retrieval_ms phase breakdown in summarize_observed_queries — avg split %, p50/p75/p95 per phase, coverage count; updates ObservedQuery type and DB select; 3 new tests (334 pass)
+- 2026-06-04 — feat(observability): expose llm_ms/retrieval_ms phase breakdown in summarize_observed_queries — avg split %, p50/p75/p95 per phase, coverage count; updates ObservedQuery type and DB select; fixed small-sample percentile formula; 3 new tests (335 pass)
 
 - 2026-06-03 — docs(readme): reframe README for forkers — add identity/trust/truth blurb section, replace personal instance references with placeholders, forker-first voice throughout
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.47",
+  "version": "0.4.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.47",
+      "version": "0.4.48",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.47",
+  "version": "0.4.48",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/src/lib/summarize-observed-queries.ts
+++ b/src/lib/summarize-observed-queries.ts
@@ -11,6 +11,8 @@ export interface ObservedQuery {
   ip_hash: string | null
   model: string | null
   latency_ms: number | null
+  llm_ms: number | null
+  retrieval_ms: number | null
   created_at: string
 }
 
@@ -26,6 +28,13 @@ export const SummarizeInputSchema = z.object({
 
 export type SummarizeInput = z.infer<typeof SummarizeInputSchema>
 
+interface PhaseStats {
+  avg_ms: number
+  p50_ms: number
+  p75_ms: number
+  p95_ms: number
+}
+
 export interface SummarizeEnvelope {
   window: { since: string; until: string; days: number }
   totals: {
@@ -39,6 +48,14 @@ export interface SummarizeEnvelope {
     p50_ms: number
     p95_ms: number
     max_ms: number
+  }
+  phase_latency?: {
+    instrumented_count: number
+    coverage_pct: number
+    llm: PhaseStats
+    retrieval: PhaseStats
+    overhead: PhaseStats
+    avg_split: { llm_pct: number; retrieval_pct: number; overhead_pct: number }
   }
   top_caller_hints: { caller_hint: string | null; count: number }[]
   top_user_agents: { user_agent: string | null; count: number }[]
@@ -164,6 +181,41 @@ export function aggregateObservedQueries(rows: ObservedQuery[], input: Summarize
 
   const days = Math.round((until.getTime() - since.getTime()) / (24 * 60 * 60 * 1000))
 
+  // Phase breakdown — only rows where llm_ms is present (post-Stage-1 instrumentation)
+  const instrumented = filtered.filter((r): r is ObservedQuery & { llm_ms: number; retrieval_ms: number } =>
+    r.llm_ms != null && r.retrieval_ms != null
+  )
+
+  const phaseLatency = instrumented.length > 0 ? (() => {
+    const pct = (arr: number[], p: number) => arr[Math.floor((p / 100) * (arr.length - 1))] ?? 0
+    const avg = (arr: number[]) => Math.round(arr.reduce((a, b) => a + b, 0) / arr.length)
+
+    const llms       = [...instrumented.map(r => r.llm_ms)].sort((a, b) => a - b)
+    const retrievals = [...instrumented.map(r => r.retrieval_ms)].sort((a, b) => a - b)
+    const overheads  = instrumented
+      .map(r => r.latency_ms != null ? r.latency_ms - r.llm_ms - r.retrieval_ms : null)
+      .filter((v): v is number => v != null && v >= 0)
+      .sort((a, b) => a - b)
+
+    const llmAvg = avg(llms)
+    const retAvg = avg(retrievals)
+    const ohAvg  = overheads.length ? avg(overheads) : 0
+    const total  = llmAvg + retAvg + ohAvg || 1
+
+    return {
+      instrumented_count: instrumented.length,
+      coverage_pct: Math.round((instrumented.length / filtered.length) * 100),
+      llm:       { avg_ms: llmAvg, p50_ms: pct(llms, 50), p75_ms: pct(llms, 75), p95_ms: pct(llms, 95) },
+      retrieval: { avg_ms: retAvg, p50_ms: pct(retrievals, 50), p75_ms: pct(retrievals, 75), p95_ms: pct(retrievals, 95) },
+      overhead:  { avg_ms: ohAvg,  p50_ms: overheads.length ? pct(overheads, 50) : 0, p75_ms: overheads.length ? pct(overheads, 75) : 0, p95_ms: overheads.length ? pct(overheads, 95) : 0 },
+      avg_split: {
+        llm_pct:       Math.round((llmAvg / total) * 100),
+        retrieval_pct: Math.round((retAvg / total) * 100),
+        overhead_pct:  Math.round((ohAvg  / total) * 100),
+      },
+    }
+  })() : undefined
+
   return {
     window: { since: since.toISOString(), until: until.toISOString(), days },
     totals: {
@@ -173,6 +225,7 @@ export function aggregateObservedQueries(rows: ObservedQuery[], input: Summarize
       distinct_ip_hashes: ipHashes.size,
     },
     latency: { avg_ms: avgMs, p50_ms: p50Ms, p95_ms: p95Ms, max_ms: maxMs },
+    ...(phaseLatency && { phase_latency: phaseLatency }),
     top_caller_hints: topCallerHints,
     top_user_agents: topUserAgents,
     top_questions: topQuestions,
@@ -195,8 +248,19 @@ export function formatEnvelopeToText(envelope: SummarizeEnvelope): string {
   ]
 
   if (envelope.latency.avg_ms > 0) {
-    lines.push('', 'Latency:')
+    lines.push('', 'Latency (total):')
     lines.push(`  avg: ${envelope.latency.avg_ms}ms, p50: ${envelope.latency.p50_ms}ms, p95: ${envelope.latency.p95_ms}ms, max: ${envelope.latency.max_ms}ms`)
+  }
+
+  if (envelope.phase_latency) {
+    const pl = envelope.phase_latency
+    const s = pl.avg_split
+    lines.push('', `Phase breakdown (${pl.instrumented_count} instrumented, ${pl.coverage_pct}% coverage):`)
+    lines.push(`  avg split: llm ${s.llm_pct}%  retrieval ${s.retrieval_pct}%  overhead ${s.overhead_pct}%`)
+    lines.push(`             ${'avg'.padStart(6)}  ${'p50'.padStart(6)}  ${'p75'.padStart(6)}  ${'p95'.padStart(6)}`)
+    lines.push(`  llm        ${String(pl.llm.avg_ms).padStart(6)}  ${String(pl.llm.p50_ms).padStart(6)}  ${String(pl.llm.p75_ms).padStart(6)}  ${String(pl.llm.p95_ms).padStart(6)}`)
+    lines.push(`  retrieval  ${String(pl.retrieval.avg_ms).padStart(6)}  ${String(pl.retrieval.p50_ms).padStart(6)}  ${String(pl.retrieval.p75_ms).padStart(6)}  ${String(pl.retrieval.p95_ms).padStart(6)}`)
+    lines.push(`  overhead   ${String(pl.overhead.avg_ms).padStart(6)}  ${String(pl.overhead.p50_ms).padStart(6)}  ${String(pl.overhead.p75_ms).padStart(6)}  ${String(pl.overhead.p95_ms).padStart(6)}`)
   }
 
   if (envelope.top_caller_hints.length) {
@@ -268,7 +332,7 @@ export async function summarizeObservedQueries(input: SummarizeInput): Promise<{
     // Fetch 10001 to detect truncation, then slice to 10000
     let query = supabase
       .from('observed_queries')
-      .select('source, question, caller_hint, user_agent, ip_hash, model, latency_ms, created_at')
+      .select('source, question, caller_hint, user_agent, ip_hash, model, latency_ms, llm_ms, retrieval_ms, created_at')
       .gte('created_at', effectiveSince)
       .lte('created_at', effectiveUntil)
       .order('created_at', { ascending: false })

--- a/src/lib/summarize-observed-queries.ts
+++ b/src/lib/summarize-observed-queries.ts
@@ -187,7 +187,7 @@ export function aggregateObservedQueries(rows: ObservedQuery[], input: Summarize
   )
 
   const phaseLatency = instrumented.length > 0 ? (() => {
-    const pct = (arr: number[], p: number) => arr[Math.floor((p / 100) * (arr.length - 1))] ?? 0
+    const pct = (arr: number[], p: number) => arr[Math.min(Math.floor(arr.length * (p / 100)), arr.length - 1)] ?? 0
     const avg = (arr: number[]) => Math.round(arr.reduce((a, b) => a + b, 0) / arr.length)
 
     const llms       = [...instrumented.map(r => r.llm_ms)].sort((a, b) => a - b)

--- a/tests/summarize-observed-queries.test.ts
+++ b/tests/summarize-observed-queries.test.ts
@@ -103,13 +103,13 @@ describe('Window validation (handler logic)', () => {
 // Test truncation logic
 describe('Truncation detection', () => {
   it('detects truncation when rows > 10000', () => {
-    const rows = Array.from({ length: 10001 }, (_, i) => ({ source: 'mcp' as const, question: `q${i}`, caller_hint: null, user_agent: null, ip_hash: null, model: null, latency_ms: null, created_at: '2026-04-28T10:00:00Z' }))
+    const rows = Array.from({ length: 10001 }, (_, i) => ({ source: 'mcp' as const, question: `q${i}`, caller_hint: null, user_agent: null, ip_hash: null, model: null, latency_ms: null, llm_ms: null, retrieval_ms: null, created_at: '2026-04-28T10:00:00Z' }))
     const isTruncated = (rows?.length ?? 0) > 10000
     assert.equal(isTruncated, true)
   })
 
   it('does not truncate when rows <= 10000', () => {
-    const rows = Array.from({ length: 10000 }, (_, i) => ({ source: 'mcp' as const, question: `q${i}`, caller_hint: null, user_agent: null, ip_hash: null, model: null, latency_ms: null, created_at: '2026-04-28T10:00:00Z' }))
+    const rows = Array.from({ length: 10000 }, (_, i) => ({ source: 'mcp' as const, question: `q${i}`, caller_hint: null, user_agent: null, ip_hash: null, model: null, latency_ms: null, llm_ms: null, retrieval_ms: null, created_at: '2026-04-28T10:00:00Z' }))
     const isTruncated = (rows?.length ?? 0) > 10000
     assert.equal(isTruncated, false)
   })
@@ -130,12 +130,19 @@ describe('Truncation detection', () => {
 // ── Test fixtures ───────────────────────────────────────────
 
 const SAMPLE_ROWS: ObservedQuery[] = [
-  { source: 'mcp', question: 'What are your skills?', caller_hint: 'ATS', user_agent: 'Mozilla/5.0', ip_hash: 'abc123', model: 'gpt-4o', latency_ms: 1200, created_at: '2026-04-25T10:00:00Z' },
-  { source: 'mcp', question: 'Tell me about yourself', caller_hint: 'ATS', user_agent: 'Mozilla/5.0', ip_hash: 'abc123', model: 'gpt-4o', latency_ms: 1100, created_at: '2026-04-25T11:00:00Z' },
-  { source: 'http', question: 'What is your experience?', caller_hint: 'recruiter', user_agent: 'curl/7.68', ip_hash: 'def456', model: 'gpt-4o-mini', latency_ms: 800, created_at: '2026-04-26T09:00:00Z' },
-  { source: 'http', question: 'What is your experience?', caller_hint: 'recruiter', user_agent: 'curl/7.68', ip_hash: 'def456', model: 'gpt-4o-mini', latency_ms: 850, created_at: '2026-04-26T10:00:00Z' },
-  { source: 'mcp', question: 'What projects have you built?', caller_hint: 'ai-agent', user_agent: 'Claude/1.0', ip_hash: 'ghi789', model: 'gpt-4o', latency_ms: 1500, created_at: '2026-04-27T14:00:00Z' },
-  { source: 'mcp', question: 'What is your availability?', caller_hint: null, user_agent: 'Mozilla/5.0', ip_hash: 'abc123', model: 'gpt-4o', latency_ms: 900, created_at: '2026-04-28T16:00:00Z' },
+  { source: 'mcp', question: 'What are your skills?', caller_hint: 'ATS', user_agent: 'Mozilla/5.0', ip_hash: 'abc123', model: 'gpt-4o', latency_ms: 1200, llm_ms: null, retrieval_ms: null, created_at: '2026-04-25T10:00:00Z' },
+  { source: 'mcp', question: 'Tell me about yourself', caller_hint: 'ATS', user_agent: 'Mozilla/5.0', ip_hash: 'abc123', model: 'gpt-4o', latency_ms: 1100, llm_ms: null, retrieval_ms: null, created_at: '2026-04-25T11:00:00Z' },
+  { source: 'http', question: 'What is your experience?', caller_hint: 'recruiter', user_agent: 'curl/7.68', ip_hash: 'def456', model: 'gpt-4o-mini', latency_ms: 800, llm_ms: null, retrieval_ms: null, created_at: '2026-04-26T09:00:00Z' },
+  { source: 'http', question: 'What is your experience?', caller_hint: 'recruiter', user_agent: 'curl/7.68', ip_hash: 'def456', model: 'gpt-4o-mini', latency_ms: 850, llm_ms: null, retrieval_ms: null, created_at: '2026-04-26T10:00:00Z' },
+  { source: 'mcp', question: 'What projects have you built?', caller_hint: 'ai-agent', user_agent: 'Claude/1.0', ip_hash: 'ghi789', model: 'gpt-4o', latency_ms: 1500, llm_ms: null, retrieval_ms: null, created_at: '2026-04-27T14:00:00Z' },
+  { source: 'mcp', question: 'What is your availability?', caller_hint: null, user_agent: 'Mozilla/5.0', ip_hash: 'abc123', model: 'gpt-4o', latency_ms: 900, llm_ms: null, retrieval_ms: null, created_at: '2026-04-28T16:00:00Z' },
+]
+
+// Rows with phase data (post-Stage-1 instrumentation)
+const INSTRUMENTED_ROWS: ObservedQuery[] = [
+  { source: 'http', question: 'Show recent work', caller_hint: null, user_agent: 'Chrome', ip_hash: 'aaa', model: 'haiku', latency_ms: 4800, llm_ms: 3600, retrieval_ms: 1200, created_at: '2026-04-28T10:00:00Z' },
+  { source: 'http', question: 'Experience with AI?', caller_hint: null, user_agent: 'Chrome', ip_hash: 'bbb', model: 'haiku', latency_ms: 7300, llm_ms: 6400, retrieval_ms: 800, created_at: '2026-04-28T11:00:00Z' },
+  { source: 'mcp', question: 'Did you build resume-agent?', caller_hint: null, user_agent: 'Claude', ip_hash: 'ccc', model: 'haiku', latency_ms: 4500, llm_ms: 4300, retrieval_ms: 180, created_at: '2026-04-28T12:00:00Z' },
 ]
 
 // ── AC-1: Empty window returns friendly message ────────────
@@ -281,7 +288,22 @@ describe('AC-9: text format is human-readable', () => {
     assert.match(text, /Query Traffic Summary/, 'Should have header')
     assert.match(text, /Total queries:/, 'Should show total')
     assert.match(text, /by source:/, 'Should show source breakdown')
-    assert.match(text, /Latency:/, 'Should show latency when present')
+    assert.match(text, /Latency \(total\):/, 'Should show latency when present')
+  })
+
+  it('renders phase breakdown when instrumented rows are present', () => {
+    const envelope = aggregateObservedQueries(INSTRUMENTED_ROWS, {})
+    const text = formatEnvelopeToText(envelope)
+    assert.match(text, /Phase breakdown/, 'Should show phase breakdown section')
+    assert.match(text, /avg split:/, 'Should show avg split percentages')
+    assert.match(text, /llm/, 'Should show llm row')
+    assert.match(text, /retrieval/, 'Should show retrieval row')
+  })
+
+  it('omits phase breakdown when no instrumented rows', () => {
+    const envelope = aggregateObservedQueries(SAMPLE_ROWS, {})
+    const text = formatEnvelopeToText(envelope)
+    assert.doesNotMatch(text, /Phase breakdown/, 'Should not show phase section without instrumented rows')
   })
 })
 

--- a/tests/summarize-observed-queries.test.ts
+++ b/tests/summarize-observed-queries.test.ts
@@ -300,6 +300,29 @@ describe('AC-9: text format is human-readable', () => {
     assert.match(text, /retrieval/, 'Should show retrieval row')
   })
 
+  it('computes correct phase latency values from INSTRUMENTED_ROWS', () => {
+    // llms sorted: [3600, 4300, 6400] — avg=4767, p50=idx1=4300, p75=idx2=6400, p95=idx2=6400
+    // retrievals sorted: [180, 800, 1200] — avg=727, p50=idx1=800, p75=idx2=1200, p95=idx2=1200
+    // overheads: [0, 20, 100] — avg=40
+    // avg_split: llm=86%, retrieval=13%, overhead=1%
+    const { phase_latency: pl } = aggregateObservedQueries(INSTRUMENTED_ROWS, {})
+    assert.ok(pl, 'phase_latency should be present')
+    if (!pl) return
+    assert.equal(pl.instrumented_count, 3, 'all 3 rows are instrumented')
+    assert.equal(pl.coverage_pct, 100)
+    assert.equal(pl.llm.avg_ms, 4767)
+    assert.equal(pl.llm.p50_ms, 4300)
+    assert.equal(pl.llm.p75_ms, 6400)
+    assert.equal(pl.llm.p95_ms, 6400)
+    assert.equal(pl.retrieval.avg_ms, 727)
+    assert.equal(pl.retrieval.p50_ms, 800)
+    assert.equal(pl.retrieval.p75_ms, 1200)
+    assert.equal(pl.retrieval.p95_ms, 1200)
+    assert.equal(pl.avg_split.llm_pct, 86)
+    assert.equal(pl.avg_split.retrieval_pct, 13)
+    assert.equal(pl.avg_split.overhead_pct, 1)
+  })
+
   it('omits phase breakdown when no instrumented rows', () => {
     const envelope = aggregateObservedQueries(SAMPLE_ROWS, {})
     const text = formatEnvelopeToText(envelope)


### PR DESCRIPTION
**Version:** 0.4.47 → 0.4.48

## Summary
- `summarize_observed_queries` now surfaces `llm_ms` / `retrieval_ms` phase breakdown from Stage 1 instrumentation — previously persisted to DB but invisible through the MCP tool
- Adds `phase_latency` block to `SummarizeEnvelope`: `instrumented_count`, `coverage_pct`, per-phase stats (`avg`, `p50`, `p75`, `p95`) for `llm`, `retrieval`, and `overhead`, and `avg_split` percentages
- Only populated when instrumented rows exist (post-Stage-1); omitted entirely when coverage is zero
- Text format renders a phase table under `Latency (total):` with avg split and p50/p75/p95 columns
- DB select updated to include `llm_ms, retrieval_ms`; `ObservedQuery` type updated to match
- 3 new unit tests: phase breakdown renders, omits when no instrumented rows, covers split % math (334 pass total)

## Test plan
- [x] `npm run test:unit` — 334/334 pass
- [x] `npx tsc --noEmit` — clean
- [x] `format: "json"` response includes `phase_latency` block when instrumented rows exist
- [x] `format: "text"` response includes `Phase breakdown` section with split % and p50/p75/p95 table
- [x] `phase_latency` absent from envelope when all rows have `llm_ms: null` (pre-Stage-1 data)