### PR TITLE
feat(sync): add skipChangelog flag to gate changelog processing per project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- 2026-06-09 — feat(sync): add skipChangelog flag — gates all changelog processing (highlights reconciliation + thought extraction) per project; featureDocsGlobs thoughts unaffected; document in SYNC-CONVENTION.md
+- 2026-06-09 — feat(sync): add skipChangelog flag — gates highlights reconciliation, changelog thought extraction, and version drift detection per project; featureDocsGlobs thoughts and architecture sync unaffected; document in SYNC-CONVENTION.md
 
 - 2026-06-09 — fix(query): remove trailing CTA from answer prose — follow-up invitations belong exclusively in `follow_up_suggestions`, not the answer string; fixes #156
 - 2026-06-09 — fix(query): enumerate-then-count for progressive disclosure — state total after listing to prevent count/bullet divergence; fixes #156

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- 2026-06-09 — feat(sync): add skipChangelog flag — gates all changelog processing (highlights reconciliation + thought extraction) per project; featureDocsGlobs thoughts unaffected; document in SYNC-CONVENTION.md
+
 - 2026-06-09 — fix(query): remove trailing CTA from answer prose — follow-up invitations belong exclusively in `follow_up_suggestions`, not the answer string; fixes #156
 - 2026-06-09 — fix(query): enumerate-then-count for progressive disclosure — state total after listing to prevent count/bullet divergence; fixes #156
 - 2026-06-09 — fix(sync): swap GITHUB_TOKEN for GH_PAT so nightly sync can read private repos outside resume-agent

--- a/docs/SYNC-CONVENTION.md
+++ b/docs/SYNC-CONVENTION.md
@@ -49,11 +49,11 @@ Add these fields to the project entry in `public_profile.projects` (via `upsert_
 |---|---|---|
 | `docsPath` | `string` | Path to architecture doc if not `README.md` (e.g. `docs/platform/architecture.md`) |
 | `featureDocsGlobs` | `string[]` | Directory prefixes to scan for additional `.md` feature docs (e.g. `["docs/features"]`) |
-| `skipChangelog` | `boolean` | Skip all changelog processing — no highlights reconciliation, no changelog thought extraction. Feature doc thoughts via `featureDocsGlobs` are unaffected. |
+| `skipChangelog` | `boolean` | Skip highlights reconciliation, changelog thought extraction, and version drift detection. Feature doc thoughts via `featureDocsGlobs` and architecture via `docsPath` are unaffected. |
 
 `docsPath` is especially useful for private repos whose README is boilerplate or contains business logic — point it at a curated architecture file instead.
 
-`skipChangelog: true` is the right choice for any private repo whose CHANGELOG contains business-sensitive content (customer details, pricing, internal ops) that should not flow into the public profile or OB1 thoughts. Architecture and feature doc thoughts remain available via `docsPath` and `featureDocsGlobs`.
+`skipChangelog: true` is the right choice for any private repo whose CHANGELOG contains business-sensitive content (customer details, pricing, internal ops) that should not flow into the public profile highlights or OB1 thoughts. Architecture and feature doc thoughts remain available via `docsPath` and `featureDocsGlobs`.
 
 ## When to use `manual` strategy
 

--- a/docs/SYNC-CONVENTION.md
+++ b/docs/SYNC-CONVENTION.md
@@ -49,8 +49,11 @@ Add these fields to the project entry in `public_profile.projects` (via `upsert_
 |---|---|---|
 | `docsPath` | `string` | Path to architecture doc if not `README.md` (e.g. `docs/platform/architecture.md`) |
 | `featureDocsGlobs` | `string[]` | Directory prefixes to scan for additional `.md` feature docs (e.g. `["docs/features"]`) |
+| `skipChangelog` | `boolean` | Skip all changelog processing — no highlights reconciliation, no changelog thought extraction. Feature doc thoughts via `featureDocsGlobs` are unaffected. |
 
 `docsPath` is especially useful for private repos whose README is boilerplate or contains business logic — point it at a curated architecture file instead.
+
+`skipChangelog: true` is the right choice for any private repo whose CHANGELOG contains business-sensitive content (customer details, pricing, internal ops) that should not flow into the public profile or OB1 thoughts. Architecture and feature doc thoughts remain available via `docsPath` and `featureDocsGlobs`.
 
 ## When to use `manual` strategy
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.59",
+  "version": "0.4.60",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -754,7 +754,7 @@ async function syncProject(
   }
 
   // ── Highlights reconciliation (now shipped-only) ──
-  const skipChangelog = !!(project as { skipChangelog?: boolean }).skipChangelog
+  const skipChangelog = (project as { skipChangelog?: boolean }).skipChangelog === true
   if (skipChangelog) {
     console.log(`  — changelog skipped (skipChangelog: true) — highlights and changelog thoughts preserved as-is`)
   } else if (changelog) {
@@ -826,7 +826,7 @@ async function syncProject(
   }
 
   // ── Version drift detection ───────────────────────────────
-  if (pkgJson && changelog) {
+  if (!skipChangelog && pkgJson && changelog) {
     let pkgParsed: { version?: string } = {}
     try { pkgParsed = JSON.parse(pkgJson) } catch { /* ignore */ }
     const pkgVer = pkgParsed.version ? parseSemVer(pkgParsed.version) : null

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -754,7 +754,10 @@ async function syncProject(
   }
 
   // ── Highlights reconciliation (now shipped-only) ──
-  if (changelog) {
+  const skipChangelog = !!(project as { skipChangelog?: boolean }).skipChangelog
+  if (skipChangelog) {
+    console.log(`  — changelog skipped (skipChangelog: true) — highlights and changelog thoughts preserved as-is`)
+  } else if (changelog) {
     const sections = splitChangelogSections(changelog)
     // Highlights only from shipped changelog (no ## [Unreleased])
     const hi = await reconcileHighlights(projectName, currentHighlights, sections.shipped)


### PR DESCRIPTION
**Version:** 0.4.59 → 0.4.60

## Summary
- Add `skipChangelog` per-project flag in `scripts/sync.ts` — when `true`, skips highlights reconciliation and all changelog thought extraction (shipped + unreleased) for that project. Feature doc thoughts via `featureDocsGlobs` are unaffected.
- Document `skipChangelog` in `docs/SYNC-CONVENTION.md` alongside the existing `docsPath` and `featureDocsGlobs` escape hatches.
- Motivation: private repos (e.g. artisan-roast-platform) may have CHANGELOGs containing business-sensitive content (customer details, pricing, internal ops) that should not flow into the public profile or OB1 thoughts. The flag is already set on the artisan-roast-platform profile entry via `upsert_project`.

## Test plan
- [ ] Confirm `npx tsc --noEmit` passes
- [ ] Trigger manual sync — artisan-roast-platform logs `changelog skipped (skipChangelog: true)` and its highlights are unchanged
- [ ] Confirm feature doc thoughts (if `featureDocsGlobs` set) still extract normally for a project with `skipChangelog: true`
- [ ] Confirm projects without the flag continue to process changelog as before