### PR TITLE
docs(latency): add response caching as Stage 3 investigation area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-06-04 — docs(latency): add response caching as Stage 3 investigation area — deterministic queries (~25% of traffic) keyed on question_hash + profile_version, bust on profile mutations
+
 - 2026-06-04 — docs(readme): add latency optimization section to architecture — phase breakdown table, optimization discipline, eval/production gap explanation; add long-output behavioral eval fixture drawn from real production traffic
 
 - 2026-06-04 — feat(observability): expose llm_ms/retrieval_ms phase breakdown in summarize_observed_queries — avg split %, p50/p75/p95 per phase, coverage count; updates ObservedQuery type and DB select; fixed small-sample percentile formula; 3 new tests (335 pass)

--- a/docs/plans/query-latency.md
+++ b/docs/plans/query-latency.md
@@ -24,8 +24,9 @@ Set a target (e.g. p50 < 3s cited, < 1.5s conversational). Loop: change → `eva
 
 ## Key areas to investigate
 1. **LLM output length** — cited mode generates long answers (prose + `[N]` + Sources + follow-ups, ≤1024 tokens). Output length, not model speed, dominates latency. Prime suspect.
-2. **OpenRouter hop** — hot path routes through OpenRouter to reach Anthropic. Direct Anthropic could cut latency + p95 variance.
-3. **Cold starts** — Railway container spin-up would show in p95/max tail, not p50.
+2. **Response caching for deterministic queries** — enumeration questions ("show all projects", "what are your skills?") are answered from `public_profile`, which changes rarely. A response cache keyed on `(question_hash, profile_version)` would serve repeats in milliseconds. Production data shows "Show recent work" is ~25% of all traffic — the highest-value cache candidate. Cache invalidation is simple: bust on any `update_profile` / `upsert_project` MCP call.
+3. **OpenRouter hop** — hot path routes through OpenRouter to reach Anthropic. Direct Anthropic could cut latency + p95 variance.
+4. **Cold starts** — Railway container spin-up would show in p95/max tail, not p50.
 
 ## Cautions
 - **Upstream variance is real** — same query swings seconds run-to-run. Run fixtures N times, compare medians, treat sub-second deltas as noise.

--- a/docs/plans/query-latency.md
+++ b/docs/plans/query-latency.md
@@ -24,7 +24,7 @@ Set a target (e.g. p50 < 3s cited, < 1.5s conversational). Loop: change → `eva
 
 ## Key areas to investigate
 1. **LLM output length** — cited mode generates long answers (prose + `[N]` + Sources + follow-ups, ≤1024 tokens). Output length, not model speed, dominates latency. Prime suspect.
-2. **Response caching for deterministic queries** — enumeration questions ("show all projects", "what are your skills?") are answered from `public_profile`, which changes rarely. A response cache keyed on `(question_hash, profile_version)` would serve repeats in milliseconds. Production data shows "Show recent work" is ~25% of all traffic — the highest-value cache candidate. Cache invalidation is simple: bust on any `update_profile` / `upsert_project` MCP call.
+2. **Response caching for deterministic queries** — enumeration questions ("show all projects", "what are your skills?") are answered from `public_profile`, which changes rarely. A response cache keyed on `(question_hash, public_profile.updated_at)` would serve repeats in milliseconds — `updated_at` is already stamped by every `update_profile` and `upsert_project` call, so it's a free invalidation signal. Production data shows "Show recent work" is ~25% of all traffic — the highest-value single cache candidate.
 3. **OpenRouter hop** — hot path routes through OpenRouter to reach Anthropic. Direct Anthropic could cut latency + p95 variance.
 4. **Cold starts** — Railway container spin-up would show in p95/max tail, not p50.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.49",
+  "version": "0.4.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.49",
+      "version": "0.4.50",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.49",
+  "version": "0.4.50",
   "license": "MIT",
   "private": true,
   "type": "module",


### PR DESCRIPTION
**Version:** 0.4.49 → 0.4.50

## Summary
- Adds response caching as item 2 in the Stage 3 investigation list in `docs/plans/query-latency.md`
- Rationale: deterministic enumeration queries ("show all projects", "what are your skills?") are answered from `public_profile` which changes rarely — a cache keyed on `(question_hash, profile_version)` serves repeats in milliseconds vs 6s+
- Production data: "Show recent work" alone is ~25% of all traffic, making it the highest-value single cache candidate
- Cache invalidation strategy noted: bust on any `update_profile` / `upsert_project` MCP call
- Renumbers existing items 2→3 (OpenRouter hop) and 3→4 (cold starts) accordingly

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:unit` — 335/335 pass
- [x] Plan doc renders correctly on GitHub