### PR TITLE
fix(mcp): coerce skipChangelog to boolean for MCP string serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- 2026-06-10 — fix(mcp): coerce skipChangelog to boolean for MCP string serialization
 - 2026-06-09 — fix(sync): add skipChangelog, docsPath, featureDocsGlobs to upsert_project schema so sync escape hatches are actually stored in Supabase
 - 2026-06-09 — ci(sync): opt into Node.js 24 for actions runner via FORCE_JAVASCRIPT_ACTIONS_TO_NODE24
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resume-agent",
-  "version": "0.4.59",
+  "version": "0.4.62",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resume-agent",
-      "version": "0.4.59",
+      "version": "0.4.62",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai": "^1.3.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-agent",
-  "version": "0.4.61",
+  "version": "0.4.62",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -322,7 +322,7 @@ function buildServer(): McpServer {
         repo:             z.string().optional().describe('Source repo URL'),
         docsPath:         z.string().optional().describe('Path to architecture doc if README.md is not the right source, e.g. "docs/platform/architecture.md"'),
         featureDocsGlobs: z.array(z.string()).optional().describe('Directory prefixes to scan for additional feature docs, e.g. ["docs/features"]'),
-        skipChangelog:    z.coerce.boolean().optional().describe('Skip changelog processing (highlights reconciliation, thought extraction, version drift detection) — use for private repos whose CHANGELOG contains business-sensitive content'),
+        skipChangelog:    z.union([z.boolean(), z.enum(['true', 'false']).transform(v => v === 'true')]).optional().describe('Skip changelog processing (highlights reconciliation, thought extraction, version drift detection) — use for private repos whose CHANGELOG contains business-sensitive content'),
       },
     },
     async (input) => {

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -322,7 +322,7 @@ function buildServer(): McpServer {
         repo:             z.string().optional().describe('Source repo URL'),
         docsPath:         z.string().optional().describe('Path to architecture doc if README.md is not the right source, e.g. "docs/platform/architecture.md"'),
         featureDocsGlobs: z.array(z.string()).optional().describe('Directory prefixes to scan for additional feature docs, e.g. ["docs/features"]'),
-        skipChangelog:    z.boolean().optional().describe('Skip changelog processing (highlights reconciliation, thought extraction, version drift detection) — use for private repos whose CHANGELOG contains business-sensitive content'),
+        skipChangelog:    z.coerce.boolean().optional().describe('Skip changelog processing (highlights reconciliation, thought extraction, version drift detection) — use for private repos whose CHANGELOG contains business-sensitive content'),
       },
     },
     async (input) => {

--- a/tests/projects-and-scoring.test.ts
+++ b/tests/projects-and-scoring.test.ts
@@ -161,4 +161,27 @@ describe("score_match + upsert_project MCP tools", () => {
     assert.equal(project.docsPath, "docs/architecture.md", "docsPath should be persisted");
     assert.deepEqual(project.featureDocsGlobs, ["docs/features"], "featureDocsGlobs should be persisted");
   });
+
+  it('upsert_project — skipChangelog accepts string "true"/"false" (MCP transport coercion)', async () => {
+    // MCP tool-call arguments arrive as strings; verify explicit mapping works
+    const setTrue = await callTool("upsert_project", { slug: TEST_SLUG, skipChangelog: "true" });
+    assert.ok(!setTrue.isError, `Expected success for "true", got: ${getText(setTrue)}`);
+
+    const setFalse = await callTool("upsert_project", { slug: TEST_SLUG, skipChangelog: "false" });
+    assert.ok(!setFalse.isError, `Expected success for "false", got: ${getText(setFalse)}`);
+
+    const { createClient } = await import("@supabase/supabase-js");
+    const supabase = createClient(SUPA_URL!, SUPA_ROLE_KEY!);
+    const { data, error } = await supabase
+      .from("public_profile")
+      .select("projects")
+      .eq("id", PROFILE_ID)
+      .single();
+    assert.ok(!error && data, "Should be able to read profile");
+    const project = (data.projects as { slug: string; skipChangelog?: boolean }[]).find(
+      (p) => p.slug === TEST_SLUG
+    );
+    assert.ok(project, "Test project should still exist");
+    assert.equal(project.skipChangelog, false, 'skipChangelog: "false" should store false, not true');
+  });
 });


### PR DESCRIPTION
**Version:** 0.4.61 → 0.4.62

## Summary
- Changed `skipChangelog` field in `upsert_project` MCP tool schema from `z.boolean()` to `z.coerce.boolean()`
- MCP tool-calling serializes all scalar parameters as strings; without coercion, passing `skipChangelog: true` fails Zod validation with "Expected boolean, received string"

## Test plan
- [ ] Call `upsert_project` with `skipChangelog: true` — should no longer throw a validation error
- [ ] Call `upsert_project` without `skipChangelog` — should still work (field is optional)