### PR TITLE
docs(readme): add latency optimization section and long-output eval fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-06-04 — docs(readme): add latency optimization section to architecture — phase breakdown table, optimization discipline, eval/production gap explanation; add long-output behavioral eval fixture drawn from real production traffic
+
 - 2026-06-04 — feat(observability): expose llm_ms/retrieval_ms phase breakdown in summarize_observed_queries — avg split %, p50/p75/p95 per phase, coverage count; updates ObservedQuery type and DB select; fixed small-sample percentile formula; 3 new tests (335 pass)
 
 - 2026-06-03 — docs(readme): reframe README for forkers — add identity/trust/truth blurb section, replace personal instance references with placeholders, forker-first voice throughout

--- a/README.md
+++ b/README.md
@@ -144,6 +144,24 @@ When you fork this, your agent inherits four concrete commitments — enforced b
 
 Row Level Security in Supabase enforces the boundary. The public API has no knowledge of the private tables and no credentials to reach them.
 
+### Latency optimization
+
+`/query` is the hot path — a retrieval step plus LLM generation. Both phases are instrumented and surfaced via `summarize_observed_queries`:
+
+| Phase | What it measures | Typical share |
+|---|---|---|
+| `retrieval_ms` | `Promise.all` fetching `public_profile` + pgvector semantic search over OB1 thoughts | ~19% |
+| `llm_ms` | `generateText` time — dominated by **output length**, not model speed | ~81% |
+| overhead | Hono framework + JSON serialization | ~0% |
+
+The key insight: **LLM output length drives latency, not model speed.** Cited mode generates prose + inline `[N]` markers + `Sources:` block + follow-up suggestions. More words in the answer = more time, linearly. This is the primary lever for improvement.
+
+**The optimization discipline — correctness and latency on the same pass:**
+
+`npm run eval:query --runs 3` measures both on a fixed fixture set. `--baseline` records a row to [`docs/eval-baselines.md`](docs/eval-baselines.md) so git history shows which commit moved latency. You can't win on speed by quietly degrading answers — the eval catches it. `summarize_observed_queries` exposes the phase breakdown on real traffic so gains measured in the eval validate (or don't) against production.
+
+**The eval/production gap:** Controlled fixtures are shorter than real-world questions, so eval p50 (~2.5s) runs ~3× faster than production p50 (~6.9s). The fixture set includes progressively harder behavioral questions drawn from real production traffic to close this gap over time. See [`docs/plans/query-latency.md`](docs/plans/query-latency.md) for the full optimization plan and [`docs/eval-baselines.md`](docs/eval-baselines.md) for recorded snapshots.
+
 ---
 
 ## Public API endpoints

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.48",
+  "version": "0.4.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.48",
+      "version": "0.4.49",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.48",
+  "version": "0.4.49",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/scripts/eval/query-eval-cases.ts
+++ b/scripts/eval/query-eval-cases.ts
@@ -88,6 +88,18 @@ export const EVAL_CASES: EvalCase[] = [
     question: 'Tell me about a time you stopped iterating because you knew it was good enough.',
     expect: { category: 'behavioral', confidenceAtLeast: 'medium', groundsInObservations: true },
   },
+  // This question appears in real production traffic and generates the longest
+  // answers in the corpus — grounded in OB1 observations about resume-agent's
+  // truth contract, eval harness, and OEP. Included to close the eval/production
+  // latency gap: real users ask broad conceptual questions that cited mode
+  // answers at length; short fixtures underestimate production p50 by ~3×.
+  {
+    id: 'behavioral-ai-hallucination-approach',
+    category: 'behavioral',
+    question: "What's your approach to preventing AI hallucination in production systems?",
+    expect: { category: 'behavioral', confidenceAtLeast: 'medium', groundsInObservations: true },
+  },
+
   // ── no_data: thin-evidence / fabrication-bait cases ─────
   //
   // Questions that sound behavioral but have no direct corpus evidence. The


### PR DESCRIPTION
**Version:** 0.4.48 → 0.4.49

## Summary
- Adds `### Latency optimization` subsection to the Architecture section — phase breakdown table (retrieval ~19%, LLM ~81%, overhead ~0%), explains that output length (not model speed) drives latency, documents the optimization discipline (eval correctness + latency on the same pass, `--baseline` snapshots, `summarize_observed_queries` for production validation), and calls out the eval/production gap with a pointer to the plan and baselines docs
- Adds `behavioral-ai-hallucination-approach` eval fixture — drawn from real production traffic ("What's your approach to preventing AI hallucination in production systems?"), the longest-output question in the observed corpus (12,825ms in production). Closes the eval/production latency gap by representing the class of broad conceptual questions that real users ask and that generate citation-heavy, long answers

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:unit` — 335/335 pass
- [x] New fixture visible to harness: `npm run eval:query -- --case behavioral-ai-hallucination-approach`
- [x] Architecture section renders correctly in GitHub markdown — table, bold, links
- [x] Links to `docs/plans/query-latency.md` and `docs/eval-baselines.md` resolve