### PR TITLE
chore(eval): record baseline with 18 cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-06-05 — chore(eval): record baseline with 18 cases — 18/18 pass, p50 3183ms, p95 11888ms; previous flake (behavioral-hard-tradeoff cites-source) resolved by majority-vote; p50/p95 now honest with long-output behavioral fixtures included
+
 - 2026-06-04 — docs(latency): add response caching as Stage 3 investigation area — deterministic queries (~25% of traffic) keyed on question_hash + profile_version, bust on profile mutations
 
 - 2026-06-04 — docs(readme): add latency optimization section to architecture — phase breakdown table, optimization discipline, eval/production gap explanation; add long-output behavioral eval fixture drawn from real production traffic

--- a/docs/eval-baselines.md
+++ b/docs/eval-baselines.md
@@ -8,3 +8,4 @@ sub-second deltas as noise. Optimize latency only with the pass rate held.
 | date | version | runs/case | pass | total p50 | total p95 | llm p50 | retrieval p50 |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | 2026-06-03 | 0.4.46 | 3 | 16/17 | 2471 | 10137 | 2059 | 445 |
+| 2026-06-04 | 0.4.50 | 3 | 18/18 | 3183 | 11888 | 2765 | 482 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.50",
+  "version": "0.4.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.50",
+      "version": "0.4.51",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.50",
+  "version": "0.4.51",
   "license": "MIT",
   "private": true,
   "type": "module",


### PR DESCRIPTION
**Version:** 0.4.50 → 0.4.51

## Summary
- Records new eval baseline row: 18/18 pass, p50 3183ms, p95 11888ms (v0.4.50, 3 runs/case)
- Adds the `behavioral-ai-hallucination-approach` fixture to the suite (18 cases vs 17 previously)
- Previous flake (`behavioral-hard-tradeoff` cites-source) resolves cleanly — majority-vote across 3 runs kills single-run variance
- p50/p95 are now honest: long-output behavioral questions (hallucination approach, hard tradeoff, feature decisions) anchor the expensive end of the distribution, closing the eval/production latency gap

## Baseline delta
| metric | old (16/17, v0.4.46) | new (18/18, v0.4.50) |
|---|---|---|
| pass rate | 16/17 | 18/18 |
| total p50 | 2471ms | 3183ms |
| total p95 | 10137ms | 11888ms |
| llm p50 | 2059ms | 2765ms |
| retrieval p50 | 445ms | 482ms |

p50 increase is expected — the fixture set now includes the class of questions that dominate production latency.

## Test plan
- [x] `npm run eval:query -- --runs 3 --baseline` — 18/18 pass, row appended to docs/eval-baselines.md
- [x] `npx tsc --noEmit` — clean