### PR TITLE
fix(sync): PAT for private repos, version drift detection, convention doc

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -29,7 +29,7 @@ jobs:
           SUPA_PROJECT_URL: ${{ secrets.SUPA_PROJECT_URL }}
           SUPA_SERVICE_ROLE: ${{ secrets.SUPA_SERVICE_ROLE }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           PUBLIC_URL: ${{ secrets.PUBLIC_URL }}
           OEP_PUBLIC_KEY: ${{ secrets.OEP_PUBLIC_KEY }}
           OEP_PRIVATE_KEY: ${{ secrets.OEP_PRIVATE_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+- 2026-06-09 — fix(sync): swap GITHUB_TOKEN for GH_PAT so nightly sync can read private repos outside resume-agent
+- 2026-06-09 — fix(sync): version drift detection — warns via OB1 thought when package.json is ahead of latest CHANGELOG section by >1 patch or any minor/major; deduped by content hash
+- 2026-06-09 — docs(sync): add SYNC-CONVENTION.md covering what syncs, keep-a-changelog convention, per-repo escape hatches, and downstream fork guidance
+
 - 2026-06-07 — docs(readme): update latency optimization section — documents shipped cache (phase breakdown, 3 levers, baseline progression table, production verification), replaces pre-optimization numbers
 
 - 2026-06-07 — perf(query): OB1 version token — adds thoughts MAX(updated_at) as second cache key dimension (60s TTL); all question types now cached; behavioral p95 drops from 11316ms to 320ms; eval 18/18 pass p50 0ms p95 320ms

--- a/docs/SYNC-CONVENTION.md
+++ b/docs/SYNC-CONVENTION.md
@@ -1,0 +1,69 @@
+# Sync Convention
+
+The nightly sync (`scripts/sync.ts`, triggered by `.github/workflows/sync.yml`) keeps portfolio project data in OB1 current. It reads from GitHub and writes to the `public_profile.projects` array in Supabase.
+
+## What the sync updates
+
+Per project with a `repo` GitHub URL in the profile:
+
+| Field | Source | Notes |
+|---|---|---|
+| `architecture` | `README.md` (or `docsPath`) | LLM reconciles; no-ops if already accurate |
+| `highlights` | `CHANGELOG.md` shipped sections | Additive enrichment; excludes `[Unreleased]` |
+| `tech` | `package.json` dependencies | Additive, capped at 15; maps package names to display names |
+| `status` | Repo `pushed_at` date | Inferred active/archived |
+| `url` | README badges / repo homepage | First valid URL found |
+| `git_evidence` | GitHub API | Commit count, contributors, OEP-signed |
+| OB1 thoughts | CHANGELOG + feature docs | Extracted facts stored with embeddings |
+| CANDIDATE_STACK | All active/in-progress projects | Rebuilt after every sync run |
+
+## Fields the sync never touches
+
+`description`, `problem`, `role`, `impact`, `started`, `name`, `slug`, `repo` — set these once via `upsert_project` and the sync leaves them alone.
+
+## The default convention
+
+For sync to work without any per-repo config, follow **keep-a-changelog** with **semver**:
+
+```
+## [Unreleased]
+- work in progress goes here
+
+## [1.2.3] - 2026-06-09
+### Added
+- concrete shipped thing
+
+## [1.2.2] - 2026-05-30
+...
+```
+
+**One rule:** every merge to main that ships real work gets a versioned section before or at merge. `[Unreleased]` is fine for in-progress work, but the sync treats it as planned — it won't appear in `highlights` until it has a version.
+
+Version drift (package.json ahead of latest CHANGELOG section by more than 1 patch) is detected automatically and written as an OB1 warning thought so it surfaces rather than silently producing stale data.
+
+## Per-repo escape hatches
+
+Add these fields to the project entry in `public_profile.projects` (via `upsert_project`) when the default doesn't fit:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `docsPath` | `string` | Path to architecture doc if not `README.md` (e.g. `docs/platform/architecture.md`) |
+| `featureDocsGlobs` | `string[]` | Directory prefixes to scan for additional `.md` feature docs (e.g. `["docs/features"]`) |
+
+`docsPath` is especially useful for private repos whose README is boilerplate or contains business logic — point it at a curated architecture file instead.
+
+## When to use `manual` strategy
+
+Some projects don't have machine-readable docs the sync can use:
+
+- **Docs-only repos** (no package.json, no CHANGELOG) — OEP is an example
+- **Private repos with no safe architecture doc** — set no `docsPath`, omit the `repo` field, and maintain `architecture` / `highlights` / `description` by hand via `upsert_project`
+
+## For downstream forks
+
+If you fork `resume-agent` and run your own sync:
+
+1. Follow keep-a-changelog + semver in your repos for zero-config sync
+2. Use `docsPath` for any repo where the README isn't the right architecture source
+3. Store your PAT as `GH_PAT` in Actions secrets — the default `GITHUB_TOKEN` cannot read private repos outside the resume-agent repo itself
+4. Add a `repo` GitHub URL to each project entry you want synced; projects without one are silently skipped

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.57",
+  "version": "0.4.58",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -323,16 +323,20 @@ function driftLabel(pkgV: string, logV: string, pkg: SemVer, log: SemVer): strin
 
 async function warnVersionDrift(slug: string, pkgVersion: string, logVersion: string, label: string): Promise<void> {
   const message = `VERSION DRIFT [${slug}]: package.json@${pkgVersion} is ahead of CHANGELOG@${logVersion} (${label}) — sync highlights and thoughts reflect ${logVersion} only until a versioned CHANGELOG entry is added`
-  const hash = contentHash(slug, `version-drift:${pkgVersion}:${logVersion}`)
-  const { data: existing } = await supabase.from('thoughts').select('id').eq('content_hash', hash).limit(1)
-  if (existing?.length) return
-  const { embedding } = await embed({ model: openrouter.embedding('openai/text-embedding-3-small'), value: message })
-  await supabase.from('thoughts').insert({
-    content: message,
-    embedding,
-    content_hash: hash,
-    metadata: { type: 'observation', source: 'sync', project: slug, topics: [slug, 'version_drift', 'sync_warning'] },
-  })
+  try {
+    const hash = contentHash(slug, `version-drift:${pkgVersion}:${logVersion}`)
+    const { data: existing } = await supabase.from('thoughts').select('id').eq('content_hash', hash).limit(1)
+    if (existing?.length) return
+    const { embedding } = await embed({ model: openrouter.embedding('openai/text-embedding-3-small'), value: message })
+    await supabase.from('thoughts').insert({
+      content: message,
+      embedding,
+      content_hash: hash,
+      metadata: { type: 'observation', source: 'sync', project: slug, topics: [slug, 'version_drift', 'sync_warning'] },
+    })
+  } catch (err) {
+    console.warn(`  ⚠ version drift thought write failed (non-fatal): ${(err as Error).message}`)
+  }
 }
 
 // ── Thought extraction + storage ─────────────────────────

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -293,6 +293,48 @@ export function splitChangelogSections(changelog: string): ChangelogSections {
   }
 }
 
+// ── Version drift detection ───────────────────────────────
+
+interface SemVer { major: number; minor: number; patch: number }
+
+function parseSemVer(v: string): SemVer | null {
+  const m = /^v?(\d+)\.(\d+)\.(\d+)/.exec(v.trim())
+  if (!m) return null
+  return { major: parseInt(m[1], 10), minor: parseInt(m[2], 10), patch: parseInt(m[3], 10) }
+}
+
+function latestChangelogVersion(changelog: string): string | null {
+  const m = /^##\s*\[?v?(\d+\.\d+\.\d+)/m.exec(changelog)
+  return m ? m[1] : null
+}
+
+function isDriftSignificant(pkg: SemVer, log: SemVer): boolean {
+  if (pkg.major > log.major) return true
+  if (pkg.major === log.major && pkg.minor > log.minor) return true
+  if (pkg.major === log.major && pkg.minor === log.minor && pkg.patch - log.patch > 1) return true
+  return false
+}
+
+function driftLabel(pkgV: string, logV: string, pkg: SemVer, log: SemVer): string {
+  if (pkg.major !== log.major) return `major: ${logV} → ${pkgV}`
+  if (pkg.minor !== log.minor) return `minor: ${logV} → ${pkgV}`
+  return `${pkg.patch - log.patch} unreleased patches: ${logV} → ${pkgV}`
+}
+
+async function warnVersionDrift(slug: string, pkgVersion: string, logVersion: string, label: string): Promise<void> {
+  const message = `VERSION DRIFT [${slug}]: package.json@${pkgVersion} is ahead of CHANGELOG@${logVersion} (${label}) — sync highlights and thoughts reflect ${logVersion} only until a versioned CHANGELOG entry is added`
+  const hash = contentHash(slug, `version-drift:${pkgVersion}:${logVersion}`)
+  const { data: existing } = await supabase.from('thoughts').select('id').eq('content_hash', hash).limit(1)
+  if (existing?.length) return
+  const { embedding } = await embed({ model: openrouter.embedding('openai/text-embedding-3-small'), value: message })
+  await supabase.from('thoughts').insert({
+    content: message,
+    embedding,
+    content_hash: hash,
+    metadata: { type: 'observation', source: 'sync', project: slug, topics: [slug, 'version_drift', 'sync_warning'] },
+  })
+}
+
 // ── Thought extraction + storage ─────────────────────────
 
 interface ExtractedFact {
@@ -774,6 +816,20 @@ async function syncProject(
     console.log(`  ✔ tech merged (${newTech.length} entries)`)
   } else {
     console.log(`  — tech unchanged`)
+  }
+
+  // ── Version drift detection ───────────────────────────────
+  if (pkgJson && changelog) {
+    let pkgParsed: { version?: string } = {}
+    try { pkgParsed = JSON.parse(pkgJson) } catch { /* ignore */ }
+    const pkgVer = pkgParsed.version ? parseSemVer(pkgParsed.version) : null
+    const logVerStr = latestChangelogVersion(changelog)
+    const logVer = logVerStr ? parseSemVer(logVerStr) : null
+    if (pkgVer && logVer && isDriftSignificant(pkgVer, logVer)) {
+      const label = driftLabel(pkgParsed.version!, logVerStr!, pkgVer, logVer)
+      console.warn(`  ⚠ version drift: ${label}`)
+      await warnVersionDrift(r.slug, pkgParsed.version!, logVerStr!, label)
+    }
   }
 
   // ── Git evidence ──────────────────────────────────────────


### PR DESCRIPTION
**Version:** 0.4.57 → 0.4.58

## Summary
- Swap `secrets.GITHUB_TOKEN` for `secrets.GH_PAT` — default Actions token is scoped to resume-agent only and cannot read private repos (e.g. artisan-roast-platform)
- Add version drift detection in `scripts/sync.ts`: compares `package.json` version against latest versioned CHANGELOG section; flags major/minor gaps or patch gap >1; writes a deduped OB1 warning thought (content-hashed on slug+versions so it fires once per combo, not every nightly run)
- Add `docs/SYNC-CONVENTION.md`: documents what the sync updates, the keep-a-changelog convention required for zero-config sync, per-repo escape hatches (`docsPath`, `featureDocsGlobs`), and guidance for downstream forks

## Test plan
- [ ] Confirm `GH_PAT` secret is set in repo Actions secrets
- [ ] Trigger manual sync via `gh workflow run sync.yml` and verify artisan-roast-platform syncs without 401 errors
- [ ] Verify version drift thought appears in OB1 for brew-guide (package.json@2.0.8 vs CHANGELOG@2.0.3)
- [ ] Confirm no TypeScript errors (`npx tsc --noEmit`)