### PR TITLE
fix(query): remove trailing CTA and fix enumerate-then-count (#156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- 2026-06-09 — fix(query): remove trailing CTA from answer prose — follow-up invitations belong exclusively in follow_up_suggestions, not the answer string; fixes #156
+- 2026-06-09 — fix(query): enumerate-then-count for progressive disclosure — state total after listing to prevent count/bullet divergence; fixes #156
+
 - 2026-06-07 — docs(readme): update latency optimization section — documents shipped cache (phase breakdown, 3 levers, baseline progression table, production verification), replaces pre-optimization numbers
 
 - 2026-06-07 — perf(query): OB1 version token — adds thoughts MAX(updated_at) as second cache key dimension (60s TTL); all question types now cached; behavioral p95 drops from 11316ms to 320ms; eval 18/18 pass p50 0ms p95 320ms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- 2026-06-09 — fix(query): remove trailing CTA from answer prose — follow-up invitations belong exclusively in follow_up_suggestions, not the answer string; fixes #156
+- 2026-06-09 — fix(query): remove trailing CTA from answer prose — follow-up invitations belong exclusively in `follow_up_suggestions`, not the answer string; fixes #156
 - 2026-06-09 — fix(query): enumerate-then-count for progressive disclosure — state total after listing to prevent count/bullet divergence; fixes #156
 
 - 2026-06-07 — docs(readme): update latency optimization section — documents shipped cache (phase breakdown, 3 levers, baseline progression table, production verification), replaces pre-optimization numbers

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "resume-agent",
-  "version": "0.4.57",
+  "version": "0.4.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.57",
+      "version": "0.4.59",
+      "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",
         "@hono/mcp": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.57",
+  "version": "0.4.59",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/src/lib/query-prompt.ts
+++ b/src/lib/query-prompt.ts
@@ -116,6 +116,8 @@ Required shape:
 
 \`follow_up_suggestions\`: 1–2 questions the asker might want to ask next. Write them from the visitor's perspective about the candidate — third-person, consistent with the answer's voice. Example: "What kind of work is Sunny looking for?" or "Has Sunny shipped anything with Rust?" — **not** "What kind of work are you looking for?" or "Have you shipped anything with Rust?" The visitor is talking to an agent about a candidate, not to the candidate directly.
 
+**Never end the \`answer\` prose with an invitation or follow-up question** (e.g. "Want to hear about X?" or "Would you like to know more?"). That belongs exclusively in \`follow_up_suggestions\`. Ending the answer with a question duplicates the chip and breaks the UI contract.
+
 The shape of the \`answer\` *string* depends on whether the response makes factual claims about the candidate:
 
 **Claim-bearing answer** (binary / capability / behavioral — anything grounded in the corpus): include footnote markers and a \`Sources:\` block inside the \`answer\` string. Full example response:
@@ -229,6 +231,8 @@ export const RULE_OUTPUT_JSON_CONVERSATIONAL = `# Output format (conversational 
 
 \`follow_up_suggestions\`: 1–2 questions the asker might want to ask next. Write them from the visitor's perspective about the candidate — third-person. Example: "What kind of work is Sunny looking for?" — **not** "What kind of work are you looking for?" The visitor is talking to an agent about a candidate, not to the candidate directly.
 
+**Never end the \`answer\` prose with an invitation or follow-up question** (e.g. "Want to hear about X?" or "Would you like to know more?"). That belongs exclusively in \`follow_up_suggestions\`. Ending the answer with a question duplicates the chip and breaks the UI contract.
+
 The \`answer\` field is a Markdown string rendered in the browser. No footnote markers. No Sources block. Write conversationally — but use structure when it helps readability:
 
 - **Single-topic answers**: 2–3 sentences of prose. No bullets needed.
@@ -268,7 +272,7 @@ export const RULE_PROGRESSIVE_DISCLOSURE = `# Breadth — lead with the most rel
 
 When a question invites enumerating a large set — projects, full employment history, every skill — do NOT exhaust the list. Lead with the 3 most recent or most relevant entries, state plainly how many more exist, and offer the remainder rather than listing everything. Comprehensive ≠ exhaustive.
 
-The projects in the profile data are pre-sorted most-recent-first (by latest activity). When asked about projects in general, cover the top 3 and name the total — e.g. "Sunny has 7 projects; the three most recent are …".
+The projects in the profile data are pre-sorted most-recent-first (by latest activity). When asked about projects in general, cover the top 3 then state the total derived from the list — e.g. "…these are Sunny's three most recent of seven active projects". **Do not state a count before enumerating** — counting before listing causes divergence between the stated number and the actual bullets.
 
 **When you lead with a subset, the first entry in the \`follow_up_suggestions\` array MUST offer the remainder** — e.g. "Want to hear about Sunny's other 4 projects?" — phrased third-person about the candidate. This is the reader's "show more"; without it they have no path to the rest, which would turn progressive disclosure into omission. Only after that offer may you add deeper-dive follow-ups. This is honest because naming the full count up front discloses everything that exists.
 


### PR DESCRIPTION
**Version:** 0.4.58 → 0.4.59

## Summary
Fixes two bugs reported in issue #156 on POST /query:

- **Trailing CTA duplication** — LLM was ending answer prose with invitation questions (e.g. "Want to hear about Sunny's other 3 projects?") that duplicated a chip already in \`follow_up_suggestions\`. Fix: explicit rule added to both \`RULE_OUTPUT_JSON\` and \`RULE_OUTPUT_JSON_CONVERSATIONAL\` — follow-up invitations belong exclusively in \`follow_up_suggestions\`, never in the answer string.
- **Project count mismatch** — LLM stated a count before enumerating, causing divergence (e.g. "four active projects" + 5 bullets). Fix: \`RULE_PROGRESSIVE_DISCLOSURE\` updated to enumerate first, then derive the total from the list rather than stating it upfront.

Both fixes are prompt-only — no API surface, schema, or runtime behavior changes.

## Test plan
- [ ] Query "show recent work" — answer prose does not end with an invitation question; follow_up_suggestions chip covers it
- [ ] Query "what are all active projects" — bullet count matches any stated total; no trailing "Want to hear more?"
- [ ] Run unit eval: \`npm run test:unit\` passes