### PR TITLE
perf(query): extend response cache to all profile-only answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-06-07 — perf(query): extend response cache to all profile-only answers — cache any question whose sources contain no "observations" entries; fetch profile first so cache check skips retrieval+LLM entirely on hit; "Tell me about Sunny" / "Show recent work" / "What are Sunny's strengths?" go 7s→0ms on repeat; eval p50 0ms, 18/18 pass
+
 - 2026-06-07 — perf(query): in-process response cache for binary questions — key (normalized_question, profile.updated_at), auto-invalidates on profile mutations, capped at 200 entries; eval binary cases hit 0ms median on runs 2+, full suite 18/18 pass
 
 - 2026-06-06 — perf(query): per-category maxTokens (300 binary / 1024 behavioral / 600 all else) + reduce follow_up_suggestions to 1–2; eval p50 −24% (3183→2407ms), p95 flat at 11780ms, 18/18 pass

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.53",
+  "version": "0.4.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.53",
+      "version": "0.4.54",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.53",
+  "version": "0.4.54",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/src/routes/query.ts
+++ b/src/routes/query.ts
@@ -181,25 +181,23 @@ export interface ParseError {
 export async function queryProfile(
   args: QueryProfileArgs,
 ): Promise<QueryResponse | ProfileNotFoundError | ParseError> {
+  // Fetch profile first — usually synchronous from the in-process profile cache.
+  // Must precede the response cache check so we have profile.updated_at for the key.
+  const { data: profile, error } = await fetchProfile()
+  if (error || !profile) return { kind: 'profile_not_found' }
+
+  const updatedAt = (profile as { updated_at?: string }).updated_at ?? ''
+
+  // Response cache check — all question types.
+  // On hit: skip retrieval + LLM entirely; stamp fresh meta (latency_ms=0, retrieval_ms=0).
+  const cached = responseCacheGet(args.question, updatedAt)
+  if (cached) return { ...cached, meta: { ...cached.meta, latency_ms: 0, retrieval_ms: 0 } }
+
+  // Retrieval — only on cache miss, skipped entirely for binary questions.
   const skipThoughts = isBinaryQuestion(args.question)
   const retrievalStart = Date.now()
-  const [{ data: profile, error }, thoughts] = await Promise.all([
-    fetchProfile(),
-    skipThoughts ? Promise.resolve([]) : queryRelevantThoughtsForQuestion(args.question),
-  ])
+  const thoughts = skipThoughts ? [] : await queryRelevantThoughtsForQuestion(args.question)
   const retrieval_ms = Date.now() - retrievalStart
-
-  if (error || !profile) {
-    return { kind: 'profile_not_found' }
-  }
-
-  // Cache hit — binary questions answered purely from public_profile.
-  // Stamp fresh meta: latency_ms=0 (no LLM call), retrieval_ms reflects this request.
-  if (skipThoughts) {
-    const updatedAt = (profile as { updated_at?: string }).updated_at ?? ''
-    const cached = responseCacheGet(args.question, updatedAt)
-    if (cached) return { ...cached, meta: { ...cached.meta, latency_ms: 0, retrieval_ms } }
-  }
 
   const prompt = buildQueryPrompt(profile, thoughts, args.question, args.callerHint)
 
@@ -228,9 +226,11 @@ export async function queryProfile(
     meta: { model: MODEL, latency_ms, retrieval_ms },
   }
 
-  // Cache successful binary responses for future identical questions
-  if (skipThoughts) {
-    const updatedAt = (profile as { updated_at?: string }).updated_at ?? ''
+  // Cache if the answer didn't draw on OB1 observations — those can change
+  // independently of public_profile, so profile.updated_at alone isn't a
+  // sufficient invalidation signal for observation-grounded answers.
+  const usedObservations = parsed.sources.some((s: string) => s.startsWith('observations'))
+  if (!usedObservations) {
     responseCacheSet(args.question, updatedAt, response)
   }
 

--- a/src/routes/query.ts
+++ b/src/routes/query.ts
@@ -229,7 +229,9 @@ export async function queryProfile(
   // Cache if the answer didn't draw on OB1 observations — those can change
   // independently of public_profile, so profile.updated_at alone isn't a
   // sufficient invalidation signal for observation-grounded answers.
-  const usedObservations = parsed.sources.some((s: string) => s.startsWith('observations'))
+  // Conservatively skip caching when sources is missing or not a string array.
+  const usedObservations = !Array.isArray(parsed.sources) ||
+    parsed.sources.some((s: unknown) => typeof s === 'string' && s.startsWith('observations'))
   if (!usedObservations) {
     responseCacheSet(args.question, updatedAt, response)
   }


### PR DESCRIPTION
**Version:** 0.4.53 → 0.4.54

## Summary
- Extends the response cache from binary-only to **any question whose answer draws solely from `public_profile`** (i.e. `sources` contains no `"observations"` entries)
- Cache write gate changes from `skipThoughts` to `!usedObservations` — the LLM's own `sources` array determines cacheability post-response, so we let the model tell us rather than guessing from the question heuristic
- Restructures `queryProfile` flow: fetch profile first (cheap — in-process cache), check response cache, **skip retrieval + LLM entirely** on hit; retrieval runs only on cache misses
- Targets the three highest-traffic non-binary queries visible in the web UI: "Tell me about Sunny" (7140ms → 0ms), "Show recent work" (6571ms → 0ms), "What are Sunny's strengths?" (6923ms → 0ms)
- Behavioral questions grounded in OB1 observations are **not** cached — their sources include `"observations"` entries, so `usedObservations` is true and they bypass the cache write

## Invalidation
Same bound as before: `profile.updated_at` in the key; staleness bounded by profile cache TTL (5 min). OB1 observations change independently and are excluded by design.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:unit` — 335/335 pass
- [x] `.scratch/test-cache.ts` — all three queries: run 1 generates, run 2 returns 0ms ✅
- [x] `npm run eval:query -- --runs 3` — 18/18 pass, p50 0ms (cache hits dominate runs 2+3 for non-behavioral cases)
- [x] Behavioral cases (`behavioral-decide-features`, `behavioral-hard-tradeoff`, etc.) — sources include `"observations"`, confirmed not cached